### PR TITLE
Alustavat rajapintamuutokset julkaisusta 2024-release-12

### DIFF
--- a/OpenApi/Kaavoitus/Avoin/ryhti-plan-public-validate-api.json
+++ b/OpenApi/Kaavoitus/Avoin/ryhti-plan-public-validate-api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Ryhti API",
-        "description": "<h2>Ryhti - kaavasuunnitelmien julkinen validointirajapinta</h2>\n\nJulkinen rajapinta kaavasuunnitelmien validointiin.\n\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\n<br/>",
+        "description": "<h2>Ryhti - kaavasuunnitelmien julkinen validointirajapinta</h2>\r\n\r\nJulkinen rajapinta kaavasuunnitelmien validointiin.\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
         "contact": {
             "name": "Feedback",
             "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
@@ -34,7 +34,7 @@
                     {
                         "name": "administrativeAreaIdentifiers",
                         "in": "query",
-                        "description": "Kunta- tai maakuntakoodi. <br /><br />Example : 049",
+                        "description": "Kunta- tai maakuntakoodi. \r\n\r\nExample : 049",
                         "required": true,
                         "style": "form",
                         "explode": false,
@@ -236,6 +236,12 @@
                             },
                             {
                                 "$ref": "#/components/schemas/TextValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodDateOnlyValue"
                             }
                         ],
                         "description": "Arvo",
@@ -261,7 +267,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Enumeraatio joka määrittää Arvo-luokkien (Domain.ValueObjects.AttributeValue) tyypin.\r\nJokaisella konkreettisella Arvo-luokan (Domain.ValueObjects.AttributeValue) toteutuksella tulee olla sitä vastaava DataType enumeraation arvo."
@@ -271,22 +279,20 @@
             },
             "CancelledGroupRelations": {
                 "required": [
-                    "planObjectKey",
-                    "planRegulationGroupKey"
+                    "planObjectUri",
+                    "planRegulationGroupUri"
                 ],
                 "type": "object",
                 "properties": {
-                    "planRegulationGroupKey": {
+                    "planRegulationGroupUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kaavamääräysryhmän kohdistamiseen käytettävä tunnus.",
-                        "format": "uuid"
+                        "description": "Kaavamääräysryhmän kohdistamiseen käytettävä tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planregulationgroup/{planRegulationGroupKey})"
                     },
-                    "planObjectKey": {
+                    "planObjectUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kaavakohteen kohdistamiseen käytettävä tunnus.",
-                        "format": "uuid"
+                        "description": "Kaavakohteen kohdistamiseen käytettävä tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{planObjectKey})"
                     }
                 },
                 "additionalProperties": false,
@@ -333,7 +339,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"code\""
@@ -381,7 +389,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"decimalRange\""
@@ -424,7 +434,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"decimal\""
@@ -462,6 +474,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "generalRegulationGroupUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/generalregulationgroup/{guid})",
+                        "readOnly": true
                     },
                     "titleOfPlanRegulation": {
                         "allOf": [
@@ -554,7 +571,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiLineStringGeometry": {
                 "required": [
@@ -597,7 +614,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPointGeometry": {
                 "required": [
@@ -637,7 +654,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPoint GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPolygonGeometry": {
                 "required": [
@@ -683,7 +700,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPolygon GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+                "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
             },
             "GeoJsonPointGeometry": {
                 "required": [
@@ -720,7 +737,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Point GeoJson<br />\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+                "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
             },
             "GeoJsonPolygonGeometry": {
                 "required": [
@@ -763,7 +780,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Polygon GeoJson<br />\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+                "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
             },
             "IdentifierValue": {
                 "required": [
@@ -806,7 +823,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"identifier\""
@@ -889,7 +908,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"localizedText\""
@@ -937,7 +958,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"numericRange\""
@@ -980,7 +1003,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"numeric\""
@@ -1002,6 +1027,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "otherPlanMaterialUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/otherplanmaterial/{guid})",
+                        "readOnly": true
                     },
                     "name": {
                         "allOf": [
@@ -1036,17 +1066,23 @@
                 "additionalProperties": false,
                 "description": "MuuKaavaAineisto"
             },
-            "PartiallyCancellationPlanObjectInfo": {
+            "PartiallyCancelledPlanObjectInfo": {
                 "required": [
-                    "partiallyCancelledPlanObjectId",
+                    "cancelledPlanUri",
+                    "partiallyCancelledPlanObjectUri",
                     "validityGeometry"
                 ],
                 "type": "object",
                 "properties": {
-                    "partiallyCancelledPlanObjectId": {
+                    "cancelledPlanUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kaavakohteen yksilöivätunnus, jota osittainen kumoutuminen koskee."
+                        "description": "Kumottavan hyväkstytyn kaavan tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{planKey})"
+                    },
+                    "partiallyCancelledPlanObjectUri": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Kumottavan kaavakohteen tunnus uri-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{planObjectKey})"
                     },
                     "validityGeometry": {
                         "allOf": [
@@ -1074,6 +1110,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{guid})",
+                        "readOnly": true
                     },
                     "lifeCycleStatus": {
                         "enum": [
@@ -1204,10 +1245,10 @@
                         "description": "Laatija",
                         "nullable": true
                     },
-                    "partiallyCancellationPlanObjects": {
+                    "partiallyCancelledPlanObjects": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/PartiallyCancellationPlanObjectInfo"
+                            "$ref": "#/components/schemas/PartiallyCancelledPlanObjectInfo"
                         },
                         "description": "// Osittain kumottavat kaavakohteet",
                         "nullable": true
@@ -1328,6 +1369,11 @@
                         "format": "date",
                         "nullable": true
                     },
+                    "planAttachmentDocumentUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planattachmentdocument/{guid})",
+                        "readOnly": true
+                    },
                     "typeOfAttachment": {
                         "minLength": 1,
                         "type": "string",
@@ -1363,10 +1409,7 @@
             },
             "PlanCancellationInfo": {
                 "required": [
-                    "cancelledGuidanceId",
-                    "cancelledPlanId",
-                    "cancelledPlanObjectId",
-                    "cancelledRegulationId",
+                    "cancelledPlanUri",
                     "cancelsEntirePlan",
                     "planCancellationInfoKey"
                 ],
@@ -1377,49 +1420,47 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
-                    "cancelledPlanId": {
+                    "planCancellationInfoUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plancancellationinfo/{guid})",
+                        "readOnly": true
+                    },
+                    "cancelledPlanUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kumottavan kaavan tunnus"
+                        "description": "Kumottavan hyväkstytyn kaavan tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{planKey})"
                     },
                     "cancelsEntirePlan": {
                         "type": "boolean",
                         "description": "Kumoaa kaavan kokonaan"
                     },
-                    "cancelledPlanObjectId": {
+                    "cancelledPlanObjectUris": {
                         "type": "array",
                         "items": {
-                            "minLength": 1,
                             "type": "string"
                         },
-                        "description": "Kumottavan kaavakohteen tunnukset",
-                        "nullable": true
+                        "description": "Kumottavan kaavakohteen tunnukset URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{planObjectKey})"
                     },
-                    "cancelledRegulationId": {
+                    "cancelledRegulationUris": {
                         "type": "array",
                         "items": {
-                            "minLength": 1,
                             "type": "string"
                         },
-                        "description": "Kumottavan määräyksen tunnukset",
-                        "nullable": true
+                        "description": "Kumottavan määräyksen tunnukset URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{planRegulationKey})"
                     },
-                    "cancelledGuidanceId": {
+                    "cancelledRecommendationUris": {
                         "type": "array",
                         "items": {
-                            "minLength": 1,
                             "type": "string"
                         },
-                        "description": "Kumottavan suosituksen tunnukset",
-                        "nullable": true
+                        "description": "Kumottavan suosituksen tunnukset URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planrecommendation/{planRecommendationKey})"
                     },
                     "cancelledGroupRelations": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/CancelledGroupRelations"
                         },
-                        "description": "Kumottavan ryhmän kohdistus. Kuvaa kaavakohteesta kumoutuvat kaavamääräysryhmät.",
-                        "nullable": true
+                        "description": "Kumottavan ryhmän kohdistus. Kuvaa kaavakohteesta kumoutuvat kaavamääräysryhmät."
                     }
                 },
                 "additionalProperties": false,
@@ -1438,6 +1479,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planMapUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planmap/{guid})",
+                        "readOnly": true
                     },
                     "name": {
                         "allOf": [
@@ -1473,6 +1519,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planObjectUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{guid})",
+                        "readOnly": true
                     },
                     "lifeCycleStatus": {
                         "enum": [
@@ -1543,7 +1594,15 @@
                             "type": "string",
                             "format": "uuid"
                         },
-                        "description": "Viittaus (GUID) kaavan mukana toimitettavaan lähtötietoaineistoon sisältyvään tietokohteeseen, joka liittyy​ kaavakohteeseen. Esim. Pohjavesialue.",
+                        "description": "Viittaus (GUID) kaavan mukana toimitettavaan lähtötietoaineistoon sisältyvään tietokohteeseen, joka liittyy kaavakohteeseen. Esim. Pohjavesialue.\r\nPäivitysvaiheessa tämän listan kuuluu olla tyhjä.",
+                        "nullable": true
+                    },
+                    "relatedPlanSourceDataUris": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Viittaus (URI) kaava-asian mukana toimitettavaan, aiemmin tallennettuun, lähtötietoaineistoon sisältyvään tietokohteeseen, joka liittyy tallennettuun kaavakohteeseen. Esim. Pohjavesialue.",
                         "nullable": true
                     },
                     "periodOfValidity": {
@@ -1584,6 +1643,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planOperatorUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planoperator/{guid})",
+                        "readOnly": true
                     },
                     "firstName": {
                         "type": "string",
@@ -1626,6 +1690,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planRecommendationUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planrecommendation/{guid})",
+                        "readOnly": true
                     },
                     "value": {
                         "allOf": [
@@ -1706,6 +1775,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planRegulationUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{guid})",
+                        "readOnly": true
+                    },
                     "value": {
                         "oneOf": [
                             {
@@ -1746,6 +1820,12 @@
                             },
                             {
                                 "$ref": "#/components/schemas/TextValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodDateOnlyValue"
                             }
                         ],
                         "nullable": true
@@ -2149,6 +2229,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planRegulationGroupUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planregulationgroup/{guid})",
+                        "readOnly": true
+                    },
                     "titleOfPlanRegulation": {
                         "allOf": [
                             {
@@ -2218,6 +2303,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planReportUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planreport/{guid})",
+                        "readOnly": true
+                    },
                     "attachmentDocuments": {
                         "minItems": 1,
                         "type": "array",
@@ -2268,7 +2358,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveDecimalRange\""
@@ -2311,7 +2403,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveDecimal\""
@@ -2359,7 +2453,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveNumericRange\""
@@ -2402,7 +2498,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveNumeric\""
@@ -2463,7 +2561,7 @@
                             "3885"
                         ],
                         "type": "string",
-                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi<br />\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873<br />\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874<br />\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875<br />\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876<br />\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877<br />\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878<br />\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879<br />\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880<br />\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881<br />\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882<br />\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883<br />\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884<br />\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885<br />\r\n   3067 TM35FIN<br />"
+                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
                     },
                     "geometry": {
                         "oneOf": [
@@ -2525,7 +2623,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"spotElevation\""
@@ -2567,7 +2667,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"text\""
@@ -2591,6 +2693,101 @@
                     }
                 },
                 "additionalProperties": false
+            },
+            "TimePeriodDateOnlyValue": {
+                "required": [
+                    "dataType"
+                ],
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AttributeValue"
+                    }
+                ],
+                "properties": {
+                    "begin": {
+                        "type": "string",
+                        "description": "Alkupäivä",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "end": {
+                        "type": "string",
+                        "description": "Loppupäivä",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "dataType": {
+                        "enum": [
+                            "LocalizedText",
+                            "Text",
+                            "Numeric",
+                            "NumericRange",
+                            "PositiveNumeric",
+                            "PositiveNumericRange",
+                            "Decimal",
+                            "DecimalRange",
+                            "PositiveDecimal",
+                            "PositiveDecimalRange",
+                            "Code",
+                            "Identifier",
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
+                        ],
+                        "type": "string",
+                        "description": "Pakollinen arvo: \"timePeriodDateOnly\""
+                    }
+                },
+                "additionalProperties": false,
+                "description": "TimePeriodDateOnly"
+            },
+            "TimePeriodValue": {
+                "required": [
+                    "dataType"
+                ],
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AttributeValue"
+                    }
+                ],
+                "properties": {
+                    "beginUtc": {
+                        "type": "string",
+                        "description": "Alkuaika",
+                        "format": "date-time"
+                    },
+                    "endUtc": {
+                        "type": "string",
+                        "description": "Loppuaika",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "dataType": {
+                        "enum": [
+                            "LocalizedText",
+                            "Text",
+                            "Numeric",
+                            "NumericRange",
+                            "PositiveNumeric",
+                            "PositiveNumericRange",
+                            "Decimal",
+                            "DecimalRange",
+                            "PositiveDecimal",
+                            "PositiveDecimalRange",
+                            "Code",
+                            "Identifier",
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
+                        ],
+                        "type": "string",
+                        "description": "Pakollinen arvo: \"timePeriod\""
+                    }
+                },
+                "additionalProperties": false,
+                "description": "TimePeriod"
             },
             "ValidationProblemDetails": {
                 "type": "object",
@@ -2641,14 +2838,7 @@
                 "flows": {
                     "clientCredentials": {
                         "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
-                        "scopes": {
-                            "ryhti.plan.write": "Kaavatietojen kirjoitusoikeus",
-                            "ryhti.building.write": "Rakennustietojen kirjoitusoikeus",
-                            "ryhti.planui.write": "Käyttöliittymä apin käyttöoikeus",
-                            "ryhti.changeinformation.read": "Muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus"
-                        }
+                        "scopes": {}
                     }
                 }
             }

--- a/OpenApi/Kaavoitus/Palveluväylä/Kaavoitus OpenApi.json
+++ b/OpenApi/Kaavoitus/Palveluväylä/Kaavoitus OpenApi.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Ryhti API",
-        "description": "<h2>Rakennetun ympäristön kaavoituksen OpenApi kuvaukset</h2>\nEnsimmäisen vaiheen kaavoituksen rajapinnat kumppanitestaukseen.\n\n<b>HUOM!</b> Rajapintakuvaukset voivat vielä muuttua kumppanitestauksen ja kommenttien perusteella.\n\nKaavoituksen tietomallien sanalliset kuvaukset löytyvät osoitteesta\n<a href=\"https://ryhti.syke.fi/alueidenkaytto/tietomallimuotoinen-kaavoitus/kaavatietomallin-tietomaaritykset/\">https://ryhti.syke.fi/alueidenkaytto/tietomallimuotoinen-kaavoitus/kaavatietomallin-tietomaaritykset/</a>\n\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\n<br/>",
+        "description": "<h2>Rakennetun ympäristön kaavoituksen OpenApi kuvaukset</h2>\r\nEnsimmäisen vaiheen kaavoituksen rajapinnat kumppanitestaukseen.\r\n\r\n<b>HUOM!</b> Rajapintakuvaukset voivat vielä muuttua kumppanitestauksen ja kommenttien perusteella.\r\n\r\nKaavoituksen tietomallien sanalliset kuvaukset löytyvät osoitteesta\r\n<a href=\"https://ryhti.syke.fi/alueidenkaytto/tietomallimuotoinen-kaavoitus/kaavatietomallin-tietomaaritykset/\">https://ryhti.syke.fi/alueidenkaytto/tietomallimuotoinen-kaavoitus/kaavatietomallin-tietomaaritykset/</a>\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
         "contact": {
             "name": "Feedback",
             "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
@@ -88,6 +88,202 @@
                             "text/json": {
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BindingPlotDivisionMatter/{permanentBindingPlotDivisionIdentifier}": {
+            "get": {
+                "tags": [
+                    "BindingPlotDivisionMatter"
+                ],
+                "summary": "Sitovan tonttijaon asian hakeminen pysyvällä sitovan tonttijaon tunnuksella.",
+                "parameters": [
+                    {
+                        "name": "permanentBindingPlotDivisionIdentifier",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BindingPlotDivisionMatterResponse"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BindingPlotDivisionMatterResponse"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BindingPlotDivisionMatterResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Kutsun rakenne ei ole scheman mukainen.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Kutsun tietosisällössä virheitä.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "BindingPlotDivisionMatter"
+                ],
+                "summary": "Rajapinta sitovan tonttijaon asian luomiseen.",
+                "description": "Asialle on varattava pysyvä yksilöivä tunnus ennen asian tuontia Ryhtiin. Pysyvän yksilöivän tunnuksen tulee olla sitovan tonttijaon pysyvä tunnus.",
+                "parameters": [
+                    {
+                        "name": "permanentBindingPlotDivisionIdentifier",
+                        "in": "path",
+                        "description": "Pysyvä yksilöivä tunnus sitovan tonttijaon asialle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Sitovan tonttijaon asia.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                                    }
+                                ]
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                                    }
+                                ]
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Sitovan tonttijaon asia tallennettu, paluuarvona uri tallennettuun resurssiin.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Content",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
                                 }
                             }
                         }
@@ -222,6 +418,494 @@
                 }
             }
         },
+        "/api/BindingPlotDivisionMatter/{permanentBindingPlotDivisionIdentifier}/Validate": {
+            "post": {
+                "tags": [
+                    "BindingPlotDivisionMatter"
+                ],
+                "summary": "Rajapinta sitovan tonttijaon asian validoimiseen ilman tallentamista.",
+                "description": "Rajapinta validoi sitovan tonttijaon asian kokonaisuudessaan, sisältäen ensimmäisen vaiheen ja kaikki sen tiedot.",
+                "parameters": [
+                    {
+                        "name": "permanentBindingPlotDivisionIdentifier",
+                        "in": "path",
+                        "description": "Pysyvä sitovan tonttijaon tunnus sitovan tonttijaon asialle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Validoitava sitovan tonttijaon asian sisältäen ensimmäisen sitovan tonttijaon asian vaiheen.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                                    }
+                                ]
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                                    }
+                                ]
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Sitovan tonttijaon asiassa ei virheitä.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Kutsun rakenne ei ole scheman mukainen.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Kutsun tietosisällössä virheitä.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BindingPlotDivisionMatter/{permanentBindingPlotDivisionIdentifier}/phase/{bindingPlotDivisionMatterPhaseKey}": {
+            "post": {
+                "tags": [
+                    "BindingPlotDivisionMatter"
+                ],
+                "summary": "Rajapinta sitovan tonttijaon asian vaiheen lisäämiseen olemassa olevalle sitovan tonttijaon asialle.",
+                "description": "Sitovan tonttijaon asian täytyy olla jo lisättynä järjestelmään. Uusi vaihe lisätään edellisen perään.",
+                "parameters": [
+                    {
+                        "name": "permanentBindingPlotDivisionIdentifier",
+                        "in": "path",
+                        "description": "Pysyvä sitovan tonttijaon tunnus sitovan tonttijaon asialle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "bindingPlotDivisionMatterPhaseKey",
+                        "in": "path",
+                        "description": "Pysyvä yksilöivä tunnus sitovan tonttijaon asian vaiheelle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Lisättävä sitovan tonttijaon asian vaihe kokonaisuudessaan.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                                    }
+                                ]
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                                    }
+                                ]
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Sitovan tonttijaon asian vaihe tallennettu.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Kutsun rakenne ei ole scheman mukainen.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Kutsun tietosisällössä virheitä.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BindingPlotDivisionMatter/{permanentBindingPlotDivisionIdentifier}/phase/{bindingPlotDivisionMatterPhaseKey}/validate": {
+            "post": {
+                "tags": [
+                    "BindingPlotDivisionMatter"
+                ],
+                "summary": "Rajapinta sitovan tonttijaon asian vaiheen validoimiseen ilman tallennusta.",
+                "description": "Sitovan tonttijaon asian täytyy olla jo lisättynä järjestelmään. Uusi vaihe lisätään edellisen perään.",
+                "parameters": [
+                    {
+                        "name": "permanentBindingPlotDivisionIdentifier",
+                        "in": "path",
+                        "description": "Pysyvä sitovan tonttijaon tunnus sitovan tonttijaon asialle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "bindingPlotDivisionMatterPhaseKey",
+                        "in": "path",
+                        "description": "Pysyvä yksilöivä tunnus sitovan tonttijaon asian vaiheelle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Lisättävä sitovan tonttijaon asian vaihe kokonaisuudessaan.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                                    }
+                                ]
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                                    }
+                                ]
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Vaiheessa ei virheitä."
+                    },
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Kutsun rakenne ei ole scheman mukainen.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Kutsun tietosisällössä virheitä.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BindingPlotDivisionMatter/{permanentBindingPlotDivisionIdentifier}/planEffects": {
+            "post": {
+                "tags": [
+                    "BindingPlotDivisionMatter"
+                ],
+                "summary": "Rajapinta kaavan vaikutusten luomiseen.",
+                "parameters": [
+                    {
+                        "name": "permanentBindingPlotDivisionIdentifier",
+                        "in": "path",
+                        "description": "Pysyvä yksilöivä tunnus sitovan tonttijaon asialle.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Kaavan vaikutukset.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PlanEffects"
+                                    }
+                                ],
+                                "description": "KaavanVaikutukset"
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PlanEffects"
+                                    }
+                                ],
+                                "description": "KaavanVaikutukset"
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PlanEffects"
+                                    }
+                                ],
+                                "description": "KaavanVaikutukset"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Kaavan vaikutukset tallennettu, paluuarvona uri tallennettuun resurssiin.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Content",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/LocalDetailedPlanMatter/{permanentPlanIdentifier}": {
             "get": {
                 "tags": [
@@ -240,7 +924,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -558,7 +1242,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -1263,7 +1947,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -1581,7 +2265,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -2288,7 +2972,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "application/pdf": {
                                 "schema": {
@@ -2323,7 +3007,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -2641,7 +3325,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -3367,6 +4051,24 @@
                 "tags": [
                     "UploadedFile"
                 ],
+                "parameters": [
+                    {
+                        "name": "municipalityId",
+                        "in": "query",
+                        "description": "Jos käyttäjällä on oikeus useampaan kuntaan tulee pyynnön sisältää kuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "regionId",
+                        "in": "query",
+                        "description": "Jos käyttäjällä on oikeus useampaan maakuntaan tulee pyynnön sisältää maakuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "multipart/form-data": {
@@ -3519,6 +4221,12 @@
                             },
                             {
                                 "$ref": "#/components/schemas/TextValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodDateOnlyValue"
                             }
                         ],
                         "description": "Arvo",
@@ -3635,7 +4343,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Enumeraatio joka määrittää Arvo-luokkien (Domain.ValueObjects.AttributeValue) tyypin.\r\nJokaisella konkreettisella Arvo-luokan (Domain.ValueObjects.AttributeValue) toteutuksella tulee olla sitä vastaava DataType enumeraation arvo."
@@ -3657,6 +4367,11 @@
                         "type": "string",
                         "description": "Sitova tonttijako avain",
                         "format": "uuid"
+                    },
+                    "bindingPlotDivisionUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivision/{guid})",
+                        "readOnly": true
                     },
                     "bindingPlotDivisionCancellationInfos": {
                         "type": "array",
@@ -3790,6 +4505,11 @@
                         "format": "date",
                         "nullable": true
                     },
+                    "bindingPlotDivisionAttachmentDocumentUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivisionattachmentdocument/{guid})",
+                        "readOnly": true
+                    },
                     "typeOfAttachment": {
                         "minLength": 1,
                         "type": "string",
@@ -3826,26 +4546,26 @@
             },
             "BindingPlotDivisionCancellationInfo": {
                 "required": [
-                    "cancelledBindingPlotDivisionId",
+                    "cancelledBindingPlotDivisionUri",
                     "cancelsEntireBindingPlotDivision"
                 ],
                 "type": "object",
                 "properties": {
-                    "cancelledBindingPlotDivisionId": {
+                    "cancelledBindingPlotDivisionUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kumoutuvan sitovan tonttijaon URI"
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivision/{bindingplotdivisionkey}) kumoutuvaan sitovaan tonttijakoon."
                     },
                     "cancelsEntireBindingPlotDivision": {
                         "type": "boolean",
                         "description": "Kumoaa sitovan tonttijaon kokonaan"
                     },
-                    "cancelledPlotDivisionPlotIds": {
+                    "cancelledPlotDivisionPlotUris": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         },
-                        "description": "Kumoutuvien tonttijako tonttien tunnukset",
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/plotdivisionplot/{plotdivisionplotkey}) kumoutuviin tonttijakotontteihin.",
                         "nullable": true
                     }
                 },
@@ -3980,6 +4700,11 @@
                         "description": "Sitovan tonttijaon asian päätösavain",
                         "format": "uuid"
                     },
+                    "bindingPlotDivisionMatterDecisionUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivisionmatterdecision/{guid})",
+                        "readOnly": true
+                    },
                     "decisionDate": {
                         "type": "string",
                         "description": "Päätöspäivämäärä",
@@ -4052,7 +4777,8 @@
                             "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0710",
                             "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0102",
                             "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0403",
-                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0404"
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0404",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0405"
                         ],
                         "type": "string",
                         "description": "Päätöksen nimitys, joka kertoo mitä päätös koskee. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi\">http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi</a>"
@@ -4114,6 +4840,11 @@
                         "description": "Sitovan tonttijaon asian vaihe avain",
                         "format": "uuid"
                     },
+                    "bindingPlotDivisionMatterPhaseUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivisionmatterphase/{guid})",
+                        "readOnly": true
+                    },
                     "decision": {
                         "allOf": [
                             {
@@ -4123,9 +4854,9 @@
                         "description": "Päätös",
                         "nullable": true
                     },
-                    "approvedPlanDecision": {
+                    "approvedPlanDecisionUri": {
                         "type": "string",
-                        "description": "Hyväksytyn kaavan päätöksen URI",
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/plandecision/{plandecisionkey}) hyväksytyn kaavan päätökseen.",
                         "nullable": true
                     },
                     "bindingPlotDivision": {
@@ -4140,6 +4871,123 @@
                 },
                 "additionalProperties": false
             },
+            "BindingPlotDivisionMatterResponse": {
+                "required": [
+                    "administrativeAreaIdentifiers",
+                    "bindingPlotDivisionType",
+                    "name",
+                    "permanentBindingPlotDivisionIdentifier",
+                    "phases",
+                    "timeOfInitiation"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+                    },
+                    "description": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "bindingPlotDivisionType": {
+                        "enum": [
+                            "http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji/code/01",
+                            "http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji/code/02"
+                        ],
+                        "type": "string",
+                        "description": "Sitovan tonttijaon laji. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji\">http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji</a>"
+                    },
+                    "permanentBindingPlotDivisionIdentifier": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "sitovan tonttijaon pysyvä tunnus"
+                    },
+                    "producerBindingPlotDivisionIdentifier": {
+                        "type": "string",
+                        "description": "kunnan antama sitovan tonttijaon tunnus",
+                        "nullable": true
+                    },
+                    "caseIdentifiers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "asianhallintatunnukset",
+                        "nullable": true
+                    },
+                    "recordNumbers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "diaarinumerot",
+                        "nullable": true
+                    },
+                    "timeOfInitiation": {
+                        "type": "string",
+                        "description": "vireilletulopäivämäärä",
+                        "format": "date"
+                    },
+                    "administrativeAreaIdentifiers": {
+                        "maxItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "hallinnollisen alueen tunnukset"
+                    },
+                    "phases": {
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                        },
+                        "description": "Vaiheet"
+                    },
+                    "responsibleParty": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/BindingPlotDivisionOperator"
+                            }
+                        ],
+                        "description": "Vastuutaho",
+                        "nullable": true
+                    },
+                    "relatedBindingPlotDivisionMatters": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Liittyvät asiat",
+                        "nullable": true
+                    },
+                    "matterAnnexes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/BindingPlotDivisionAttachmentDocument"
+                        },
+                        "description": "AsianLiitteet",
+                        "nullable": true
+                    },
+                    "bindingPlotDivisionMatterUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivisionmatter/{identifier})",
+                        "readOnly": true
+                    }
+                },
+                "additionalProperties": false
+            },
             "BindingPlotDivisionOperator": {
                 "required": [
                     "bindingPlotDivisionOperatorKey"
@@ -4150,6 +4998,11 @@
                         "type": "string",
                         "description": "Toimijan avain",
                         "format": "uuid"
+                    },
+                    "bindingPlotDivisionOperatorUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivisionoperator/{guid})",
+                        "readOnly": true
                     },
                     "firstName": {
                         "type": "string",
@@ -4206,22 +5059,20 @@
             },
             "CancelledGroupRelations": {
                 "required": [
-                    "planObjectKey",
-                    "planRegulationGroupKey"
+                    "planObjectUri",
+                    "planRegulationGroupUri"
                 ],
                 "type": "object",
                 "properties": {
-                    "planRegulationGroupKey": {
+                    "planRegulationGroupUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kaavamääräysryhmän kohdistamiseen käytettävä tunnus.",
-                        "format": "uuid"
+                        "description": "Kaavamääräysryhmän kohdistamiseen käytettävä tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planregulationgroup/{planRegulationGroupKey})"
                     },
-                    "planObjectKey": {
+                    "planObjectUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kaavakohteen kohdistamiseen käytettävä tunnus.",
-                        "format": "uuid"
+                        "description": "Kaavakohteen kohdistamiseen käytettävä tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{planObjectKey})"
                     }
                 },
                 "additionalProperties": false,
@@ -4268,7 +5119,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"code\""
@@ -4339,7 +5192,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"decimalRange\""
@@ -4382,7 +5237,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"decimal\""
@@ -4424,6 +5281,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "generalRegulationGroupUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/generalregulationgroup/{guid})",
+                        "readOnly": true
                     },
                     "titleOfPlanRegulation": {
                         "allOf": [
@@ -4516,7 +5378,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiLineStringGeometry": {
                 "required": [
@@ -4559,7 +5421,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPointGeometry": {
                 "required": [
@@ -4599,7 +5461,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPoint GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPolygonGeometry": {
                 "required": [
@@ -4645,7 +5507,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPolygon GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+                "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
             },
             "GeoJsonPointGeometry": {
                 "required": [
@@ -4682,7 +5544,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Point GeoJson<br />\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+                "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
             },
             "GeoJsonPolygonGeometry": {
                 "required": [
@@ -4725,7 +5587,100 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Polygon GeoJson<br />\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+                "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+            },
+            "HandlingEvent": {
+                "required": [
+                    "handlingEventKey",
+                    "handlingEventType"
+                ],
+                "type": "object",
+                "properties": {
+                    "handlingEventKey": {
+                        "type": "string",
+                        "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
+                        "format": "uuid"
+                    },
+                    "handlingEventUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/handlingevent/{guid})",
+                        "readOnly": true
+                    },
+                    "handlingEventType": {
+                        "enum": [
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/01",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/02",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/03",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/04",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/05",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/06",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/07",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/08",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/09",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/10",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/11",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/12",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/13",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/14",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/15",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/16",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/17",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/18",
+                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/19"
+                        ],
+                        "type": "string",
+                        "description": "Käsittelytapahtuman tyyppi. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/kaavakastap\">http://uri.suomi.fi/codelist/rytj/kaavakastap</a>"
+                    },
+                    "eventTime": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "name": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "description": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "location": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RyhtiGeometry"
+                            }
+                        ],
+                        "description": "Käsittelytapahtuman sijainti",
+                        "nullable": true
+                    },
+                    "additionalInformationLink": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "cancelled": {
+                        "type": "boolean",
+                        "nullable": true
+                    },
+                    "relatedDocuments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PlanAttachmentDocument"
+                        },
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false,
+                "description": "Käsittelytapahtuma"
             },
             "HealthReport": {
                 "type": "object",
@@ -4740,11 +5695,8 @@
                         "readOnly": true
                     },
                     "totalDuration": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpan"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-span",
                         "readOnly": true
                     },
                     "entries": {
@@ -4761,11 +5713,8 @@
                 "type": "object",
                 "properties": {
                     "duration": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpan"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-span",
                         "readOnly": true
                     },
                     "status": {
@@ -4821,7 +5770,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"identifier\""
@@ -4842,6 +5793,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "interactionEventUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/interactionevent/{guid})",
+                        "readOnly": true
                     },
                     "interactionEventType": {
                         "enum": [
@@ -4911,6 +5867,593 @@
                 },
                 "additionalProperties": false,
                 "description": "Vuorovaikutustapahtuma"
+            },
+            "LandUseRestriction": {
+                "required": [
+                    "landUseRestrictionKey",
+                    "landUseRestrictionObjects",
+                    "periodOfValidity"
+                ],
+                "type": "object",
+                "properties": {
+                    "landUseRestrictionKey": {
+                        "type": "string",
+                        "description": "Avain",
+                        "format": "uuid"
+                    },
+                    "landUseRestrictionUri": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "periodOfValidity": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/TimePeriodDateOnly"
+                            }
+                        ],
+                        "description": "Voimassaoloaika"
+                    },
+                    "landUseRestrictionObjects": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandUseRestrictionObject"
+                        },
+                        "description": "Alueidenkäytön rajoituskohde"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionAttachmentDocument": {
+                "required": [
+                    "accessibility",
+                    "attachmentDocumentKey",
+                    "categoryOfPublicity",
+                    "documentDate",
+                    "documentIdentifier",
+                    "fileKey",
+                    "languages",
+                    "name",
+                    "personalDataContent",
+                    "retentionTime",
+                    "typeOfAttachment"
+                ],
+                "type": "object",
+                "properties": {
+                    "attachmentDocumentKey": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
+                        "format": "uuid"
+                    },
+                    "documentIdentifier": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
+                    },
+                    "name": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+                    },
+                    "personalDataContent": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
+                    },
+                    "categoryOfPublicity": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
+                    },
+                    "accessibility": {
+                        "type": "boolean"
+                    },
+                    "retentionTime": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
+                    },
+                    "confirmationDate": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "languages": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
+                    },
+                    "fileKey": {
+                        "type": "string",
+                        "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
+                        "format": "uuid"
+                    },
+                    "descriptors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Descriptor"
+                        },
+                        "nullable": true
+                    },
+                    "documentDate": {
+                        "minLength": 1,
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "arrivedDate": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "landUseRestrictionAttachmentDocumentUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionattachmentdocument/{guid})",
+                        "readOnly": true
+                    },
+                    "typeOfAttachment": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Tieto, joka kuvaa tuotettavan asiakirjan lajia. Asiakirjoja tuotetaan yleensä asiankäsittelyyn liittyvissä yksittäisissä toimissa tai tapahtumissa (toimenpide).\r\nAsiakirjatyyppi noudattaa yhteistä luokitusta/koodistoa, esimerkkejä arvoille ovat raportti, päätös, ilmoitus, muistio, tiedote...\r\nKäytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/asiakirjanLaji\">http://uri.suomi.fi/codelist/rytj/asiakirjanLaji</a>"
+                    },
+                    "documentSpecification": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "documentCreatorOperators": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandUseRestrictionOperator"
+                        },
+                        "description": "Asiakirjan laatijat",
+                        "nullable": true
+                    },
+                    "relatedLandUseRestrictionDocuments": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Liiteasiakirjaan liittyvät muut liiteasiakirjat",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionHandlingEvent": {
+                "required": [
+                    "handlingEventKey",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "handlingEventKey": {
+                        "type": "string",
+                        "description": "Avain",
+                        "format": "uuid"
+                    },
+                    "handlingEventUri": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "type": {
+                        "enum": [
+                            "http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenKasittelytapahtumanLaji/code/01",
+                            "http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenKasittelytapahtumanLaji/code/02",
+                            "http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenKasittelytapahtumanLaji/code/03"
+                        ],
+                        "type": "string",
+                        "description": "Laji. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenKasittelytapahtumanLaji\">http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenKasittelytapahtumanLaji</a>"
+                    },
+                    "name": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "description": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "eventTime": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/TimePeriod"
+                            }
+                        ],
+                        "description": "Tapahtuman aika (hetki tai aikaväli)",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionMatter": {
+                "required": [
+                    "administrativeAreaIdentifiers",
+                    "landUseRestrictionType",
+                    "name",
+                    "permanentLandUseRestrictionIdentifier",
+                    "phases",
+                    "timeOfInitiation"
+                ],
+                "type": "object",
+                "properties": {
+                    "permanentLandUseRestrictionIdentifier": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Alueidenkäytön rajoituksen pysyvä tunnus"
+                    },
+                    "landUseRestrictionMatterUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionmatter/{identifier})",
+                        "readOnly": true
+                    },
+                    "name": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+                    },
+                    "landUseRestrictionType": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Alueidenkäytön rajoituksen tyyppi. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji\">http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji</a>"
+                    },
+                    "phases": {
+                        "maxItems": 1,
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandUseRestrictionMatterPhase"
+                        },
+                        "description": "Vaiheet"
+                    },
+                    "timeOfInitiation": {
+                        "type": "string",
+                        "description": "Vireilletulopäivämäärä",
+                        "format": "date"
+                    },
+                    "administrativeAreaIdentifiers": {
+                        "maxItems": 1,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "hallinnollisen alueen tunnukset"
+                    },
+                    "description": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LanguageString"
+                            }
+                        ],
+                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+                        "nullable": true
+                    },
+                    "caseIdentifiers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Asianhallintatunnukset",
+                        "nullable": true
+                    },
+                    "recordNumbers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Diaarinumerot",
+                        "nullable": true
+                    },
+                    "producerLandUseRestrictionIdentifier": {
+                        "type": "string",
+                        "description": "Kunnan antama alueidenkäytön rajoituksen tunnus",
+                        "nullable": true
+                    },
+                    "matterAnnexes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandUseRestrictionAttachmentDocument"
+                        },
+                        "description": "AsianLiitteet",
+                        "nullable": true
+                    },
+                    "responsibleParty": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LandUseRestrictionOperator"
+                            }
+                        ],
+                        "description": "Vastuutaho",
+                        "nullable": true
+                    },
+                    "relatedLandUseRestrictionMatters": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Liittyvät alueidenkäytön rajoituksen asiat",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionMatterDecision": {
+                "required": [
+                    "dateOfDecision",
+                    "dateOfValidity",
+                    "decisionDate",
+                    "decisionDocuments",
+                    "decisionMaker",
+                    "landUseRestrictionMatterDecisionKey",
+                    "name",
+                    "typeOfDecisionMaker"
+                ],
+                "type": "object",
+                "properties": {
+                    "landUseRestrictionMatterDecisionKey": {
+                        "type": "string",
+                        "description": "Avain",
+                        "format": "uuid"
+                    },
+                    "landUseRestrictionMatterDecisionUri": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "decisionDate": {
+                        "type": "string",
+                        "description": "Päätöspäivämäärä",
+                        "format": "date"
+                    },
+                    "dateOfDecision": {
+                        "type": "string",
+                        "description": "Päätöksenantopäivämäärä",
+                        "format": "date"
+                    },
+                    "dateOfValidity": {
+                        "type": "string",
+                        "description": "Lainvoimaisuuspäivämäärä",
+                        "format": "date"
+                    },
+                    "decisionDocuments": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandUseRestrictionAttachmentDocument"
+                        },
+                        "description": "Päätösasiakirjat"
+                    },
+                    "decisionMaker": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LandUseRestrictionOperator"
+                            }
+                        ],
+                        "description": "Päätöksentekijä"
+                    },
+                    "name": {
+                        "enum": [
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/01",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0101",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/02",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0201",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/03",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0301",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0302",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0303",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0304",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/04",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0401",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0402",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/05",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0501",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/06",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0601",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/07",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0701",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0702",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0703",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0704",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0705",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0706",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0707",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0708",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0709",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0710",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0102",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0403",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0404",
+                            "http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi/code/0405"
+                        ],
+                        "type": "string",
+                        "description": "Päätöksen nimitys, joka kertoo mitä päätös koskee. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi\">http://uri.suomi.fi/codelist/rytj/AlueidenkaytonPaatoksenNimi</a>"
+                    },
+                    "typeOfDecisionMaker": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Päättäjän laji. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>"
+                    },
+                    "decisionIdentifier": {
+                        "type": "string",
+                        "description": "Päätöstunnus",
+                        "nullable": true
+                    },
+                    "statute": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Statute"
+                            }
+                        ],
+                        "description": "Ohjaava säädös",
+                        "nullable": true
+                    },
+                    "landUseRestriction": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LandUseRestriction"
+                            }
+                        ],
+                        "description": "Alueidenkäytön rajoitus",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionMatterPhase": {
+                "required": [
+                    "decision",
+                    "handlingEvent",
+                    "landUseRestrictionMatterPhaseKey",
+                    "lifeCycleStatus"
+                ],
+                "type": "object",
+                "properties": {
+                    "landUseRestrictionMatterPhaseKey": {
+                        "type": "string",
+                        "description": "Avain",
+                        "format": "uuid"
+                    },
+                    "landUseRestrictionMatterPhaseUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionmatterphase/{guid})",
+                        "readOnly": true
+                    },
+                    "lifeCycleStatus": {
+                        "enum": [
+                            "http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenElinkaarenTila/code/01",
+                            "http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenElinkaarenTila/code/02",
+                            "http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenElinkaarenTila/code/03"
+                        ],
+                        "type": "string",
+                        "description": "Elinkaaritila. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenElinkaarenTila\">http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenElinkaarenTila</a>"
+                    },
+                    "handlingEvent": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LandUseRestrictionHandlingEvent"
+                            }
+                        ],
+                        "description": "Käsittelytapahtuma"
+                    },
+                    "decision": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/LandUseRestrictionMatterDecision"
+                            }
+                        ],
+                        "description": "Päätös"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionObject": {
+                "required": [
+                    "geometry",
+                    "landUseRestrictionObjectKey"
+                ],
+                "type": "object",
+                "properties": {
+                    "landUseRestrictionObjectKey": {
+                        "type": "string",
+                        "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus.",
+                        "format": "uuid"
+                    },
+                    "landUseRestrictionObjectUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionobject/{guid})",
+                        "readOnly": true
+                    },
+                    "relatedProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Tieto liittyvistä kiinteistöistä, joita rajoitus koskee",
+                        "nullable": true
+                    },
+                    "relatedPlans": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RelatedPlan"
+                        },
+                        "description": "Alueidenkäytön rajoituskohteen alueelle kohdistuvan kaavan pysyvä kaavatunnus",
+                        "nullable": true
+                    },
+                    "geometry": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RyhtiGeometry"
+                            }
+                        ],
+                        "description": "Geometria-attribuutin arvon tulee olla alue, 3-ulotteinen kappale, monialue tai monikappale."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "LandUseRestrictionOperator": {
+                "required": [
+                    "landUseRestrictionOperatorKey"
+                ],
+                "type": "object",
+                "properties": {
+                    "landUseRestrictionOperatorKey": {
+                        "type": "string",
+                        "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus.",
+                        "format": "uuid"
+                    },
+                    "landUseRestrictionOperatorUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionoperator/{guid})",
+                        "readOnly": true
+                    },
+                    "firstName": {
+                        "type": "string",
+                        "description": "Toimijan etunimi",
+                        "nullable": true
+                    },
+                    "lastName": {
+                        "type": "string",
+                        "description": "Toimijan sukunimi",
+                        "nullable": true
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Toimijan nimike",
+                        "nullable": true
+                    },
+                    "organizationName": {
+                        "type": "string",
+                        "description": "Toimijan organisaation nimi.",
+                        "nullable": true
+                    },
+                    "businessId": {
+                        "type": "string",
+                        "description": "Toimijan organisaation y-tunnus.",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false
             },
             "LanguageString": {
                 "type": "object",
@@ -4986,7 +6529,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"localizedText\""
@@ -5063,7 +6608,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"numericRange\""
@@ -5106,7 +6653,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"numeric\""
@@ -5128,6 +6677,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "otherPlanMaterialUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/otherplanmaterial/{guid})",
+                        "readOnly": true
                     },
                     "name": {
                         "allOf": [
@@ -5162,17 +6716,23 @@
                 "additionalProperties": false,
                 "description": "MuuKaavaAineisto"
             },
-            "PartiallyCancellationPlanObjectInfo": {
+            "PartiallyCancelledPlanObjectInfo": {
                 "required": [
-                    "partiallyCancelledPlanObjectId",
+                    "cancelledPlanUri",
+                    "partiallyCancelledPlanObjectUri",
                     "validityGeometry"
                 ],
                 "type": "object",
                 "properties": {
-                    "partiallyCancelledPlanObjectId": {
+                    "cancelledPlanUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kaavakohteen yksilöivätunnus, jota osittainen kumoutuminen koskee."
+                        "description": "Kumottavan hyväkstytyn kaavan tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{planKey})"
+                    },
+                    "partiallyCancelledPlanObjectUri": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Kumottavan kaavakohteen tunnus uri-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{planObjectKey})"
                     },
                     "validityGeometry": {
                         "allOf": [
@@ -5198,6 +6758,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "participationAndAssessmentSchemeUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/participationandassessmentscheme/{guid})",
+                        "readOnly": true
+                    },
                     "attachmentDocuments": {
                         "minItems": 1,
                         "type": "array",
@@ -5221,6 +6786,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{guid})",
+                        "readOnly": true
                     },
                     "lifeCycleStatus": {
                         "enum": [
@@ -5351,10 +6921,10 @@
                         "description": "Laatija",
                         "nullable": true
                     },
-                    "partiallyCancellationPlanObjects": {
+                    "partiallyCancelledPlanObjects": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/PartiallyCancellationPlanObjectInfo"
+                            "$ref": "#/components/schemas/PartiallyCancelledPlanObjectInfo"
                         },
                         "description": "// Osittain kumottavat kaavakohteet",
                         "nullable": true
@@ -5475,6 +7045,11 @@
                         "format": "date",
                         "nullable": true
                     },
+                    "planAttachmentDocumentUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planattachmentdocument/{guid})",
+                        "readOnly": true
+                    },
                     "typeOfAttachment": {
                         "minLength": 1,
                         "type": "string",
@@ -5510,10 +7085,7 @@
             },
             "PlanCancellationInfo": {
                 "required": [
-                    "cancelledGuidanceId",
-                    "cancelledPlanId",
-                    "cancelledPlanObjectId",
-                    "cancelledRegulationId",
+                    "cancelledPlanUri",
                     "cancelsEntirePlan",
                     "planCancellationInfoKey"
                 ],
@@ -5524,49 +7096,47 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
-                    "cancelledPlanId": {
+                    "planCancellationInfoUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plancancellationinfo/{guid})",
+                        "readOnly": true
+                    },
+                    "cancelledPlanUri": {
                         "minLength": 1,
                         "type": "string",
-                        "description": "Kumottavan kaavan tunnus"
+                        "description": "Kumottavan hyväkstytyn kaavan tunnus URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{planKey})"
                     },
                     "cancelsEntirePlan": {
                         "type": "boolean",
                         "description": "Kumoaa kaavan kokonaan"
                     },
-                    "cancelledPlanObjectId": {
+                    "cancelledPlanObjectUris": {
                         "type": "array",
                         "items": {
-                            "minLength": 1,
                             "type": "string"
                         },
-                        "description": "Kumottavan kaavakohteen tunnukset",
-                        "nullable": true
+                        "description": "Kumottavan kaavakohteen tunnukset URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{planObjectKey})"
                     },
-                    "cancelledRegulationId": {
+                    "cancelledRegulationUris": {
                         "type": "array",
                         "items": {
-                            "minLength": 1,
                             "type": "string"
                         },
-                        "description": "Kumottavan määräyksen tunnukset",
-                        "nullable": true
+                        "description": "Kumottavan määräyksen tunnukset URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{planRegulationKey})"
                     },
-                    "cancelledGuidanceId": {
+                    "cancelledRecommendationUris": {
                         "type": "array",
                         "items": {
-                            "minLength": 1,
                             "type": "string"
                         },
-                        "description": "Kumottavan suosituksen tunnukset",
-                        "nullable": true
+                        "description": "Kumottavan suosituksen tunnukset URI-muodossa (https://uri.rakennetunymparistontietojarjestelma.fi/planrecommendation/{planRecommendationKey})"
                     },
                     "cancelledGroupRelations": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/CancelledGroupRelations"
                         },
-                        "description": "Kumottavan ryhmän kohdistus. Kuvaa kaavakohteesta kumoutuvat kaavamääräysryhmät.",
-                        "nullable": true
+                        "description": "Kumottavan ryhmän kohdistus. Kuvaa kaavakohteesta kumoutuvat kaavamääräysryhmät."
                     }
                 },
                 "additionalProperties": false,
@@ -5586,6 +7156,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planDecisionUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plandecision/{guid})",
+                        "readOnly": true
                     },
                     "name": {
                         "enum": [
@@ -5690,93 +7265,40 @@
                 "additionalProperties": false,
                 "description": "Kaavapäätös"
             },
-            "PlanHandlingEvent": {
+            "PlanEffects": {
                 "required": [
-                    "handlingEventKey",
-                    "handlingEventType"
+                    "bindingPlotDivisionUri",
+                    "relatedPlotDivisionPlots",
+                    "type"
                 ],
                 "type": "object",
                 "properties": {
-                    "handlingEventKey": {
+                    "type": {
+                        "minLength": 1,
                         "type": "string",
-                        "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
-                        "format": "uuid"
+                        "description": "Kaavan vaikutuksen laji. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/kaavanVaikutuksenLaji\">http://uri.suomi.fi/codelist/rytj/kaavanVaikutuksenLaji</a>"
                     },
-                    "handlingEventType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/09",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/10",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/13",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/14",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/15",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/16",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/17",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/18",
-                            "http://uri.suomi.fi/codelist/rytj/kaavakastap/code/19"
-                        ],
+                    "bindingPlotDivisionUri": {
+                        "minLength": 1,
                         "type": "string",
-                        "description": "Käsittelytapahtuman tyyppi. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/kaavakastap\">http://uri.suomi.fi/codelist/rytj/kaavakastap</a>"
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivision/{bindingplotdivisionkey}) sitovaan tonttijakoon."
                     },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "description": "Käsittelytapahtuman sijainti",
-                        "nullable": true
-                    },
-                    "additionalInformationLink": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "cancelled": {
+                    "fullyIncluded": {
                         "type": "boolean",
+                        "description": "Jos arvo on true, kaavan vaikutus kohdistuu sitovaan tonttijakoon kokonaisuudessaan, muuten tonttijakotontti kohtaisesti.",
                         "nullable": true
                     },
-                    "relatedDocuments": {
+                    "relatedPlotDivisionPlots": {
+                        "minItems": 1,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/PlanAttachmentDocument"
+                            "$ref": "#/components/schemas/RelatedPlotDivisionPlot"
                         },
-                        "nullable": true
+                        "description": "Tonttijakotontin yksilöivätunnus, jota vaikutus koskee."
                     }
                 },
                 "additionalProperties": false,
-                "description": "Käsittelytapahtuma"
+                "description": "KaavanVaikutukset"
             },
             "PlanMap": {
                 "required": [
@@ -5791,6 +7313,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planMapUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planmap/{guid})",
+                        "readOnly": true
                     },
                     "name": {
                         "allOf": [
@@ -6014,10 +7541,10 @@
                         ],
                         "description": "Aluerajaus"
                     },
-                    "planHandlingEvent": {
+                    "handlingEvent": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/PlanHandlingEvent"
+                                "$ref": "#/components/schemas/HandlingEvent"
                             }
                         ],
                         "description": "Käsittelytapahtuma",
@@ -6051,6 +7578,11 @@
                         "type": "string",
                         "format": "uuid"
                     },
+                    "planMatterPhaseUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planmatterphase/{guid})",
+                        "readOnly": true
+                    },
                     "lifeCycleStatus": {
                         "enum": [
                             "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/01",
@@ -6080,10 +7612,10 @@
                             }
                         ]
                     },
-                    "planHandlingEvent": {
+                    "handlingEvent": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/PlanHandlingEvent"
+                                "$ref": "#/components/schemas/HandlingEvent"
                             }
                         ],
                         "description": "Käsittelytapahtuma",
@@ -6301,6 +7833,11 @@
                         "items": {
                             "$ref": "#/components/schemas/PlanMatterPhaseUriResponse"
                         }
+                    },
+                    "planMatterUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planmatter/{identifier})",
+                        "readOnly": true
                     }
                 },
                 "additionalProperties": false
@@ -6468,6 +8005,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planObjectUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planobject/{guid})",
+                        "readOnly": true
+                    },
                     "lifeCycleStatus": {
                         "enum": [
                             "http://uri.suomi.fi/codelist/rytj/kaavaelinkaari/code/01",
@@ -6537,7 +8079,15 @@
                             "type": "string",
                             "format": "uuid"
                         },
-                        "description": "Viittaus (GUID) kaavan mukana toimitettavaan lähtötietoaineistoon sisältyvään tietokohteeseen, joka liittyy​ kaavakohteeseen. Esim. Pohjavesialue.",
+                        "description": "Viittaus (GUID) kaavan mukana toimitettavaan lähtötietoaineistoon sisältyvään tietokohteeseen, joka liittyy kaavakohteeseen. Esim. Pohjavesialue.\r\nPäivitysvaiheessa tämän listan kuuluu olla tyhjä.",
+                        "nullable": true
+                    },
+                    "relatedPlanSourceDataUris": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Viittaus (URI) kaava-asian mukana toimitettavaan, aiemmin tallennettuun, lähtötietoaineistoon sisältyvään tietokohteeseen, joka liittyy tallennettuun kaavakohteeseen. Esim. Pohjavesialue.",
                         "nullable": true
                     },
                     "periodOfValidity": {
@@ -6578,6 +8128,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planOperatorUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planoperator/{guid})",
+                        "readOnly": true
                     },
                     "firstName": {
                         "type": "string",
@@ -6620,6 +8175,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planRecommendationUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planrecommendation/{guid})",
+                        "readOnly": true
                     },
                     "value": {
                         "allOf": [
@@ -6700,6 +8260,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planRegulationUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{guid})",
+                        "readOnly": true
+                    },
                     "value": {
                         "oneOf": [
                             {
@@ -6740,6 +8305,12 @@
                             },
                             {
                                 "$ref": "#/components/schemas/TextValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodValue"
+                            },
+                            {
+                                "$ref": "#/components/schemas/TimePeriodDateOnlyValue"
                             }
                         ],
                         "nullable": true
@@ -7143,6 +8714,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planRegulationGroupUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planregulationgroup/{guid})",
+                        "readOnly": true
+                    },
                     "titleOfPlanRegulation": {
                         "allOf": [
                             {
@@ -7212,6 +8788,11 @@
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
                     },
+                    "planReportUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/planreport/{guid})",
+                        "readOnly": true
+                    },
                     "attachmentDocuments": {
                         "minItems": 1,
                         "type": "array",
@@ -7234,6 +8815,11 @@
                         "type": "string",
                         "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
                         "format": "uuid"
+                    },
+                    "planSourceDataUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plansourcedata/{guid})",
+                        "readOnly": true
                     },
                     "type": {
                         "minLength": 1,
@@ -7290,6 +8876,11 @@
                         "type": "string",
                         "description": "Tonttijakotontin avain",
                         "format": "uuid"
+                    },
+                    "plotDivisionPlotUri": {
+                        "type": "string",
+                        "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/plotdivisionplot/{guid})",
+                        "readOnly": true
                     },
                     "plotDivisionPlotIdentifier": {
                         "minLength": 1,
@@ -7638,20 +9229,20 @@
                         "description": "Desimaaliarvoväli",
                         "nullable": true
                     },
-                    "areaReservationRegulations": {
+                    "areaReservationRegulationUris": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         },
-                        "description": "Aluevaraus määräykset",
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{planregulationkey}) kaavassa osoitettuun aluevarauksen kaavamääräykseen.",
                         "nullable": true
                     },
-                    "volumeOfBuildingRegulations": {
+                    "volumeOfBuildingRegulationUris": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         },
-                        "description": "Rakentamisen määrän määräykset",
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{planregulationkey}) kaavassa osoitettuun rakentamisen määrän kaavamääräykseen.",
                         "nullable": true
                     }
                 },
@@ -7696,7 +9287,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveDecimalRange\""
@@ -7739,7 +9332,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveDecimal\""
@@ -7787,7 +9382,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveNumericRange\""
@@ -7830,7 +9427,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"positiveNumeric\""
@@ -7869,19 +9468,71 @@
             "RelatedPlan": {
                 "type": "object",
                 "properties": {
-                    "relatedPlanIdentifier": {
+                    "relatedPlanUri": {
                         "type": "string",
-                        "description": "Liittyvän kaavan tunnus (URI)",
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/plan/{plankey}) tonttijakotontin alueelle kohdistuvaan vaikuttavaan kaavaan.",
                         "nullable": true
                     },
                     "relatedProducerPlanIdentifier": {
                         "type": "string",
-                        "description": "Liittyvä tuottajan kaavatunnus",
+                        "description": "Alueelle kohdistuvan vaikuttavan kaavan tuottajan kaavatunnus.",
                         "nullable": true
                     }
                 },
                 "additionalProperties": false,
                 "description": "Liittyvä kaava"
+            },
+            "RelatedPlotDivisionPlot": {
+                "required": [
+                    "referenceUri",
+                    "relatedPlans"
+                ],
+                "type": "object",
+                "properties": {
+                    "referenceUri": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/plotdivisionplot/{plotdivisionplotkey}) sitovassa tonttijaossa osoitettuun tonttijakotonttiin."
+                    },
+                    "relatedPlans": {
+                        "minItems": 1,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/RelatedPlan"
+                        },
+                        "description": "Tonttijakotontin alueelle kohdistuvan vaikuttavan kaavan pysyvä kaavatunnus"
+                    },
+                    "areaReservationRegulationUris": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{planregulationkey}) kaavassa osoitettuun aluevarauksen kaavamääräykseen.",
+                        "nullable": true
+                    },
+                    "volumeOfBuildingRegulationUris": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Viittaustunnus (https://uri.rakennetunymparistontietojarjestelma.fi/planregulation/{planregulationkey}) kaavassa osoitettuun rakentamisen määrän kaavamääräykseen.",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false,
+                "description": "LiittyväTonttijakotontti"
+            },
+            "ReserveBuildingOrdinancePermanentIdentifierCommand": {
+                "type": "object",
+                "properties": {
+                    "administrativeAreaIdentifier": {
+                        "type": "string"
+                    },
+                    "projectName": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
             },
             "ReserveLocalDetailedPlanMatterPermanentIdentifierCommand": {
                 "type": "object",
@@ -7928,6 +9579,21 @@
                 "additionalProperties": false,
                 "description": "Sanoma tonttijaon pysyvien tunnisteiden varaamiseen."
             },
+            "ReservePermanentLandUseRestrictionIdentifierCommand": {
+                "type": "object",
+                "properties": {
+                    "administrativeAreaIdentifier": {
+                        "type": "string",
+                        "description": "Hallinnollisen alueen tunnus (esim. kunta tai maakunta)"
+                    },
+                    "projectName": {
+                        "type": "string",
+                        "description": "Kaavahankkeen pysyvä nimi. Nimi on uniikki eikä sitä voi vaihtaa."
+                    }
+                },
+                "additionalProperties": false,
+                "description": "Sanoma alueidenkäytön rajoitusten pysyvien tunnisteiden varaamiseen."
+            },
             "ReserveRegionalPlanMatterPermanentIdentifierCommand": {
                 "type": "object",
                 "properties": {
@@ -7968,7 +9634,7 @@
                             "3885"
                         ],
                         "type": "string",
-                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi<br />\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873<br />\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874<br />\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875<br />\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876<br />\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877<br />\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878<br />\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879<br />\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880<br />\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881<br />\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882<br />\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883<br />\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884<br />\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885<br />\r\n   3067 TM35FIN<br />"
+                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
                     },
                     "geometry": {
                         "oneOf": [
@@ -8030,7 +9696,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"spotElevation\""
@@ -8156,7 +9824,9 @@
                             "PositiveDecimalRange",
                             "Code",
                             "Identifier",
-                            "SpotElevation"
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
                         ],
                         "type": "string",
                         "description": "Pakollinen arvo: \"text\""
@@ -8196,85 +9866,100 @@
                 },
                 "additionalProperties": false
             },
-            "TimeSpan": {
+            "TimePeriodDateOnlyValue": {
+                "required": [
+                    "dataType"
+                ],
                 "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AttributeValue"
+                    }
+                ],
                 "properties": {
-                    "ticks": {
-                        "type": "integer",
-                        "format": "int64"
+                    "begin": {
+                        "type": "string",
+                        "description": "Alkupäivä",
+                        "format": "date",
+                        "nullable": true
                     },
-                    "days": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
+                    "end": {
+                        "type": "string",
+                        "description": "Loppupäivä",
+                        "format": "date",
+                        "nullable": true
                     },
-                    "hours": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "milliseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "microseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "nanoseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "minutes": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "seconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "totalDays": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalHours": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMilliseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMicroseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalNanoseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMinutes": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalSeconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
+                    "dataType": {
+                        "enum": [
+                            "LocalizedText",
+                            "Text",
+                            "Numeric",
+                            "NumericRange",
+                            "PositiveNumeric",
+                            "PositiveNumericRange",
+                            "Decimal",
+                            "DecimalRange",
+                            "PositiveDecimal",
+                            "PositiveDecimalRange",
+                            "Code",
+                            "Identifier",
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
+                        ],
+                        "type": "string",
+                        "description": "Pakollinen arvo: \"timePeriodDateOnly\""
                     }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "description": "TimePeriodDateOnly"
+            },
+            "TimePeriodValue": {
+                "required": [
+                    "dataType"
+                ],
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AttributeValue"
+                    }
+                ],
+                "properties": {
+                    "beginUtc": {
+                        "type": "string",
+                        "description": "Alkuaika",
+                        "format": "date-time"
+                    },
+                    "endUtc": {
+                        "type": "string",
+                        "description": "Loppuaika",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "dataType": {
+                        "enum": [
+                            "LocalizedText",
+                            "Text",
+                            "Numeric",
+                            "NumericRange",
+                            "PositiveNumeric",
+                            "PositiveNumericRange",
+                            "Decimal",
+                            "DecimalRange",
+                            "PositiveDecimal",
+                            "PositiveDecimalRange",
+                            "Code",
+                            "Identifier",
+                            "SpotElevation",
+                            "TimePeriod",
+                            "TimePeriodDateOnly"
+                        ],
+                        "type": "string",
+                        "description": "Pakollinen arvo: \"timePeriod\""
+                    }
+                },
+                "additionalProperties": false,
+                "description": "TimePeriod"
             },
             "ValidationProblemDetails": {
                 "type": "object",
@@ -8326,12 +10011,7 @@
                     "clientCredentials": {
                         "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
                         "scopes": {
-                            "ryhti.plan.write": "Kaavatietojen kirjoitusoikeus",
-                            "ryhti.building.write": "Rakennustietojen kirjoitusoikeus",
-                            "ryhti.planui.write": "Käyttöliittymä apin käyttöoikeus",
-                            "ryhti.changeinformation.read": "Muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus"
+                            "ryhti.plan.write": "Kaavatietojen kirjoitusoikeus"
                         }
                     }
                 }

--- a/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Ryhti API",
-        "description": "<h2>Rakennetun ympäristön muutostietorajapinta</h2>\n\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\n<br/>",
+        "description": "<h2>Rakennetun ympäristön muutostietorajapinta</h2>\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
         "contact": {
             "name": "Feedback",
             "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
@@ -101,6 +101,16 @@
                     "ChangeInformation"
                 ],
                 "summary": "Hae rakennuksen muutostiedot",
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "description": "Viimeisin ID muutostentietojen hakemiseksi.",
                     "content": {
@@ -135,7 +145,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -175,7 +185,7 @@
                         }
                     },
                     "422": {
-                        "description": "Client Error",
+                        "description": "Unprocessable Content",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -203,6 +213,16 @@
                     "ChangeInformation"
                 ],
                 "summary": "Hae karkeutetut rakennuksen muutostiedot",
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "description": "Viimeisin ID muutostentietojen hakemiseksi.",
                     "content": {
@@ -237,7 +257,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -277,7 +297,7 @@
                         }
                     },
                     "422": {
-                        "description": "Client Error",
+                        "description": "Unprocessable Content",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -305,6 +325,16 @@
                     "ChangeInformation"
                 ],
                 "summary": "Hae rakennuslupa-asia muutostiedot",
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "description": "Viimeisin ID muutostentietojen hakemiseksi.",
                     "content": {
@@ -339,7 +369,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -379,7 +409,7 @@
                         }
                     },
                     "422": {
-                        "description": "Client Error",
+                        "description": "Unprocessable Content",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -402,6 +432,118 @@
             }
         },
         "/api/ChangeInformation/BuildingPermitGeneralized": {
+            "post": {
+                "tags": [
+                    "ChangeInformation"
+                ],
+                "summary": "Hae rakennuslupa-asia muutostiedot",
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/GetChangeInfo"
+                                    }
+                                ]
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/GetChangeInfo"
+                                    }
+                                ]
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/GetChangeInfo"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Content",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/ChangeInformation/Operator": {
             "post": {
                 "tags": [
                     "ChangeInformation"
@@ -441,7 +583,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -481,7 +623,7 @@
                         }
                     },
                     "422": {
-                        "description": "Client Error",
+                        "description": "Unprocessable Content",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -509,6 +651,15 @@
                     "InitialInformation"
                 ],
                 "summary": "Hae rakennuksen perustiedot",
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -542,7 +693,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -569,6 +720,15 @@
                 "tags": [
                     "InitialInformation"
                 ],
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -602,7 +762,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -629,65 +789,14 @@
                 "tags": [
                     "InitialInformation"
                 ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
                         }
                     }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/BuildingPermitGeneralized": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
                 ],
                 "requestBody": {
                     "content": {
@@ -722,7 +831,76 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InitialInformationCollection"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InitialInformationCollection"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InitialInformationCollection"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/InitialInformation/BuildingPermitGeneralized": {
+            "post": {
+                "tags": [
+                    "InitialInformation"
+                ],
+                "parameters": [
+                    {
+                        "name": "municipality",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/GetInitialInfo"
+                                    }
+                                ]
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/GetInitialInfo"
+                                    }
+                                ]
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/GetInitialInfo"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -1095,6 +1273,7 @@
                     "categoryOfPublicity",
                     "documentDate",
                     "documentIdentifier",
+                    "fileKey",
                     "languages",
                     "name",
                     "personalDataContent",
@@ -1154,8 +1333,7 @@
                     "fileKey": {
                         "type": "string",
                         "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
-                        "format": "uuid",
-                        "nullable": true
+                        "format": "uuid"
                     },
                     "descriptors": {
                         "type": "array",
@@ -1624,7 +1802,8 @@
             },
             "BuildingSite": {
                 "required": [
-                    "stormWaterTreatmentType"
+                    "stormWaterTreatmentType",
+                    "tenure"
                 ],
                 "type": "object",
                 "properties": {
@@ -1702,7 +1881,8 @@
                             "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
                         ],
                         "type": "string",
-                        "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>"
+                        "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>",
+                        "nullable": true
                     }
                 },
                 "additionalProperties": false,
@@ -1758,6 +1938,45 @@
                 },
                 "additionalProperties": false,
                 "description": "Määräyksestä poikkeaminen"
+            },
+            "ChangeInformationAdministrativeLocationUnit": {
+                "type": "object",
+                "properties": {
+                    "administrativeLocationUnitKey": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "unitIdentifier": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "propertyIdentifier": {
+                        "type": "string"
+                    },
+                    "unseparatedParcelIdentifier": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "property": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Property"
+                            }
+                        ],
+                        "description": "Kiinteistö",
+                        "nullable": true
+                    },
+                    "parcel": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/UnseparatedParcel"
+                            }
+                        ],
+                        "description": "Määräala",
+                        "nullable": true
+                    }
+                },
+                "additionalProperties": false
             },
             "ChangeInformationApartment": {
                 "type": "object",
@@ -2087,18 +2306,16 @@
                     "administrativeLocationUnit": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
                             }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö"
+                        ]
                     },
                     "decisionAdministrativeLocationUnit": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
                             }
                         ],
-                        "description": "Hallinnollinen sijaintiyksikkö",
                         "nullable": true
                     },
                     "buildingObjectOwner": {
@@ -2147,6 +2364,16 @@
                         "type": "integer",
                         "format": "int32",
                         "nullable": true
+                    },
+                    "numberOfNewApartments": {
+                        "type": "integer",
+                        "format": "int32",
+                        "nullable": true
+                    },
+                    "numberOfDeletedApartments": {
+                        "type": "integer",
+                        "format": "int32",
+                        "nullable": true
                     }
                 },
                 "additionalProperties": false
@@ -2170,6 +2397,12 @@
                     "parentType": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "parentChain": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParentTypeKey"
+                        }
                     },
                     "objectState": {
                         "allOf": [
@@ -2230,7 +2463,8 @@
                             {
                                 "$ref": "#/components/schemas/ChangeInformationBuilding"
                             }
-                        ]
+                        ],
+                        "nullable": true
                     },
                     "diff": {
                         "type": "array",
@@ -2301,7 +2535,8 @@
                     },
                     "buildingSite": {
                         "required": [
-                            "stormWaterTreatmentType"
+                            "stormWaterTreatmentType",
+                            "tenure"
                         ],
                         "allOf": [
                             {
@@ -2377,6 +2612,12 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "parentChain": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParentTypeKey"
+                        }
+                    },
                     "objectState": {
                         "allOf": [
                             {
@@ -2436,7 +2677,8 @@
                             {
                                 "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
                             }
-                        ]
+                        ],
+                        "nullable": true
                     },
                     "diff": {
                         "type": "array",
@@ -4083,7 +4325,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiLineStringGeometry": {
                 "required": [
@@ -4126,7 +4368,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPointGeometry": {
                 "required": [
@@ -4166,7 +4408,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPoint GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPolygonGeometry": {
                 "required": [
@@ -4212,7 +4454,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPolygon GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+                "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
             },
             "GeoJsonPointGeometry": {
                 "required": [
@@ -4249,7 +4491,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Point GeoJson<br />\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+                "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
             },
             "GeoJsonPolygonGeometry": {
                 "required": [
@@ -4292,7 +4534,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Polygon GeoJson<br />\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+                "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
             },
             "GetChangeInfo": {
                 "type": "object",
@@ -4387,11 +4629,8 @@
                         "readOnly": true
                     },
                     "totalDuration": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpan"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-span",
                         "readOnly": true
                     },
                     "entries": {
@@ -4408,11 +4647,8 @@
                 "type": "object",
                 "properties": {
                     "duration": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpan"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-span",
                         "readOnly": true
                     },
                     "status": {
@@ -4700,26 +4936,32 @@
                 "properties": {
                     "fin": {
                         "type": "string",
+                        "description": "suomi",
                         "nullable": true
                     },
                     "swe": {
                         "type": "string",
+                        "description": "ruotsi",
                         "nullable": true
                     },
                     "smn": {
                         "type": "string",
+                        "description": "inarinsaame",
                         "nullable": true
                     },
                     "sms": {
                         "type": "string",
+                        "description": "koltansaame",
                         "nullable": true
                     },
                     "sme": {
                         "type": "string",
+                        "description": "pohjoissaame",
                         "nullable": true
                     },
                     "eng": {
                         "type": "string",
+                        "description": "englanti",
                         "nullable": true
                     }
                 },
@@ -4896,6 +5138,16 @@
                 },
                 "additionalProperties": false
             },
+            "ParentTypeKey": {
+                "type": "object",
+                "properties": {
+                    "parentType": {
+                        "type": "string"
+                    },
+                    "parentKey": {}
+                },
+                "additionalProperties": false
+            },
             "PermitRegulation": {
                 "required": [
                     "permitRegulationType"
@@ -5051,6 +5303,54 @@
                     }
                 },
                 "additionalProperties": {}
+            },
+            "Property": {
+                "type": "object",
+                "properties": {
+                    "municipalityNumber": {
+                        "type": "string"
+                    },
+                    "propertyIdentifier": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "registrationDate": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "endDate": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "landArea": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "geometry": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RyhtiGeometry"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "relationToBaseProperty": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "description": "Kiinteistö"
             },
             "Purpose": {
                 "required": [
@@ -5253,7 +5553,7 @@
                             "3885"
                         ],
                         "type": "string",
-                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi<br />\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873<br />\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874<br />\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875<br />\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876<br />\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877<br />\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878<br />\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879<br />\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880<br />\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881<br />\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882<br />\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883<br />\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884<br />\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885<br />\r\n   3067 TM35FIN<br />"
+                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
                     },
                     "geometry": {
                         "oneOf": [
@@ -5595,85 +5895,37 @@
                 "additionalProperties": false,
                 "description": "Rakennelman osa"
             },
-            "TimeSpan": {
+            "UnseparatedParcel": {
                 "type": "object",
                 "properties": {
-                    "ticks": {
-                        "type": "integer",
-                        "format": "int64"
+                    "municipalityNumber": {
+                        "type": "string"
                     },
-                    "days": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
+                    "unseparatedParcelIdentifier": {
+                        "type": "string"
                     },
-                    "hours": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
+                    "status": {
+                        "type": "string"
                     },
-                    "milliseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
+                    "registrationDate": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
                     },
-                    "microseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
+                    "endDate": {
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
                     },
-                    "nanoseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
+                    "type": {
+                        "type": "string"
                     },
-                    "minutes": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "seconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "totalDays": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalHours": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMilliseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMicroseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalNanoseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMinutes": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalSeconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
+                    "relationToBaseProperty": {
+                        "type": "string"
                     }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "description": "Määräala"
             },
             "UsageData": {
                 "type": "object",
@@ -5799,12 +6051,12 @@
                     "clientCredentials": {
                         "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
                         "scopes": {
-                            "ryhti.plan.write": "Kaavatietojen kirjoitusoikeus",
-                            "ryhti.building.write": "Rakennustietojen kirjoitusoikeus",
-                            "ryhti.planui.write": "Käyttöliittymä apin käyttöoikeus",
-                            "ryhti.changeinformation.read": "Muutostietojen lukuoikeus",
+                            "ryhti.changeinformation.read": "Muutostietojen lukuoikeus.",
                             "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus"
+                            "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus",
+                            "ryhti.changeinformation.building.owners.all": "Omistajatietojen lukuoikeus, ml turvakiellon alaiset henkilöt.",
+                            "ryhti.changeinformation.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia henkilöitä.",
+                            "ryhti.changeinformation.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin."
                         }
                     }
                 }

--- a/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.1",
     "info": {
         "title": "Ryhti API",
-        "description": "<h2>Rakennetun ympäristön OpenApi kuvaukset </h2>\nEnsimmäisen vaiheen rakentamisen OpenApi rajapinnat kumppanitestaukseen.\n\n<b>HUOM!</b> Rajapintakuvaukset voivat vielä muuttua kumppanitestauksen ja kommenttien perusteella.\n\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\n<br/>",
+        "description": "<h2>Rakennetun ympäristön OpenApi kuvaukset </h2>\r\nEnsimmäisen vaiheen rakentamisen OpenApi rajapinnat kumppanitestaukseen.\r\n\r\n<b>HUOM!</b> Rajapintakuvaukset voivat vielä muuttua kumppanitestauksen ja kommenttien perusteella.\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
         "contact": {
             "name": "Feedback",
             "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
@@ -88,6 +88,140 @@
                             "text/json": {
                                 "schema": {
                                     "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/Building/{permanentBuildingIdentifier}": {
+            "get": {
+                "tags": [
+                    "Building"
+                ],
+                "summary": "Haetaan rakennuksen kaikki tiedot Ryhdin REST-rajapinnasta",
+                "parameters": [
+                    {
+                        "name": "permanentBuildingIdentifier",
+                        "in": "path",
+                        "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Building"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Building"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Building"
+                                }
+                            }
+                        }
+                    },
+                    "201": {
+                        "description": "Rakennuskohteen tallentaminen onnistui."
+                    },
+                    "400": {
+                        "description": "Rakennuskohteen tallentaminen epäonnistui virheellisen kutsun johdosta."
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Rakennuskohteen tallentaminen epäonnistui virheellisen tiedon johdosta."
+                    }
+                }
+            }
+        },
+        "/api/BuildingGeneralized/{permanentBuildingIdentifier}": {
+            "get": {
+                "tags": [
+                    "Building"
+                ],
+                "summary": "Haetaan karkeutettu rakennustieto",
+                "parameters": [
+                    {
+                        "name": "permanentBuildingIdentifier",
+                        "in": "path",
+                        "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Rakennuskohteen haku onnistui.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Building"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Building"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Building"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Ei oikeutta lukea rakennuskohteen tietoja."
+                    },
+                    "404": {
+                        "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
                                 }
                             }
                         }
@@ -297,6 +431,134 @@
                             "text/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BuildingOwnersAll/{permanentBuildingIdentifier}": {
+            "get": {
+                "tags": [
+                    "BuildingOwners"
+                ],
+                "summary": "Haetaan rakennuksen omistajatiedot, ml turvakiellon alaiset tiedot.",
+                "parameters": [
+                    {
+                        "name": "permanentBuildingIdentifier",
+                        "in": "path",
+                        "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Omistajatietojen haku onnistui."
+                    },
+                    "403": {
+                        "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BuildingOwners/{permanentBuildingIdentifier}": {
+            "get": {
+                "tags": [
+                    "BuildingOwners"
+                ],
+                "summary": "Haetaan rakennuksen omistajatiedot, ilman turvakiellon alaisia tietoja.",
+                "parameters": [
+                    {
+                        "name": "permanentBuildingIdentifier",
+                        "in": "path",
+                        "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Omistajatietojen haku onnistui."
+                    },
+                    "403": {
+                        "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
                                 }
                             }
                         }
@@ -539,6 +801,88 @@
                     }
                 }
             },
+            "get": {
+                "tags": [
+                    "BuildingPermit"
+                ],
+                "summary": "Hae rakentamislupa-asia.",
+                "parameters": [
+                    {
+                        "name": "buildingPermitId",
+                        "in": "path",
+                        "description": "Rakennuslupa-asian pysyvä yksilöivä lupatunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Rakennusluvan hakeminen onnistui."
+                    },
+                    "400": {
+                        "description": "Rakennusluvan hakeminen epäonnistui virheellisen kutsun johdosta.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Rakennusluvan hakeminen epäonnistui virheellisen tiedon johdosta.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "put": {
                 "tags": [
                     "BuildingPermit"
@@ -651,6 +995,90 @@
                     },
                     "422": {
                         "description": "rakentamislupa-asia tallentaminen epäonnistui",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/BuildingPermitGeneralized/{buildingPermitId}": {
+            "get": {
+                "tags": [
+                    "BuildingPermit"
+                ],
+                "summary": "Hae karkeutettu rakentamislupa-asia.",
+                "parameters": [
+                    {
+                        "name": "buildingPermitId",
+                        "in": "path",
+                        "description": "Rakennuslupa-asian pysyvä yksilöivä lupatunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Karkeutetun rakennusluvan hakeminen onnistui."
+                    },
+                    "400": {
+                        "description": "Karkeutetun rakennusluvan hakeminen epäonnistui virheellisen kutsun johdosta.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Karkeutetun rakennusluvan hakeminen epäonnistui virheellisen tiedon johdosta.",
                         "content": {
                             "text/plain": {
                                 "schema": {
@@ -1398,6 +1826,24 @@
                 "tags": [
                     "Document"
                 ],
+                "parameters": [
+                    {
+                        "name": "municipalityId",
+                        "in": "query",
+                        "description": "Jos käyttäjällä on oikeus useampaan kuntaan tulee pyynnön sisältää kuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "regionId",
+                        "in": "query",
+                        "description": "Jos käyttäjällä on oikeus useampaan maakuntaan tulee pyynnön sisältää maakuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "multipart/form-data": {
@@ -1570,6 +2016,70 @@
                             "text/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ValidationProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/ForemenPlanners/{permanentPermitIdentifier}": {
+            "get": {
+                "tags": [
+                    "ForemenPlanners"
+                ],
+                "summary": "Haetaan työnjohtajien ja suunnittelijoiden tiedot",
+                "parameters": [
+                    {
+                        "name": "permanentPermitIdentifier",
+                        "in": "path",
+                        "description": "Lupa-asian pysyvä yksilöivä tunnus.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Työnjohtajien ja sunnittelijoiden tietojen haku onnistui."
+                    },
+                    "403": {
+                        "description": "Ei oikeutta lukea lupa-asian tietoja.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Lupa-asia ei löytynyt pysyvällä tunnuksella.",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProblemDetails"
                                 }
                             }
                         }
@@ -6517,7 +7027,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiLineStringGeometry": {
                 "required": [
@@ -6560,7 +7070,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "LineString GeoJson<br />\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPointGeometry": {
                 "required": [
@@ -6600,7 +7110,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPoint GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+                "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
             },
             "GeoJsonMultiPolygonGeometry": {
                 "required": [
@@ -6646,7 +7156,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "MultiPolygon GeoJson<br />\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+                "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
             },
             "GeoJsonPointGeometry": {
                 "required": [
@@ -6683,7 +7193,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Point GeoJson<br />\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+                "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
             },
             "GeoJsonPolygonGeometry": {
                 "required": [
@@ -6726,7 +7236,7 @@
                     }
                 },
                 "additionalProperties": false,
-                "description": "Polygon GeoJson<br />\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+                "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
             },
             "GetPermanentApartmentIdentifierCommand": {
                 "required": [
@@ -7201,11 +7711,8 @@
                         "readOnly": true
                     },
                     "totalDuration": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpan"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-span",
                         "readOnly": true
                     },
                     "entries": {
@@ -7222,11 +7729,8 @@
                 "type": "object",
                 "properties": {
                     "duration": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/TimeSpan"
-                            }
-                        ],
+                        "type": "string",
+                        "format": "date-span",
                         "readOnly": true
                     },
                     "status": {
@@ -8438,7 +8942,7 @@
                             "3885"
                         ],
                         "type": "string",
-                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi<br />\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873<br />\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874<br />\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875<br />\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876<br />\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877<br />\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878<br />\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879<br />\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880<br />\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881<br />\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882<br />\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883<br />\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884<br />\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885<br />\r\n   3067 TM35FIN<br />"
+                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
                     },
                     "geometry": {
                         "oneOf": [
@@ -8801,86 +9305,6 @@
                 "additionalProperties": false,
                 "description": "Rakennelman osa"
             },
-            "TimeSpan": {
-                "type": "object",
-                "properties": {
-                    "ticks": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "days": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "hours": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "milliseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "microseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "nanoseconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "minutes": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "seconds": {
-                        "type": "integer",
-                        "format": "int32",
-                        "readOnly": true
-                    },
-                    "totalDays": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalHours": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMilliseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMicroseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalNanoseconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalMinutes": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    },
-                    "totalSeconds": {
-                        "type": "number",
-                        "format": "double",
-                        "readOnly": true
-                    }
-                },
-                "additionalProperties": false
-            },
             "UsageData": {
                 "required": [
                     "purpose"
@@ -9011,12 +9435,11 @@
                     "clientCredentials": {
                         "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
                         "scopes": {
-                            "ryhti.plan.write": "Kaavatietojen kirjoitusoikeus",
                             "ryhti.building.write": "Rakennustietojen kirjoitusoikeus",
-                            "ryhti.planui.write": "Käyttöliittymä apin käyttöoikeus",
-                            "ryhti.changeinformation.read": "Muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus"
+                            "ryhti.building.owners.all": "Oikeus rakennuksen kaikkin omistajatietoihin, ml turvakiellon alaiset.",
+                            "ryhti.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia tietoja.",
+                            "ryhti.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin.",
+                            "ryhti.building.generalized": "Oikeus karkeutettuun rakennustietoon."
                         }
                     }
                 }


### PR DESCRIPTION
Julkaisun tarkemmat kuvaukset tulevat release noteseihin myöhemmin. 

**Huom!** Kaavapuolen OpenApi kuvauksen tonttijaon validointi ja tallennus rajapinnat julkaistaan vain testiympäristöön, eikä vielä tuotantoon.