### PR TITLE
Julkaisun 2024-14 muutokset.

### DIFF
--- a/OpenApi/Alueidenkäyttö/Avoin/ryhti-plan-public-validate-api.json
+++ b/OpenApi/Alueidenkäyttö/Avoin/ryhti-plan-public-validate-api.json
@@ -34,7 +34,7 @@
                     {
                         "name": "administrativeAreaIdentifiers",
                         "in": "query",
-                        "description": "Kunta- tai maakuntakoodi. \r\n\r\nExample : 049",
+                        "description": "Kunta- tai maakuntakoodi. \r\n\r\nEsimerkki : 049",
                         "required": true,
                         "style": "form",
                         "explode": false,

--- a/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
@@ -1,9171 +1,9541 @@
 {
     "openapi": "3.0.1",
     "info": {
-        "title": "Ryhti API",
-        "description": "<h2>Rakennetun ympäristön muutostietorajapinta</h2>\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
-        "contact": {
-            "name": "Feedback",
-            "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
-        },
-        "license": {
-            "name": "CC BY 4.0",
-            "url": "https://creativecommons.org/licenses/by/4.0/"
-        },
-        "version": "1"
+      "title": "Ryhti API",
+      "description": "<h2>Rakennetun ympäristön muutostietorajapinta</h2>\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
+      "contact": {
+        "name": "Feedback",
+        "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
+      },
+      "license": {
+        "name": "CC BY 4.0",
+        "url": "https://creativecommons.org/licenses/by/4.0/"
+      },
+      "version": "1"
     },
     "servers": [
-        {
-            "url": "/change-information"
-        }
+      {
+        "url": "/change-information"
+      }
     ],
     "paths": {
-        "/api/Authenticate": {
-            "post": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "Hae OAuth2 -token käyttäen client credentials tunnusta ja salaisuutta.",
-                "description": "ClientId välitetään querysting parametrina ja clientSecrect http bodyssä. <b>X-Token-Expires-In</b> http headerissa palautuu tokenin voimassaoloaika sekunneissa.",
-                "parameters": [
-                    {
-                        "name": "clientId",
-                        "in": "query",
-                        "description": "OAuth clientId.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "OAuth clientSecret välitetään http bodyssä heittomerkkien sisällä. Esim. ```\"minunsalaisuus\"```",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "string"
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "type": "string"
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "type": "string"
-                            }
-                        }
-                    }
+      "/api/Authenticate": {
+        "post": {
+          "tags": [
+            "Authentication"
+          ],
+          "summary": "Hae OAuth2 -token käyttäen client credentials tunnusta ja salaisuutta.",
+          "description": "ClientId välitetään querysting parametrina ja clientSecrect http bodyssä. <b>X-Token-Expires-In</b> http headerissa palautuu tokenin voimassaoloaika sekunneissa.",
+          "parameters": [
+            {
+              "name": "clientId",
+              "in": "query",
+              "description": "OAuth clientId.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "OAuth clientSecret välitetään http bodyssä heittomerkkien sisällä. Esim. ```\"minunsalaisuus\"```",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OAuth token, joka pitää välittää Authorization headerissä muissa api-kutsuissa.\r\n            ```X-Token-Expires-In``` http header kertoo sekunneissa tokeninen voimassaoloajan.\r\n            Muita api-rajapintoja kutsuttaessa lisää kutsuun Authorization header seuraavasti: ```Authorization: Bearer [token]```",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "string"
+                  }
                 },
-                "responses": {
-                    "200": {
-                        "description": "OAuth token, joka pitää välittää Authorization headerissä muissa api-kutsuissa.\r\n            ```X-Token-Expires-In``` http header kertoo sekunneissa tokeninen voimassaoloajan.\r\n            Muita api-rajapintoja kutsuttaessa lisää kutsuun Authorization header seuraavasti: ```Authorization: Bearer [token]```",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/Building": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae rakennuksen muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
+                "application/json": {
+                  "schema": {
+                    "type": "string"
+                  }
                 },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
+                "text/json": {
+                  "schema": {
+                    "type": "string"
+                  }
                 }
-            }
-        },
-        "/api/ChangeInformation/BuildingGeneralized": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae karkeutetut rakennuksen muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "string"
+                  }
                 },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/BuildingPermit": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae rakennuslupa-asian muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
+                "application/json": {
+                  "schema": {
+                    "type": "string"
+                  }
                 },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
+                "text/json": {
+                  "schema": {
+                    "type": "string"
+                  }
                 }
+              }
             }
-        },
-        "/api/ChangeInformation/BuildingPermitGeneralized": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae karkeutetut rakennuslupa-asian muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/Operator": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae toimijan muutostiedot",
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/Structure": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae rakennelman muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/DemolitionPermit": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae purkamislupa-asia muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/LandscapeWorkPermit": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae maisematyölupa muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ChangeInformation/DeviationPermit": {
-            "post": {
-                "tags": [
-                    "ChangeInformation"
-                ],
-                "summary": "Hae poikkeamislupa-asia muutostiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetChangeInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Content",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/Building": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "summary": "Hae rakennuksen perustiedot",
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/BuildingPermit": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/BuildingGeneralized": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/BuildingPermitGeneralized": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/DemolitionPermit": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/LandscapeWorkPermit": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/InitialInformation/DeviationPermit": {
-            "post": {
-                "tags": [
-                    "InitialInformation"
-                ],
-                "parameters": [
-                    {
-                        "name": "municipality",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "text/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        },
-                        "application/*+json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/GetInitialInfo"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InitialInformationCollection"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/Status/health": {
-            "get": {
-                "tags": [
-                    "Status"
-                ],
-                "summary": "Rajapinnan toimivuuden tarkistus.",
-                "description": "Antaa tiedon rajapinnan toimivuudesta.",
-                "responses": {
-                    "200": {
-                        "description": "Rajapinta toimii oletetusti.",
-                        "content": {
-                            "text/plain": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HealthReport"
-                                }
-                            },
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HealthReport"
-                                }
-                            },
-                            "text/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HealthReport"
-                                }
-                            }
-                        }
-                    },
-                    "503": {
-                        "description": "Rajapinnan toiminnassa ongelmia."
-                    }
-                }
-            }
+          }
         }
+      },
+      "/api/ChangeInformation/Building": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae rakennuksen muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/BuildingGeneralized": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae karkeutetut rakennuksen muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/BuildingPermit": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae rakennuslupa-asian muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/BuildingPermitGeneralized": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae karkeutetut rakennuslupa-asian muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/Operator": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae toimijan muutostiedot",
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/Structure": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae rakennelman muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/DemolitionPermit": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae purkamislupa-asia muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/LandscapeWorkPermit": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae maisematyölupa muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/ChangeInformation/DeviationPermit": {
+        "post": {
+          "tags": [
+            "ChangeInformation"
+          ],
+          "summary": "Hae poikkeamislupa-asia muutostiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetChangeInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "422": {
+              "description": "Unprocessable Content",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ValidationProblemDetails"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/Building": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "summary": "Hae rakennuksen perustiedot",
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/BuildingPermit": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/BuildingGeneralized": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/BuildingPermitGeneralized": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/DemolitionPermit": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/LandscapeWorkPermit": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/InitialInformation/DeviationPermit": {
+        "post": {
+          "tags": [
+            "InitialInformation"
+          ],
+          "parameters": [
+            {
+              "name": "municipality",
+              "in": "query",
+              "schema": {
+                "type": "string"
+              }
+            }
+          ],
+          "requestBody": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/GetInitialInfo"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "OK",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/InitialInformationCollection"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/api/Status/health": {
+        "get": {
+          "tags": [
+            "Status"
+          ],
+          "summary": "Rajapinnan toimivuuden tarkistus.",
+          "description": "Antaa tiedon rajapinnan toimivuudesta.",
+          "responses": {
+            "200": {
+              "description": "Rajapinta toimii oletetusti.",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HealthReport"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HealthReport"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HealthReport"
+                  }
+                }
+              }
+            },
+            "503": {
+              "description": "Rajapinnan toiminnassa ongelmia."
+            }
+          }
+        }
+      }
     },
     "components": {
-        "schemas": {
-            "AcceptedDeviation": {
-                "type": "object",
-                "properties": {
-                    "acceptedDeviationKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "deviationType": {
-                        "type": "string",
-                        "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
-                    },
-                    "contentOfDeviation": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Luvan yhteydessä myönnettävä poikkeaminen"
-            },
-            "Address": {
-                "type": "object",
-                "properties": {
-                    "addressKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "addressName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "numberPartOfAddressNumber": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "subdivisionLetterOfAddressNumber": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "postalCode": {
-                        "type": "string",
-                        "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
-                        "nullable": true
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "numberPartOfAddressNumber2": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "subdivisionLetterOfAddressNumber2": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "addressNumber": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Osoite"
-            },
-            "AdministrativeLocationUnit": {
-                "type": "object",
-                "properties": {
-                    "administrativeLocationUnitKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "unitIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "propertyIdentifier": {
-                        "type": "string"
-                    },
-                    "unseparatedParcelIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "Apartment": {
-                "required": [
-                    "addressNumber",
-                    "apartmentKey",
-                    "apartmentType",
-                    "lifeCycleState"
-                ],
-                "type": "object",
-                "properties": {
-                    "apartmentKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-                        ],
-                        "type": "string",
-                        "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
-                        "nullable": true
-                    },
-                    "apartmentEquipment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ApartmentEquipment"
-                        },
-                        "nullable": true
-                    },
-                    "apartmentIdentifier": {
-                        "type": "string"
-                    },
-                    "apartmentType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-                        ],
-                        "type": "string",
-                        "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
-                    },
-                    "floorArea": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "numberOfRooms": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "kitchenType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-                        ],
-                        "type": "string",
-                        "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-                        "nullable": true
-                    },
-                    "isWaterCloset": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "apartmentChangeType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-                        ],
-                        "type": "string",
-                        "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
-                        "nullable": true
-                    },
-                    "commissioningDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "addressNumber": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "apartmentStorey": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "apartmentIdentifierLetterSuffix": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentSubdivisionLetter": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentNumber": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Huoneisto"
-            },
-            "ApartmentEquipment": {
-                "type": "object",
-                "properties": {
-                    "apartmentEquipmentKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "apartmentEquipmentType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/05"
-                        ],
-                        "type": "string",
-                        "description": "Huoneiston varusteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste\">http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste</a>",
-                        "nullable": true
-                    },
-                    "numberOfEquipment": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Huoneiston varuste"
-            },
-            "AreaToBeBuiltForSpecificActivities": {
-                "required": [
-                    "buildingObjectOwner",
-                    "buildingObjectType"
-                ],
-                "type": "object",
-                "properties": {
-                    "areaToBeBuiltForSpecificActivitiesKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "specificActivitiesAreaType": {
-                        "type": "string",
-                        "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>",
-                        "nullable": true
-                    },
-                    "networkConnection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NetworkConnection"
-                        },
-                        "nullable": true
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "temporary": {
-                        "type": "boolean"
-                    },
-                    "demolitionDeadline": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot",
-                        "nullable": true
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö",
-                        "nullable": true
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö",
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "description": "Rakennuskohteen omistaja",
-                        "nullable": true
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "constructionDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionDesign"
-                        },
-                        "nullable": true
-                    },
-                    "buildingInformationModel": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingInformationModel"
-                        },
-                        "nullable": true
-                    },
-                    "specialDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SpecialDesign"
-                        },
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Erityistä toimintaa varten rakennettava alue"
-            },
-            "AssemblyFacility": {
-                "required": [
-                    "assemblyFacilityKey",
-                    "capacityOfAssemblyFacilities"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "geometry": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "assemblyFacilityKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "capacityOfAssemblyFacilities": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Kokoontumistila"
-            },
-            "Building": {
-                "required": [
-                    "buildingKey",
-                    "buildingObjectOwner",
-                    "buildingObjectType",
-                    "mainPurpose",
-                    "numberOfStoreys"
-                ],
-                "type": "object",
-                "properties": {
-                    "buildingKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permanentBuildingIdentifier": {
-                        "type": "string",
-                        "description": "Pysyvä rakennustunnus (PRT)"
-                    },
-                    "temporary": {
-                        "type": "boolean",
-                        "description": "Onko väliaikainen",
-                        "nullable": true
-                    },
-                    "demolitionDeadline": {
-                        "type": "string",
-                        "description": "Demolition deadline",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "numberOfStoreys": {
-                        "type": "integer",
-                        "description": "Kerrosluku",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "buildingSection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingSection"
-                        },
-                        "description": "Rakennuksen osat",
-                        "nullable": true
-                    },
-                    "mainPurpose": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-                        ],
-                        "type": "string",
-                        "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
-                        "nullable": true
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot",
-                        "nullable": true
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö"
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö",
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "description": "Rakennuskohteen omistaja",
-                        "nullable": true
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "addChangeEvent": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "renovationDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuksen tiedot."
-            },
-            "BuildingAttachmentDocument": {
-                "required": [
-                    "attachmentDocumentKey",
-                    "categoryOfPublicity",
-                    "documentDate",
-                    "documentIdentifier",
-                    "fileKey",
-                    "languages",
-                    "name",
-                    "personalDataContent",
-                    "retentionTime"
-                ],
-                "type": "object",
-                "properties": {
-                    "attachmentDocumentKey": {
-                        "type": "string",
-                        "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
-                        "format": "uuid"
-                    },
-                    "documentIdentifier": {
-                        "minLength": 1,
-                        "type": "string",
-                        "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-                    },
-                    "personalDataContent": {
-                        "minLength": 1,
-                        "type": "string",
-                        "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
-                    },
-                    "categoryOfPublicity": {
-                        "minLength": 1,
-                        "type": "string",
-                        "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
-                    },
-                    "accessibility": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "retentionTime": {
-                        "minLength": 1,
-                        "type": "string",
-                        "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
-                    },
-                    "confirmationDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "languages": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
-                    },
-                    "fileKey": {
-                        "type": "string",
-                        "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
-                        "format": "uuid"
-                    },
-                    "descriptors": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Descriptor"
-                        },
-                        "nullable": true
-                    },
-                    "documentDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "arrivedDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "attachmentType": {
-                        "type": "string",
-                        "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
-                    },
-                    "documentCreatorPersonalIdentityCode": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "documentCreatorOtherId": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "documentCreatorFirstName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "documentCreatorFamilyName": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Liiteasiakirja"
-            },
-            "BuildingInformationModel": {
-                "required": [
-                    "buildingInformationModelType"
-                ],
-                "type": "object",
-                "properties": {
-                    "buildingInformationModelKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "buildingInformationModelType": {
-                        "type": "string",
-                        "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
-                    },
-                    "document": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    },
-                    "referencePoint": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ]
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennustietomalli"
-            },
-            "BuildingMaterialOfLoadBearingStructures": {
-                "required": [
-                    "buildingMaterialOfLoadBearingStructuresKey",
-                    "buildingMaterialOfLoadBearingStructuresType",
-                    "isPrimary"
-                ],
-                "type": "object",
-                "properties": {
-                    "buildingMaterialOfLoadBearingStructuresKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "buildingMaterialOfLoadBearingStructuresType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/00",
-                            "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Kantavan rakenteen rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine\">http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Kantavien rakenteiden rakennusaine"
-            },
-            "BuildingObjectChange": {
-                "type": "object",
-                "properties": {
-                    "buildingObjectChangeKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "volumeChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "grossFloorAreaChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "permittedBuildingAreaChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "totalAreaChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "floorAreaChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "basementAreaChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "numberOfStoreysChange": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuskohteen muutos"
-            },
-            "BuildingObjectLocationData": {
-                "type": "object",
-                "properties": {
-                    "buildingObjectLocationDataKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "votingDistrictNumber": {
-                        "type": "string"
-                    },
-                    "pointLocation": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ]
-                    },
-                    "geometry": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/RyhtiGeometry"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuskohteen sijaintitiedot"
-            },
-            "BuildingObjectOwner": {
-                "type": "object",
-                "properties": {
-                    "buildingObjectOwnerKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "ownerOperator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
-                        "description": ""
-                    },
-                    "differentOwner": {
-                        "type": "boolean",
-                        "description": ""
-                    },
-                    "tenureStatus": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "ownerContactOperator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "ownerType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/09",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/10",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/13",
-                            "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/14"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen omistajan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/OmistajanLahde\">http://uri.suomi.fi/codelist/rytj/OmistajanLahde</a>"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuskohteen omistaja"
-            },
-            "BuildingPermitApplication": {
-                "type": "object",
-                "properties": {
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-                        ],
-                        "type": "string",
-                        "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
-                        "nullable": true
-                    },
-                    "applicationContent": {
-                        "type": "string"
-                    },
-                    "dateOfReception": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "callForDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CallForDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "permitApplicationKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permitApplicationType": {
-                        "type": "string",
-                        "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakentamislupahakemus"
-            },
-            "BuildingPermitDecision": {
-                "type": "object",
-                "properties": {
-                    "acceptedDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AcceptedDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "permitRegulation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PermitRegulation"
-                        },
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-                    },
-                    "decisionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfValidityOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "decisionDocument": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                            }
-                        ],
-                        "description": "Liiteasiakirja",
-                        "nullable": true
-                    },
-                    "decisionArticle": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "publicNoticeDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "decisionText": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "guidingStatute": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GuidingStatute"
-                        },
-                        "nullable": true
-                    },
-                    "relatedPermit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "nullable": true
-                    },
-                    "decisionMakerType": {
-                        "type": "string",
-                        "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-                        "nullable": true
-                    },
-                    "decisionMakerFirstName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "decisionMakerName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "buildingPermitDecisionKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permitApplicationType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "constructionToBeStartedBy": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "constructionToBeCompletedBy": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "constructionToBeStartedByExtension": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "constructionToBeCompletedByExtension": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "engagingParty": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EngagingParty"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakentamislupapäätös"
-            },
-            "BuildingSection": {
-                "type": "object",
-                "properties": {
-                    "buildingSectionKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/rakelinvaih\">http://uri.suomi.fi/codelist/rakrek/rakelinvaih</a>",
-                        "nullable": true
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "protectionMethod": {
-                        "type": "string",
-                        "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suojtapa\">http://uri.suomi.fi/codelist/rytj/suojtapa</a>",
-                        "nullable": true
-                    },
-                    "cultureHistoricalSignificance": {
-                        "type": "string",
-                        "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/kulthistmer\">http://uri.suomi.fi/codelist/rakrek/kulthistmer</a>",
-                        "nullable": true
-                    },
-                    "materialData": {
-                        "required": [
-                            "constructionMethod",
-                            "buildingMaterialOfLoadBearingStructures",
-                            "wideBodiedBuilding"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/MaterialData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "energyData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/EnergyData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "interiorData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/InteriorData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "exteriorData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExteriorData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "buildingServicesEngineeringData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "usageData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/UsageData"
-                            }
-                        ],
-                        "description": ""
-                    },
-                    "equipment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Equipment"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "entrance": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Entrance"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "assemblyFacility": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AssemblyFacility"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "elevator": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Elevator"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "apartment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Apartment"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "constructionDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionDesign"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "buildingInformationModel": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingInformationModel"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "specialDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SpecialDesign"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "partitionReason": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji\">http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji</a>"
-                    },
-                    "partitionDescription": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "civilDefenceShelter": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CivilDefenceShelter"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "relatedFinishedBuildingSection": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid",
-                        "nullable": true
-                    },
-                    "demolitionDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "reasonForDemolition": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-                        ],
-                        "type": "string",
-                        "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuksen osa"
-            },
-            "BuildingServicesEngineeringData": {
-                "type": "object",
-                "properties": {
-                    "ventilationMethod": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/VentilationMethod"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "sewerageMethodType": {
-                        "type": "string",
-                        "description": "Jätevesien käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jatevesienkasittely\">http://uri.suomi.fi/codelist/rytj/jatevesienkasittely</a>",
-                        "nullable": true
-                    },
-                    "householdWaterType": {
-                        "type": "string",
-                        "description": "Talousveden laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/talousvesi\">http://uri.suomi.fi/codelist/rytj/talousvesi</a>",
-                        "nullable": true
-                    },
-                    "networkConnection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NetworkConnection"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "stormWaterTreatmentType": {
-                        "type": "string",
-                        "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Talotekniikkatiedot"
-            },
-            "BuildingSite": {
-                "required": [
-                    "stormWaterTreatmentType",
-                    "tenure"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "geometry": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "buildingSiteKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "area": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "stormWaterTreatmentType": {
-                        "type": "string",
-                        "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
-                        "nullable": true
-                    },
-                    "buildingSiteAddress": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "spatialPlan": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "statusOfPlan": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/01",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/02",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/03",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/04",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/05",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/06",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/07",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/08",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/09"
-                        ],
-                        "type": "string",
-                        "description": "Kaavatilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaava\">http://uri.suomi.fi/codelist/vtj/Rake_kaava</a>",
-                        "nullable": true
-                    },
-                    "tenure": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
-                        ],
-                        "type": "string",
-                        "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuspaikka"
-            },
-            "CalculatoryDeliveredEnergyUsage": {
-                "required": [
-                    "calculatoryDeliveredEnergyUsageKey",
-                    "deliveredEnergyType",
-                    "energyAmountYearly"
-                ],
-                "type": "object",
-                "properties": {
-                    "calculatoryDeliveredEnergyUsageKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "deliveredEnergyType": {
-                        "type": "string",
-                        "description": "Ostoenergian laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ostoenergia\">http://uri.suomi.fi/codelist/rytj/ostoenergia</a>"
-                    },
-                    "energyAmountYearly": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Energiankulutus"
-            },
-            "CallForDeviation": {
-                "required": [
-                    "deviationType"
-                ],
-                "type": "object",
-                "properties": {
-                    "callForDeviationKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "deviationType": {
-                        "type": "string",
-                        "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
-                    },
-                    "contentOfDeviation": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Määräyksestä poikkeaminen"
-            },
-            "ChangeInformationAdministrativeLocationUnit": {
-                "type": "object",
-                "properties": {
-                    "administrativeLocationUnitKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "unitIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "propertyIdentifier": {
-                        "type": "string"
-                    },
-                    "unseparatedParcelIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "property": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Property"
-                            }
-                        ],
-                        "description": "Kiinteistö",
-                        "nullable": true
-                    },
-                    "parcel": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/UnseparatedParcel"
-                            }
-                        ],
-                        "description": "Määräala",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationApartment": {
-                "type": "object",
-                "properties": {
-                    "apartmentKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-                            "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-                        ],
-                        "type": "string",
-                        "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
-                        "nullable": true
-                    },
-                    "apartmentEquipment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ApartmentEquipment"
-                        },
-                        "nullable": true
-                    },
-                    "apartmentIdentifier": {
-                        "type": "string"
-                    },
-                    "apartmentType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-                        ],
-                        "type": "string",
-                        "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
-                    },
-                    "floorArea": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "numberOfRooms": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "kitchenType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-                        ],
-                        "type": "string",
-                        "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-                        "nullable": true
-                    },
-                    "isWaterCloset": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "apartmentChangeType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-                        ],
-                        "type": "string",
-                        "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
-                        "nullable": true
-                    },
-                    "commissioningDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "addressNumber": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "apartmentStorey": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "housingType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "occupancyOfApartment": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentIdentifierLetterSuffix": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentSubdivisionLetter": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentNumber": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationAreaToBeBuiltForSpecificActivities": {
-                "type": "object",
-                "properties": {
-                    "areaToBeBuiltForSpecificActivitiesKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "specificActivitiesAreaType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "networkConnection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/NetworkConnection"
-                        },
-                        "nullable": true
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "temporary": {
-                        "type": "boolean"
-                    },
-                    "demolitionDeadline": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string"
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot",
-                        "nullable": true
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "nullable": true
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "constructionDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionDesign"
-                        },
-                        "nullable": true
-                    },
-                    "buildingInformationModel": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingInformationModel"
-                        },
-                        "nullable": true
-                    },
-                    "specialDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SpecialDesign"
-                        },
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuilding": {
-                "type": "object",
-                "properties": {
-                    "buildingKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permanentBuildingIdentifier": {
-                        "type": "string",
-                        "description": "Pysyvä rakennustunnus (PRT)"
-                    },
-                    "temporary": {
-                        "type": "boolean",
-                        "description": "Onko väliaikainen",
-                        "nullable": true
-                    },
-                    "demolitionDeadline": {
-                        "type": "string",
-                        "description": "Demolition deadline",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "numberOfStoreys": {
-                        "type": "integer",
-                        "description": "Kerrosluku",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "buildingSection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationBuildingSection"
-                        },
-                        "description": "Rakennuksen osat",
-                        "nullable": true
-                    },
-                    "mainPurpose": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-                        ],
-                        "type": "string",
-                        "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
-                        "nullable": true
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot",
-                        "nullable": true
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                            }
-                        ]
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "description": "Rakennuskohteen omistaja",
-                        "nullable": true
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "addChangeEvent": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "renovationDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "mainPurpose1994": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "numberOfNewApartments": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "numberOfDeletedApartments": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingChangeDiffDto": {
-                "type": "object",
-                "properties": {
-                    "changeType": {
-                        "type": "string"
-                    },
-                    "objectKey": {
-                        "nullable": true
-                    },
-                    "objectType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentKey": {
-                        "nullable": true
-                    },
-                    "parentType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentChain": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ParentTypeKey"
-                        }
-                    },
-                    "objectState": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuilding"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "objectStatePrev": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuilding"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingChangeInfoCollectionDto": {
-                "type": "object",
-                "properties": {
-                    "lastSeen": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PaginationToken"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "upToDate": {
-                        "type": "boolean"
-                    },
-                    "changes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoDto"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingChangeInfoDto": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "objectKey": {},
-                    "objectState": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuilding"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "diff": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationBuildingChangeDiffDto"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingPermitIssue": {
-                "type": "object",
-                "properties": {
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-                        "nullable": true
-                    },
-                    "municipalityNumber": {
-                        "type": "string"
-                    },
-                    "permanentPermitIdentifier": {
-                        "type": "string"
-                    },
-                    "decision": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingPermitDecision"
-                            }
-                        ],
-                        "description": "Rakentamislupapäätös",
-                        "nullable": true
-                    },
-                    "extensionDecision": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ExtensionDecision"
-                        },
-                        "nullable": true
-                    },
-                    "changePermit": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangePermit"
-                        },
-                        "nullable": true
-                    },
-                    "buildingPermitApplication": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingPermitApplication"
-                        },
-                        "description": "Rakentamislupahakemus",
-                        "nullable": true
-                    },
-                    "constructionAction": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationConstructionAction"
-                        }
-                    },
-                    "buildingSite": {
-                        "required": [
-                            "stormWaterTreatmentType",
-                            "tenure"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingSite"
-                            }
-                        ],
-                        "description": "Rakennuspaikka",
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    },
-                    "constructionProject": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ConstructionProject"
-                            }
-                        ],
-                        "description": "Rakentamishanke",
-                        "nullable": true
-                    },
-                    "updateType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-                        "nullable": true
-                    },
-                    "updateDescription": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "dateOfInitiation": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingPermitIssueChangeDiffDto": {
-                "type": "object",
-                "properties": {
-                    "changeType": {
-                        "type": "string"
-                    },
-                    "objectKey": {
-                        "nullable": true
-                    },
-                    "objectType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentKey": {
-                        "nullable": true
-                    },
-                    "parentType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentChain": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ParentTypeKey"
-                        }
-                    },
-                    "objectState": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "objectStatePrev": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingPermitIssueChangeInfoCollectionDto": {
-                "type": "object",
-                "properties": {
-                    "lastSeen": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PaginationToken"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "upToDate": {
-                        "type": "boolean"
-                    },
-                    "changes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoDto"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingPermitIssueChangeInfoDto": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "objectKey": {},
-                    "objectState": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "diff": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeDiffDto"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationBuildingSection": {
-                "type": "object",
-                "properties": {
-                    "buildingSectionKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-                        ],
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "protectionMethod": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "cultureHistoricalSignificance": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "materialData": {
-                        "required": [
-                            "constructionMethod",
-                            "buildingMaterialOfLoadBearingStructures",
-                            "wideBodiedBuilding"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/MaterialData"
-                            }
-                        ],
-                        "description": "Materiaalitiedot",
-                        "nullable": true
-                    },
-                    "energyData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/EnergyData"
-                            }
-                        ],
-                        "description": "Energiatiedot",
-                        "nullable": true
-                    },
-                    "interiorData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/InteriorData"
-                            }
-                        ],
-                        "description": "Sisätilojen tiedot",
-                        "nullable": true
-                    },
-                    "exteriorData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExteriorData"
-                            }
-                        ],
-                        "description": "Ulkokuoren tiedot",
-                        "nullable": true
-                    },
-                    "buildingServicesEngineeringData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                            }
-                        ],
-                        "description": "Talotekniikkatiedot",
-                        "nullable": true
-                    },
-                    "usageData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/UsageData"
-                            }
-                        ],
-                        "description": "Rakennuksen käyttötiedot"
-                    },
-                    "equipment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Equipment"
-                        },
-                        "nullable": true
-                    },
-                    "entrance": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Entrance"
-                        },
-                        "nullable": true
-                    },
-                    "assemblyFacility": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AssemblyFacility"
-                        },
-                        "nullable": true
-                    },
-                    "elevator": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Elevator"
-                        },
-                        "nullable": true
-                    },
-                    "apartment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangeInformationApartment"
-                        },
-                        "nullable": true
-                    },
-                    "constructionDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionDesign"
-                        },
-                        "nullable": true
-                    },
-                    "buildingInformationModel": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingInformationModel"
-                        },
-                        "nullable": true
-                    },
-                    "specialDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SpecialDesign"
-                        },
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    },
-                    "partitionReason": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-                        ],
-                        "type": "string"
-                    },
-                    "partitionDescription": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "civilDefenceShelter": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CivilDefenceShelter"
-                        },
-                        "nullable": true
-                    },
-                    "relatedFinishedBuildingSection": {
-                        "type": "string",
-                        "format": "uuid",
-                        "nullable": true
-                    },
-                    "demolitionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "reasonForDemolition": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-                        ],
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationConstructionAction": {
-                "type": "object",
-                "properties": {
-                    "constructionActionKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "constructionActionType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-                        ],
-                        "type": "string",
-                        "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
-                        "nullable": true
-                    },
-                    "buildingObjectChange": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectChange"
-                            }
-                        ],
-                        "description": "Rakennuskohteen muutos",
-                        "nullable": true
-                    },
-                    "descriptionOfAction": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "areaUndergoingChanges": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "reasonForDemolition": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-                        ],
-                        "type": "string",
-                        "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-                        "nullable": true
-                    },
-                    "renovation": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "renovationRate": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "building": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationBuilding"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "structure": {
-                        "required": [
-                            "structureMainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationStructure"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "areaToBeBuiltForSpecificActivities": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "startDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "commissioningDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "statusOfConstructionAction": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-                        ],
-                        "type": "string",
-                        "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-                        "nullable": true
-                    },
-                    "fullyApprovedForUse": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "businessConstruction": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "changeType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-                        ],
-                        "type": "string",
-                        "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-                        "nullable": true
-                    },
-                    "dvvPermitIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "expiryDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "locatedOnUnseparatedParcel": {
-                        "type": "boolean",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangeInformationStructure": {
-                "required": [
-                    "buildingObjectOwner",
-                    "buildingObjectType",
-                    "structureMainPurpose"
-                ],
-                "type": "object",
-                "properties": {
-                    "structureKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permanentStructureIdentifier": {
-                        "type": "string"
-                    },
-                    "temporary": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "demolitionDeadline": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "numberOfStoreys": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "structureSection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StructureSection"
-                        },
-                        "nullable": true
-                    },
-                    "structureMainPurpose": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-                        ],
-                        "type": "string",
-                        "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot",
-                        "nullable": true
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                            }
-                        ]
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "description": "Rakennuskohteen omistaja",
-                        "nullable": true
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ChangePermit": {
-                "type": "object",
-                "properties": {
-                    "acceptedDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AcceptedDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "permitRegulation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PermitRegulation"
-                        },
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-                    },
-                    "decisionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfValidityOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "decisionDocument": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                            }
-                        ],
-                        "description": "Liiteasiakirja",
-                        "nullable": true
-                    },
-                    "decisionArticle": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "publicNoticeDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "decisionText": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "guidingStatute": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GuidingStatute"
-                        },
-                        "nullable": true
-                    },
-                    "relatedPermit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "nullable": true
-                    },
-                    "decisionMakerType": {
-                        "type": "string",
-                        "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-                        "nullable": true
-                    },
-                    "decisionMakerFirstName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "decisionMakerName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "changePermitKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Muutospäätös"
-            },
-            "CivilDefenceShelter": {
-                "required": [
-                    "civilDefenceShelterCapacity",
-                    "civilDefenceShelterClass",
-                    "civilDefenceShelterKey",
-                    "civilDefenceShelterShared"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "geometry": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "civilDefenceShelterKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "civilDefenceShelterClass": {
-                        "type": "string",
-                        "description": "Väestönsuojan luokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka\">http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka</a>",
-                        "nullable": true
-                    },
-                    "civilDefenceShelterCapacity": {
-                        "type": "integer",
-                        "description": "Väestönsuojan suojapaikkojen määrä",
-                        "format": "int32"
-                    },
-                    "civilDefenceShelterShared": {
-                        "type": "boolean"
-                    },
-                    "civilDefenceShelterAdditionalInformation": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "civilDefenceShelterOtherBuildings": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CivilDefenceShelterOtherBuildings"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Väestönsuoja"
-            },
-            "CivilDefenceShelterOtherBuildings": {
-                "type": "object",
-                "properties": {
-                    "civilDefenceShelterOtherBuildingsKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permanentBuildingIdentifier": {
-                        "type": "string"
-                    },
-                    "civilDefenceShelterPointedCapacity": {
-                        "type": "integer",
-                        "format": "int32"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Väestönsuojan muut rakennukset"
-            },
-            "ConstructionAction": {
-                "required": [
-                    "constructionActionType",
-                    "statusOfConstructionAction"
-                ],
-                "type": "object",
-                "properties": {
-                    "constructionActionKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "constructionActionType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-                        ],
-                        "type": "string",
-                        "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
-                        "nullable": true
-                    },
-                    "buildingObjectChange": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectChange"
-                            }
-                        ],
-                        "description": "Rakennuskohteen muutos",
-                        "nullable": true
-                    },
-                    "descriptionOfAction": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "areaUndergoingChanges": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "reasonForDemolition": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-                        ],
-                        "type": "string",
-                        "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-                        "nullable": true
-                    },
-                    "renovation": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "renovationRate": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "building": {
-                        "required": [
-                            "buildingKey",
-                            "numberOfStoreys",
-                            "mainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Building"
-                            }
-                        ],
-                        "description": "Rakennuksen tiedot.",
-                        "nullable": true
-                    },
-                    "finishedBuilding": {
-                        "required": [
-                            "buildingKey",
-                            "numberOfStoreys",
-                            "mainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Building"
-                            }
-                        ],
-                        "description": "Rakennuksen tiedot.",
-                        "nullable": true
-                    },
-                    "structure": {
-                        "required": [
-                            "structureMainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Structure"
-                            }
-                        ],
-                        "description": "Rakennelma",
-                        "nullable": true
-                    },
-                    "finishedStructure": {
-                        "required": [
-                            "structureMainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Structure"
-                            }
-                        ],
-                        "description": "Rakennelma",
-                        "nullable": true
-                    },
-                    "areaToBeBuiltForSpecificActivities": {
-                        "required": [
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-                            }
-                        ],
-                        "description": "Erityistä toimintaa varten rakennettava alue",
-                        "nullable": true
-                    },
-                    "startDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "commissioningDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "statusOfConstructionAction": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-                        ],
-                        "type": "string",
-                        "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-                        "nullable": true
-                    },
-                    "fullyApprovedForUse": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "businessConstruction": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "changeType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-                        ],
-                        "type": "string",
-                        "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-                        "nullable": true
-                    },
-                    "dvvPermitIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "expiryDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "finishedAreaToBeBuiltForSpecificActivities": {
-                        "required": [
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-                            }
-                        ],
-                        "description": "Erityistä toimintaa varten rakennettava alue",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakentamistoimenpide"
-            },
-            "ConstructionDesign": {
-                "type": "object",
-                "properties": {
-                    "constructionDesignKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "constructionDesignType": {
-                        "type": "string",
-                        "description": "Rakennusssuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/raksuunlajit\">http://uri.suomi.fi/codelist/rytj/raksuunlajit</a>"
-                    },
-                    "document": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennussuunnitelma"
-            },
-            "ConstructionProject": {
-                "type": "object",
-                "properties": {
-                    "constructionProjectKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "descriptionOfConstructionProject": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "startDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "endDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "planner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Planner"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "foreman": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Foreman"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "inspection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Inspection"
-                        },
-                        "description": "",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakentamishanke"
-            },
-            "ContactAddress": {
-                "type": "object",
-                "properties": {
-                    "addressKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "addressName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "numberPartOfAddressNumber": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "subdivisionLetterOfAddressNumber": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "postalCode": {
-                        "type": "string",
-                        "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
-                        "nullable": true
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "numberPartOfAddressNumber2": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "subdivisionLetterOfAddressNumber2": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentIdentifierLetterSuffix": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "apartmentIdentifierNumber": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "apartmentIdentifierSubdivisionLetter": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "additionalAddressAttribute": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "c_O": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "poBoxAddress": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "countryCode": {
-                        "type": "string",
-                        "description": "Maakoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-                        "nullable": true
-                    },
-                    "foreignAddress": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "foreignPostalAddress": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "additionalForeignAddress": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "postalAddress": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "contactAddressType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/08"
-                        ],
-                        "type": "string",
-                        "description": "Yhteysosoitteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji\">http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji</a>"
-                    },
-                    "source": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/tietolahde/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/tietolahde/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/tietolahde/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/tietolahde/code/04"
-                        ],
-                        "type": "string",
-                        "description": "Tietolähde. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tietolahde\">http://uri.suomi.fi/codelist/rytj/tietolahde</a>"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Yhteysosoite"
-            },
-            "CoolingEnergySource": {
-                "required": [
-                    "coolingEnergySourceType",
-                    "isPrimary"
-                ],
-                "type": "object",
-                "properties": {
-                    "coolingEnergySourceKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "coolingEnergySourceType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/08"
-                        ],
-                        "type": "string",
-                        "description": "Jäähdytysenergian lähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytys\">http://uri.suomi.fi/codelist/rytj/jaahdytys</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Jäähdytysenergian lähde"
-            },
-            "CoolingMethod": {
-                "required": [
-                    "coolingMethodType"
-                ],
-                "type": "object",
-                "properties": {
-                    "coolingMethodKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "coolingMethodType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/03"
-                        ],
-                        "type": "string",
-                        "description": "Jäähdytystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytystapa\">http://uri.suomi.fi/codelist/rytj/jaahdytystapa</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Jäähdytystapa"
-            },
-            "DemolitionPermitApplication": {
-                "type": "object",
-                "properties": {
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-                        ],
-                        "type": "string",
-                        "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
-                        "nullable": true
-                    },
-                    "applicationContent": {
-                        "type": "string"
-                    },
-                    "dateOfReception": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "callForDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CallForDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "demolitionPermitApplicationKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permitApplicationType": {
-                        "type": "string",
-                        "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "PurkamislupaHakemus"
-            },
-            "DemolitionPermitDecision": {
-                "type": "object",
-                "properties": {
-                    "acceptedDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AcceptedDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "permitRegulation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PermitRegulation"
-                        },
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-                    },
-                    "decisionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfValidityOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "decisionDocument": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                            }
-                        ],
-                        "description": "Liiteasiakirja",
-                        "nullable": true
-                    },
-                    "decisionArticle": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "publicNoticeDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "decisionText": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "guidingStatute": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GuidingStatute"
-                        },
-                        "nullable": true
-                    },
-                    "relatedPermit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "nullable": true
-                    },
-                    "decisionMakerType": {
-                        "type": "string",
-                        "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-                        "nullable": true
-                    },
-                    "decisionMakerFirstName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "decisionMakerName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "demolitionPermitDecisionKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permitApplicationType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "constructionToBeStartedBy": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "constructionToBeCompletedBy": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "constructionToBeStartedByExtension": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "constructionToBeCompletedByExtension": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "engagingParty": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EngagingParty"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakentamislupapäätös"
-            },
-            "DemolitionPermitIssue": {
-                "required": [
-                    "dateOfInitiation",
-                    "demolitionDecision",
-                    "demolitionPermitApplication"
-                ],
-                "type": "object",
-                "properties": {
-                    "dateOfInitiation": {
-                        "type": "string",
-                        "description": "Vireilletulopäivä",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-                        "nullable": true
-                    },
-                    "municipalityNumber": {
-                        "type": "string"
-                    },
-                    "demolitionPermitApplication": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DemolitionPermitApplication"
-                        },
-                        "description": "Purkamislupahakemus",
-                        "nullable": true
-                    },
-                    "demolitionDecision": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DemolitionPermitDecision"
-                            }
-                        ],
-                        "description": "Purkamislupapäätös",
-                        "nullable": true
-                    },
-                    "extensionDecision": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ExtensionDecision"
-                        },
-                        "nullable": true
-                    },
-                    "changePermit": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ChangePermit"
-                        },
-                        "nullable": true
-                    },
-                    "buildingSite": {
-                        "required": [
-                            "stormWaterTreatmentType",
-                            "tenure"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingSite"
-                            }
-                        ],
-                        "description": "Rakennuspaikka",
-                        "nullable": true
-                    },
-                    "constructionAction": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionAction"
-                        },
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    },
-                    "constructionProject": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ConstructionProject"
-                            }
-                        ],
-                        "description": "Rakentamishanke",
-                        "nullable": true
-                    },
-                    "updateType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-                        "nullable": true
-                    },
-                    "updateDescription": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "permanentPermitIdentifier": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Purkamislupa-asia"
-            },
-            "DemolitionPermitIssueChangeDiffDto": {
-                "type": "object",
-                "properties": {
-                    "changeType": {
-                        "type": "string"
-                    },
-                    "objectKey": {
-                        "nullable": true
-                    },
-                    "objectType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentKey": {
-                        "nullable": true
-                    },
-                    "parentType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentChain": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ParentTypeKey"
-                        }
-                    },
-                    "objectState": {
-                        "required": [
-                            "demolitionPermitApplication",
-                            "demolitionDecision",
-                            "dateOfInitiation"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DemolitionPermitIssue"
-                            }
-                        ],
-                        "description": "Purkamislupa-asia",
-                        "nullable": true
-                    },
-                    "objectStatePrev": {
-                        "required": [
-                            "demolitionPermitApplication",
-                            "demolitionDecision",
-                            "dateOfInitiation"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DemolitionPermitIssue"
-                            }
-                        ],
-                        "description": "Purkamislupa-asia",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "DemolitionPermitIssueChangeInfoCollectionDto": {
-                "type": "object",
-                "properties": {
-                    "lastSeen": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PaginationToken"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "upToDate": {
-                        "type": "boolean"
-                    },
-                    "changes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoDto"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "DemolitionPermitIssueChangeInfoDto": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "objectKey": {},
-                    "objectState": {
-                        "required": [
-                            "demolitionPermitApplication",
-                            "demolitionDecision",
-                            "dateOfInitiation"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DemolitionPermitIssue"
-                            }
-                        ],
-                        "description": "Purkamislupa-asia",
-                        "nullable": true
-                    },
-                    "diff": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DemolitionPermitIssueChangeDiffDto"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "Descriptor": {
-                "type": "object",
-                "properties": {
-                    "descriptorIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "vocabulary": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "descriptor": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "DeviationObject": {
-                "required": [
-                    "buildingObjectOwner"
-                ],
-                "type": "object",
-                "properties": {
-                    "deviationObjectKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-                    },
-                    "totalArea": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot"
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö"
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö",
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "description": "Rakennuskohteen omistaja"
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        }
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Poikkeamisen kohde"
-            },
-            "DeviationPermitApplication": {
-                "type": "object",
-                "properties": {
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-                        ],
-                        "type": "string",
-                        "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
-                        "nullable": true
-                    },
-                    "applicationContent": {
-                        "type": "string"
-                    },
-                    "dateOfReception": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "callForDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CallForDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "deviationPermitApplicationKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "buildingInformationModel": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingInformationModel"
-                        }
-                    },
-                    "constructionDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionDesign"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Poikkeamislupahakemus"
-            },
-            "DeviationPermitDecision": {
-                "type": "object",
-                "properties": {
-                    "acceptedDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AcceptedDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "permitRegulation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PermitRegulation"
-                        },
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-                    },
-                    "decisionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfValidityOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "decisionDocument": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                            }
-                        ],
-                        "description": "Liiteasiakirja",
-                        "nullable": true
-                    },
-                    "decisionArticle": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "publicNoticeDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "decisionText": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "guidingStatute": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GuidingStatute"
-                        },
-                        "nullable": true
-                    },
-                    "relatedPermit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "nullable": true
-                    },
-                    "decisionMakerType": {
-                        "type": "string",
-                        "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-                        "nullable": true
-                    },
-                    "decisionMakerFirstName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "decisionMakerName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "deviationPermitDecisionKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "expiryDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "engagingParty": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/EngagingParty"
-                        },
-                        "description": ""
-                    },
-                    "decisionInForceUntil": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Poikkeamislupapäätös"
-            },
-            "DeviationPermitIssue": {
-                "required": [
-                    "dateOfInitiation",
-                    "deviationPermitApplication",
-                    "deviationPermitDecision"
-                ],
-                "type": "object",
-                "properties": {
-                    "dateOfInitiation": {
-                        "type": "string",
-                        "description": "Vireilletulopäivä",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-                        "nullable": true
-                    },
-                    "municipalityNumber": {
-                        "type": "string"
-                    },
-                    "permanentPermitIdentifier": {
-                        "type": "string"
-                    },
-                    "recordNumber": {
-                        "type": "string"
-                    },
-                    "deviationPermitDecision": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeviationPermitDecision"
-                            }
-                        ],
-                        "description": "Poikkeamislupapäätös"
-                    },
-                    "deviationPermitApplication": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeviationPermitApplication"
-                            }
-                        ],
-                        "description": "Poikkeamislupahakemus"
-                    },
-                    "deviationObject": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DeviationObject"
-                        }
-                    },
-                    "buildingSite": {
-                        "required": [
-                            "stormWaterTreatmentType",
-                            "tenure"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingSite"
-                            }
-                        ],
-                        "description": "Rakennuspaikka"
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "nullable": true
-                    },
-                    "updateType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-                        ],
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "updateDescription": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Poikkeamislupa-asia"
-            },
-            "DeviationPermitIssueChangeDiffDto": {
-                "type": "object",
-                "properties": {
-                    "changeType": {
-                        "type": "string"
-                    },
-                    "objectKey": {
-                        "nullable": true
-                    },
-                    "objectType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentKey": {
-                        "nullable": true
-                    },
-                    "parentType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentChain": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ParentTypeKey"
-                        }
-                    },
-                    "objectState": {
-                        "required": [
-                            "deviationPermitDecision",
-                            "deviationPermitApplication",
-                            "dateOfInitiation"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeviationPermitIssue"
-                            }
-                        ],
-                        "description": "Poikkeamislupa-asia",
-                        "nullable": true
-                    },
-                    "objectStatePrev": {
-                        "required": [
-                            "deviationPermitDecision",
-                            "deviationPermitApplication",
-                            "dateOfInitiation"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeviationPermitIssue"
-                            }
-                        ],
-                        "description": "Poikkeamislupa-asia",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "DeviationPermitIssueChangeInfoCollectionDto": {
-                "type": "object",
-                "properties": {
-                    "lastSeen": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PaginationToken"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "upToDate": {
-                        "type": "boolean"
-                    },
-                    "changes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoDto"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "DeviationPermitIssueChangeInfoDto": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "objectKey": {},
-                    "objectState": {
-                        "required": [
-                            "deviationPermitDecision",
-                            "deviationPermitApplication",
-                            "dateOfInitiation"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/DeviationPermitIssue"
-                            }
-                        ],
-                        "description": "Poikkeamislupa-asia",
-                        "nullable": true
-                    },
-                    "diff": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DeviationPermitIssueChangeDiffDto"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ElectricalEnergySource": {
-                "required": [
-                    "electricalEnergySourceType"
-                ],
-                "type": "object",
-                "properties": {
-                    "electricalEnergySourceKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "electricalEnergySourceType": {
-                        "type": "string",
-                        "description": "Sähköenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde\">http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Sähköenergian lähde"
-            },
-            "Elevator": {
-                "required": [
-                    "elevatorType",
-                    "lifeCycleState"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "geometry": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "elevatorKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "elevatorType": {
-                        "type": "string",
-                        "description": "Hissin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hissi\">http://uri.suomi.fi/codelist/rytj/hissi</a>"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
-                        "nullable": true
-                    },
-                    "insideLength": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "insideWidth": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "doorOpeningWidth": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "doorOpeningHeight": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "passengerCapacity": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "loadCapacity": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Hissi"
-            },
-            "EnergyData": {
-                "type": "object",
-                "properties": {
-                    "energyDataKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "energyRating": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/08"
-                        ],
-                        "type": "string",
-                        "description": "Energialuokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Energialuokka\">http://uri.suomi.fi/codelist/rytj/Energialuokka</a>",
-                        "nullable": true
-                    },
-                    "computationalEnergyEfficiencyComparand": {
-                        "type": "number",
-                        "description": "",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "heatingMethod": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/HeatingMethod"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "heatingEnergySource": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/HeatingEnergySource"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "coolingMethod": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CoolingMethod"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "coolingEnergySource": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/CoolingEnergySource"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "electricalEnergySource": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ElectricalEnergySource"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "netHeatedArea": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "heatedVolume": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "calculatoryDeliveredEnergyUsage": {
-                        "required": [
-                            "calculatoryDeliveredEnergyUsageKey",
-                            "deliveredEnergyType",
-                            "energyAmountYearly"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/CalculatoryDeliveredEnergyUsage"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "energyRatingSubindex": {
-                        "type": "string",
-                        "description": "Energiatehokkuusluokan alaindeksi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi\">http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Energiatiedot"
-            },
-            "EngagingParty": {
-                "type": "object",
-                "properties": {
-                    "engagingPartyKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "personalIdentityCode": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "businessId": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "otherId": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "isPerson": {
-                        "type": "boolean",
-                        "description": ""
-                    },
-                    "firstName": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "familyName": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "organizationName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "applicantContactOperator": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "languageCode": {
-                        "type": "string",
-                        "description": "IETF kielikoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes\">http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes</a>",
-                        "nullable": true
-                    },
-                    "nationalityCode": {
-                        "type": "string",
-                        "description": "Valtiokoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-                        "nullable": true
-                    },
-                    "deathDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Hankkeeseen ryhtyvä"
-            },
-            "Entrance": {
-                "required": [
-                    "entranceKey",
-                    "entranceType",
-                    "isPrimary",
-                    "lifeCycleState"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "geometry": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "entranceKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    },
-                    "entranceType": {
-                        "type": "string",
-                        "description": "Sisäänkäynnin tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sisaankaynti\">http://uri.suomi.fi/codelist/rytj/sisaankaynti</a>"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
-                            "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
-                        "nullable": true
-                    },
-                    "addressOfEntrance": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "isAccessible": {
-                        "type": "boolean",
-                        "description": "Kerrosluku"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Sisäänkäynti"
-            },
-            "Equipment": {
-                "type": "object",
-                "properties": {
-                    "equipmentKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "equipmentType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/09",
-                            "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/10"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen varuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennusvaruste\">http://uri.suomi.fi/codelist/rytj/rakennusvaruste</a>"
-                    },
-                    "equipmentCount": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Varuste"
-            },
-            "ExtensionDecision": {
-                "type": "object",
-                "properties": {
-                    "acceptedDeviation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AcceptedDeviation"
-                        },
-                        "nullable": true
-                    },
-                    "permitRegulation": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PermitRegulation"
-                        },
-                        "nullable": true
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                            "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-                        ],
-                        "type": "string",
-                        "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-                    },
-                    "decisionDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "dateOfValidityOfDecision": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "decisionDocument": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                            }
-                        ],
-                        "description": "Liiteasiakirja",
-                        "nullable": true
-                    },
-                    "decisionArticle": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "publicNoticeDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "decisionText": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "guidingStatute": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GuidingStatute"
-                        },
-                        "nullable": true
-                    },
-                    "relatedPermit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        },
-                        "nullable": true
-                    },
-                    "decisionMakerType": {
-                        "type": "string",
-                        "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-                        "nullable": true
-                    },
-                    "decisionMakerFirstName": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "decisionMakerName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "extensionDecisionKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Jatkoaikapäätös"
-            },
-            "ExteriorData": {
-                "type": "object",
-                "properties": {
-                    "numberOfStoreys": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "height": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "flightObstacle": {
-                        "type": "boolean",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "shape": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "description": ""
-                    },
-                    "relationToGroundLevel": {
-                        "type": "string",
-                        "description": "Suhde maan pintaan. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Suhde_pintaan\">http://uri.suomi.fi/codelist/rytj/Suhde_pintaan</a>",
-                        "nullable": true
-                    },
-                    "volume": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "grossFloorArea": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "permittedBuildingArea": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "totalArea": {
-                        "type": "integer",
-                        "description": "",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Ulkokuoren tiedot"
-            },
-            "FacadeMaterial": {
-                "required": [
-                    "facadeMaterialType"
-                ],
-                "type": "object",
-                "properties": {
-                    "facadeMaterialKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "facadeMaterialType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/00",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Julkisivun rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine\">http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Julkisivumateriaali"
-            },
-            "Foreman": {
-                "type": "object",
-                "properties": {
-                    "foremanKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "foremanRole": {
-                        "type": "string",
-                        "description": "Työnjohtajan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli\">http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli</a>"
-                    },
-                    "foremanCompetence": {
-                        "type": "string",
-                        "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-                    },
-                    "responsibilityStartDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "responsibilityEndDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "buildingReference": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ForemanBuildingReference"
-                        },
-                        "nullable": true
-                    },
-                    "structureReference": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ForemanStructureReference"
-                        },
-                        "nullable": true
-                    },
-                    "specificAreaReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    },
-                    "requiredCompetence": {
-                        "type": "string",
-                        "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-                    },
-                    "personalIdentityCode": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "otherId": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "familyName": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Työnjohtaja"
-            },
-            "ForemanBuildingReference": {
-                "type": "object",
-                "properties": {
-                    "permanentBuildingIdentifierReference": {
-                        "type": "string"
-                    },
-                    "buildingSectionReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennusviite"
-            },
-            "ForemanStructureReference": {
-                "type": "object",
-                "properties": {
-                    "permanentStructureIdentifierReference": {
-                        "type": "string"
-                    },
-                    "buildingSectionReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennelmaviite"
-            },
-            "GeoJsonGeometry": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Tuetut geometriatyypit"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
-            },
-            "GeoJsonLineStringGeometry": {
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/GeoJsonGeometry"
-                    }
-                ],
-                "properties": {
-                    "coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "number",
-                                "format": "double"
-                            }
-                        },
-                        "description": "Koordinaatit",
-                        "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
-                    },
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
-                    }
-                },
-                "additionalProperties": false,
-                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
-            },
-            "GeoJsonMultiLineStringGeometry": {
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/GeoJsonGeometry"
-                    }
-                ],
-                "properties": {
-                    "coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "number",
-                                    "format": "double"
-                                }
-                            }
-                        },
-                        "description": "Koordinaatit",
-                        "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
-                    },
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
-                    }
-                },
-                "additionalProperties": false,
-                "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
-            },
-            "GeoJsonMultiPointGeometry": {
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/GeoJsonGeometry"
-                    }
-                ],
-                "properties": {
-                    "coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "number",
-                                "format": "double"
-                            }
-                        },
-                        "description": "Koordinaatit",
-                        "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
-                    },
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
-                    }
-                },
-                "additionalProperties": false,
-                "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
-            },
-            "GeoJsonMultiPolygonGeometry": {
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/GeoJsonGeometry"
-                    }
-                ],
-                "properties": {
-                    "coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "number",
-                                        "format": "double"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Koordinaatit",
-                        "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
-                    },
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
-                    }
-                },
-                "additionalProperties": false,
-                "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
-            },
-            "GeoJsonPointGeometry": {
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/GeoJsonGeometry"
-                    }
-                ],
-                "properties": {
-                    "coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "number",
-                            "format": "double"
-                        },
-                        "description": "Koordinaatit",
-                        "example": "[100.0, 0.0]"
-                    },
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
-            },
-            "GeoJsonPolygonGeometry": {
-                "required": [
-                    "coordinates",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/GeoJsonGeometry"
-                    }
-                ],
-                "properties": {
-                    "coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "type": "number",
-                                    "format": "double"
-                                }
-                            }
-                        },
-                        "description": "Koordinaatit",
-                        "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
-                    },
-                    "type": {
-                        "enum": [
-                            "Point",
-                            "MultiPoint",
-                            "LineString",
-                            "MultiLineString",
-                            "Polygon",
-                            "MultiPolygon"
-                        ],
-                        "type": "string",
-                        "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
-            },
-            "GetChangeInfo": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "nullable": true
-                    },
-                    "objectKey": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "GetInitialInfo": {
-                "type": "object",
-                "properties": {
-                    "lastObjectKey": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "GuidingStatute": {
-                "type": "object",
-                "properties": {
-                    "guidingStatuteKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "statuteName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "statuteCollectionNumber": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "statuteCollectionYear": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "chapter": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "section": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "subSection": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "paragraph": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "subParagraph": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Säädösviite"
-            },
-            "HealthReport": {
-                "type": "object",
-                "properties": {
-                    "status": {
-                        "enum": [
-                            "Unhealthy",
-                            "Degraded",
-                            "Healthy"
-                        ],
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "totalDuration": {
-                        "type": "string",
-                        "format": "date-span",
-                        "readOnly": true
-                    },
-                    "entries": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "$ref": "#/components/schemas/HealthReportEntry"
-                        },
-                        "readOnly": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "HealthReportEntry": {
-                "type": "object",
-                "properties": {
-                    "duration": {
-                        "type": "string",
-                        "format": "date-span",
-                        "readOnly": true
-                    },
-                    "status": {
-                        "enum": [
-                            "Unhealthy",
-                            "Degraded",
-                            "Healthy"
-                        ],
-                        "type": "string",
-                        "readOnly": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "HeatingEnergySource": {
-                "type": "object",
-                "properties": {
-                    "heatingEnergySourceKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "heatingEnergySourceType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/09",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/10",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/11",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1101",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1102",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1103",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1104",
-                            "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Lämmitysenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde\">http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde</a>",
-                        "nullable": true
-                    },
-                    "isPrimary": {
-                        "type": "boolean",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Lämmitysenergianlähde"
-            },
-            "HeatingMethod": {
-                "type": "object",
-                "properties": {
-                    "heatingMethodKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "heatingMethodType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Lämmitystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitystapa\">http://uri.suomi.fi/codelist/rytj/lammitystapa</a>",
-                        "nullable": true
-                    },
-                    "isPrimary": {
-                        "type": "boolean",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Lämmitystapa"
-            },
-            "InitialInformationCollection": {
-                "type": "object",
-                "properties": {
-                    "next": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/InitialInformationNextInfo"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "nullable": true
-                    },
-                    "items": {
-                        "type": "array",
-                        "items": {}
-                    }
-                },
-                "additionalProperties": false
-            },
-            "InitialInformationNextInfo": {
-                "type": "object",
-                "properties": {
-                    "lastObjectKey": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "Inspection": {
-                "type": "object",
-                "properties": {
-                    "inspectionKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "inspectionType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
-                            "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
-                        ],
-                        "type": "string",
-                        "description": ""
-                    },
-                    "inspectionDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date"
-                    },
-                    "requiredByPermitRegulations": {
-                        "type": "boolean",
-                        "description": ""
-                    },
-                    "partiality": {
-                        "type": "string",
-                        "description": ""
-                    },
-                    "inspectionStatus": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
-                        ],
-                        "type": "string",
-                        "description": ""
-                    },
-                    "buildingReference": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/InspectionBuildingReference"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "structureReference": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/InspectionStructureReference"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "specificAreaReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "buildingObjectChange": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectChange"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "specificationOfObjectOfInspection": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "inspectionRemarks": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "inspectionCarriedOutByFirstName": {
-                        "type": "string",
-                        "description": ""
-                    },
-                    "inspectionCarriedOutByLastName": {
-                        "type": "string",
-                        "description": ""
-                    },
-                    "personsPresent": {
-                        "type": "string",
-                        "description": ""
-                    },
-                    "buildingsAttachmentDocument": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "description": "",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Katselmus"
-            },
-            "InspectionBuildingReference": {
-                "type": "object",
-                "properties": {
-                    "permanentBuildingIdentifierReference": {
-                        "type": "string"
-                    },
-                    "buildingSectionReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "InspectionStructureReference": {
-                "type": "object",
-                "properties": {
-                    "permanentStructureIdentifierReference": {
-                        "type": "string"
-                    },
-                    "buildingSectionReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "InteriorData": {
-                "type": "object",
-                "properties": {
-                    "floorArea": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "basementArea": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Sisätilojen tiedot"
-            },
-            "LanguageString": {
-                "type": "object",
-                "properties": {
-                    "fin": {
-                        "type": "string",
-                        "description": "suomi",
-                        "nullable": true
-                    },
-                    "swe": {
-                        "type": "string",
-                        "description": "ruotsi",
-                        "nullable": true
-                    },
-                    "smn": {
-                        "type": "string",
-                        "description": "inarinsaame",
-                        "nullable": true
-                    },
-                    "sms": {
-                        "type": "string",
-                        "description": "koltansaame",
-                        "nullable": true
-                    },
-                    "sme": {
-                        "type": "string",
-                        "description": "pohjoissaame",
-                        "nullable": true
-                    },
-                    "eng": {
-                        "type": "string",
-                        "description": "englanti",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "MaterialData": {
-                "required": [
-                    "buildingMaterialOfLoadBearingStructures",
-                    "constructionMethod",
-                    "wideBodiedBuilding"
-                ],
-                "type": "object",
-                "properties": {
-                    "constructionMethod": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/01",
-                            "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/02"
-                        ],
-                        "type": "string",
-                        "description": "Rakentamistapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_runkotapa\">http://uri.suomi.fi/codelist/vtj/Rake_runkotapa</a>",
-                        "nullable": true
-                    },
-                    "buildingMaterialOfLoadBearingStructures": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingMaterialOfLoadBearingStructures"
-                        },
-                        "description": "Kantavien rakenteiden rakennusaine"
-                    },
-                    "facadeMaterial": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/FacadeMaterial"
-                        }
-                    },
-                    "fireClass": {
-                        "type": "string",
-                        "description": "Paloluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Paloluokka\">http://uri.suomi.fi/codelist/rytj/Paloluokka</a>",
-                        "nullable": true
-                    },
-                    "wideBodiedBuilding": {
-                        "type": "boolean"
-                    },
-                    "reusableMaterialAmount": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Materiaalitiedot"
-            },
-            "NetworkConnection": {
-                "type": "object",
-                "properties": {
-                    "networkConnectionKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "networkConnectionType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/05",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/06",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/07",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/08",
-                            "http://uri.suomi.fi/codelist/rytj/verkliit/code/09"
-                        ],
-                        "type": "string",
-                        "description": "Verkostoliittymän laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/verkliit\">http://uri.suomi.fi/codelist/rytj/verkliit</a>",
-                        "nullable": true
-                    },
-                    "connected": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "connectionPoint": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Verkostoliittymä"
-            },
-            "Operator": {
-                "type": "object",
-                "properties": {
-                    "personalIdentityCode": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "businessId": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "otherId": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "isPerson": {
-                        "type": "boolean",
-                        "description": ""
-                    },
-                    "firstName": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "familyName": {
-                        "type": "string",
-                        "description": "",
-                        "nullable": true
-                    },
-                    "organizationName": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "operatorAddress": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ContactAddress"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "languageCode": {
-                        "type": "string",
-                        "description": "IETF kielikoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes\">http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes</a>",
-                        "nullable": true
-                    },
-                    "nationalityCode": {
-                        "type": "string",
-                        "description": "Valtiokoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-                        "nullable": true
-                    },
-                    "deathDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Toimija"
-            },
-            "OperatorChangeDiffDto": {
-                "type": "object",
-                "properties": {
-                    "changeType": {
-                        "type": "string"
-                    },
-                    "objectKey": {
-                        "nullable": true
-                    },
-                    "objectType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentKey": {
-                        "nullable": true
-                    },
-                    "parentType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentChain": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ParentTypeKey"
-                        }
-                    },
-                    "objectState": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
-                        "description": "Toimija",
-                        "nullable": true
-                    },
-                    "objectStatePrev": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
-                        "description": "Toimija",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "OperatorChangeInfoCollectionDto": {
-                "type": "object",
-                "properties": {
-                    "lastSeen": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PaginationToken"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "upToDate": {
-                        "type": "boolean"
-                    },
-                    "changes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/OperatorChangeInfoDto"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "OperatorChangeInfoDto": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "objectKey": {},
-                    "objectState": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Operator"
-                            }
-                        ],
-                        "description": "Toimija",
-                        "nullable": true
-                    },
-                    "diff": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/OperatorChangeDiffDto"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "PaginationToken": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "nullable": true
-                    },
-                    "objectKey": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ParentTypeKey": {
-                "type": "object",
-                "properties": {
-                    "parentType": {
-                        "type": "string"
-                    },
-                    "parentKey": {}
-                },
-                "additionalProperties": false
-            },
-            "PermitRegulation": {
-                "required": [
-                    "permitRegulationType"
-                ],
-                "type": "object",
-                "properties": {
-                    "permitRegulationKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permitRegulationType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M01",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0101",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0102",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0103",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0104",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0105",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0106",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0107",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0108",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0109",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0110",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M02",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0201",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0202",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M03",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0301",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0302",
-                            "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M04"
-                        ],
-                        "type": "string",
-                        "description": "Lupamääräys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen\">http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen</a>"
-                    },
-                    "textOfPermitRegulation": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Lupamääräys"
-            },
-            "Planner": {
-                "type": "object",
-                "properties": {
-                    "plannerKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "plannerRole": {
-                        "type": "string",
-                        "description": "Suunnittelijan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli\">http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli</a>"
-                    },
-                    "plannerCompetence": {
-                        "type": "string",
-                        "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-                    },
-                    "responsibilityStartDate": {
-                        "type": "string",
-                        "format": "date"
-                    },
-                    "responsibilityEndDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "buildingReference": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PlannerBuildingReference"
-                        },
-                        "nullable": true
-                    },
-                    "structureReference": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/PlannerStructureReference"
-                        },
-                        "nullable": true
-                    },
-                    "specificAreaReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    },
-                    "requiredCompetence": {
-                        "type": "string",
-                        "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-                    },
-                    "personalIdentityCode": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "otherId": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "firstName": {
-                        "type": "string"
-                    },
-                    "familyName": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Suunnittelija"
-            },
-            "PlannerBuildingReference": {
-                "type": "object",
-                "properties": {
-                    "permanentBuildingIdentifierReference": {
-                        "type": "string"
-                    },
-                    "buildingSectionReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "PlannerStructureReference": {
-                "type": "object",
-                "properties": {
-                    "permanentStructureIdentifierReference": {
-                        "type": "string"
-                    },
-                    "buildingSectionReference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "ProblemDetails": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "title": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "status": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "detail": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "instance": {
-                        "type": "string",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": {}
-            },
-            "Property": {
-                "type": "object",
-                "properties": {
-                    "municipalityNumber": {
-                        "type": "string"
-                    },
-                    "propertyIdentifier": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "registrationDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "endDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "landArea": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "geometry": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/RyhtiGeometry"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "relationToBaseProperty": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Kiinteistö"
-            },
-            "Purpose": {
-                "required": [
-                    "isPrimary",
-                    "type"
-                ],
-                "type": "object",
-                "properties": {
-                    "purposeKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "type": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                            "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-                        ],
-                        "type": "string",
-                        "description": "Käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Käyttötarkoitus"
-            },
-            "RyhtiGeometry": {
-                "required": [
-                    "geometry",
-                    "srid"
-                ],
-                "type": "object",
-                "properties": {
-                    "srid": {
-                        "enum": [
-                            "3067",
-                            "3873",
-                            "3874",
-                            "3875",
-                            "3876",
-                            "3877",
-                            "3878",
-                            "3879",
-                            "3880",
-                            "3881",
-                            "3882",
-                            "3883",
-                            "3884",
-                            "3885"
-                        ],
-                        "type": "string",
-                        "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
-                    },
-                    "geometry": {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/GeoJsonPointGeometry"
-                            },
-                            {
-                                "$ref": "#/components/schemas/GeoJsonMultiPointGeometry"
-                            },
-                            {
-                                "$ref": "#/components/schemas/GeoJsonLineStringGeometry"
-                            },
-                            {
-                                "$ref": "#/components/schemas/GeoJsonMultiLineStringGeometry"
-                            },
-                            {
-                                "$ref": "#/components/schemas/GeoJsonPolygonGeometry"
-                            },
-                            {
-                                "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
-                            }
-                        ],
-                        "description": "Geometria GeoJson rakenteella: https://geojson.org/"
-                    }
-                },
-                "additionalProperties": false
-            },
-            "SpecialDesign": {
-                "required": [
-                    "specialDesignType"
-                ],
-                "type": "object",
-                "properties": {
-                    "specialDesignKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "specialDesignType": {
-                        "type": "string",
-                        "description": "Erityissuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/erityissuun\">http://uri.suomi.fi/codelist/rytj/erityissuun</a>"
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "document": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        }
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Erityissuunnitelma"
-            },
-            "Structure": {
-                "required": [
-                    "buildingObjectOwner",
-                    "buildingObjectType",
-                    "structureMainPurpose"
-                ],
-                "type": "object",
-                "properties": {
-                    "structureKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "permanentStructureIdentifier": {
-                        "type": "string"
-                    },
-                    "temporary": {
-                        "type": "boolean",
-                        "nullable": true
-                    },
-                    "demolitionDeadline": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "numberOfStoreys": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "structureSection": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StructureSection"
-                        },
-                        "nullable": true
-                    },
-                    "structureMainPurpose": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-                        ],
-                        "type": "string",
-                        "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-                    },
-                    "buildingObjectType": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-                    },
-                    "location": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingObjectLocationData"
-                            }
-                        ],
-                        "description": "Rakennuskohteen sijaintitiedot",
-                        "nullable": true
-                    },
-                    "administrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö"
-                    },
-                    "decisionAdministrativeLocationUnit": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                            }
-                        ],
-                        "description": "Hallinnollinen sijaintiyksikkö",
-                        "nullable": true
-                    },
-                    "buildingObjectOwner": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingObjectOwner"
-                        },
-                        "description": "Rakennuskohteen omistaja",
-                        "nullable": true
-                    },
-                    "address": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Address"
-                        },
-                        "nullable": true
-                    },
-                    "name": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "description": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennelma"
-            },
-            "StructureChangeDiffDto": {
-                "type": "object",
-                "properties": {
-                    "changeType": {
-                        "type": "string"
-                    },
-                    "objectKey": {
-                        "nullable": true
-                    },
-                    "objectType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentKey": {
-                        "nullable": true
-                    },
-                    "parentType": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "parentChain": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ParentTypeKey"
-                        }
-                    },
-                    "objectState": {
-                        "required": [
-                            "structureMainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Structure"
-                            }
-                        ],
-                        "description": "Rakennelma",
-                        "nullable": true
-                    },
-                    "objectStatePrev": {
-                        "required": [
-                            "structureMainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Structure"
-                            }
-                        ],
-                        "description": "Rakennelma",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "StructureChangeInfoCollectionDto": {
-                "type": "object",
-                "properties": {
-                    "lastSeen": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/PaginationToken"
-                            }
-                        ],
-                        "nullable": true
-                    },
-                    "upToDate": {
-                        "type": "boolean"
-                    },
-                    "changes": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StructureChangeInfoDto"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            },
-            "StructureChangeInfoDto": {
-                "type": "object",
-                "properties": {
-                    "eventId": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "eventTime": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "objectKey": {},
-                    "objectState": {
-                        "required": [
-                            "structureMainPurpose",
-                            "buildingObjectType",
-                            "buildingObjectOwner"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/Structure"
-                            }
-                        ],
-                        "description": "Rakennelma",
-                        "nullable": true
-                    },
-                    "diff": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/StructureChangeDiffDto"
-                        },
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false
-            },
-            "StructureSection": {
-                "type": "object",
-                "properties": {
-                    "structureSectionKey": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid"
-                    },
-                    "lifeCycleState": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                            "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-                        ],
-                        "type": "string",
-                        "description": "Rakennelman elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/rakelinvaih\">http://uri.suomi.fi/codelist/rakrek/rakelinvaih</a>"
-                    },
-                    "completionDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "protectionMethod": {
-                        "type": "string",
-                        "description": "Rakennelman osan suojatapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suojtapa\">http://uri.suomi.fi/codelist/rytj/suojtapa</a>",
-                        "nullable": true
-                    },
-                    "cultureHistoricalSignificance": {
-                        "type": "string",
-                        "description": "Rakennelman osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/kulthistmer\">http://uri.suomi.fi/codelist/rakrek/kulthistmer</a>",
-                        "nullable": true
-                    },
-                    "materialData": {
-                        "required": [
-                            "constructionMethod",
-                            "buildingMaterialOfLoadBearingStructures",
-                            "wideBodiedBuilding"
-                        ],
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/MaterialData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "energyData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/EnergyData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "exteriorData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/ExteriorData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "buildingServicesEngineeringData": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                            }
-                        ],
-                        "description": "",
-                        "nullable": true
-                    },
-                    "structurePurpose": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                            "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-                        ],
-                        "type": "string",
-                        "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-                    },
-                    "equipment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Equipment"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "constructionDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ConstructionDesign"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "buildingInformationModel": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingInformationModel"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "specialDesign": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SpecialDesign"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "attachment": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                        },
-                        "description": "",
-                        "nullable": true
-                    },
-                    "partitionReason": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                            "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-                        ],
-                        "type": "string",
-                        "description": "Rakennelman osan osittelun laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji\">http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji</a>"
-                    },
-                    "partitionDescription": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/LanguageString"
-                            }
-                        ],
-                        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-                        "nullable": true
-                    },
-                    "relatedFinishedStructureSection": {
-                        "type": "string",
-                        "description": "",
-                        "format": "uuid",
-                        "nullable": true
-                    },
-                    "demolitionDate": {
-                        "type": "string",
-                        "description": "",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "reasonForDemolition": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                            "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-                        ],
-                        "type": "string",
-                        "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennelman osa"
-            },
-            "UnseparatedParcel": {
-                "type": "object",
-                "properties": {
-                    "municipalityNumber": {
-                        "type": "string"
-                    },
-                    "unseparatedParcelIdentifier": {
-                        "type": "string"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "registrationDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "endDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "relationToBaseProperty": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Määräala"
-            },
-            "UsageData": {
-                "type": "object",
-                "properties": {
-                    "commissioningDate": {
-                        "type": "string",
-                        "format": "date",
-                        "nullable": true
-                    },
-                    "usageStatus": {
-                        "enum": [
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
-                            "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
-                        ],
-                        "type": "string",
-                        "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-                        "nullable": true
-                    },
-                    "purpose": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Purpose"
-                        },
-                        "nullable": true
-                    },
-                    "usefulFloorArea": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true
-                    },
-                    "intendedWorkingLife": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "plannedUserCount": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Rakennuksen käyttötiedot"
-            },
-            "ValidationProblemDetails": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "title": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "status": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    },
-                    "detail": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "instance": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "errors": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "additionalProperties": {}
-            },
-            "VentilationMethod": {
-                "required": [
-                    "isPrimary",
-                    "ventilationMethodType"
-                ],
-                "type": "object",
-                "properties": {
-                    "ventilationMethodKey": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "ventilationMethodType": {
-                        "type": "string",
-                        "description": "Ilmanvaihtotavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ilmanvaihto\">http://uri.suomi.fi/codelist/rytj/ilmanvaihto</a>"
-                    },
-                    "isPrimary": {
-                        "type": "boolean"
-                    }
-                },
-                "additionalProperties": false,
-                "description": "Ilmanvaihtotapa"
-            }
-        },
-        "securitySchemes": {
-            "Bearer": {
-                "type": "apiKey",
-                "description": "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\"",
-                "name": "Authorization",
-                "in": "header"
-            },
-            "oauth2": {
-                "type": "oauth2",
-                "flows": {
-                    "clientCredentials": {
-                        "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
-                        "scopes": {
-                            "ryhti.changeinformation.read": "Muutostietojen lukuoikeus.",
-                            "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus",
-                            "ryhti.changeinformation.building.owners.all": "Omistajatietojen lukuoikeus, ml turvakiellon alaiset henkilöt.",
-                            "ryhti.changeinformation.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia henkilöitä.",
-                            "ryhti.changeinformation.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin."
-                        }
-                    }
+      "schemas": {
+        "AcceptedDeviation": {
+          "required": [
+            "acceptedDeviationKey",
+            "contentOfDeviation"
+          ],
+          "type": "object",
+          "properties": {
+            "acceptedDeviationKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "deviationType": {
+              "type": "string",
+              "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
+            },
+            "contentOfDeviation": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
                 }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
             }
+          },
+          "additionalProperties": false,
+          "description": "Luvan yhteydessä myönnettävä poikkeaminen"
+        },
+        "Address": {
+          "required": [
+            "addressKey"
+          ],
+          "type": "object",
+          "properties": {
+            "addressKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "addressName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "numberPartOfAddressNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "subdivisionLetterOfAddressNumber": {
+              "type": "string",
+              "nullable": true
+            },
+            "postalCode": {
+              "type": "string",
+              "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
+              "nullable": true
+            },
+            "location": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "numberPartOfAddressNumber2": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "subdivisionLetterOfAddressNumber2": {
+              "type": "string",
+              "nullable": true
+            },
+            "addressNumber": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Osoite"
+        },
+        "AdministrativeLocationUnit": {
+          "required": [
+            "administrativeLocationUnitKey",
+            "propertyIdentifier"
+          ],
+          "type": "object",
+          "properties": {
+            "administrativeLocationUnitKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "unitIdentifier": {
+              "type": "string",
+              "nullable": true
+            },
+            "propertyIdentifier": {
+              "type": "string"
+            },
+            "unseparatedParcelIdentifier": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Hallinnollinen sijaintiyksikkö"
+        },
+        "Apartment": {
+          "required": [
+            "addressNumber",
+            "apartmentKey",
+            "apartmentType",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "apartmentKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
+              ],
+              "type": "string",
+              "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
+              "nullable": true
+            },
+            "apartmentEquipment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ApartmentEquipment"
+              },
+              "nullable": true
+            },
+            "apartmentIdentifier": {
+              "type": "string"
+            },
+            "apartmentType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+              ],
+              "type": "string",
+              "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+            },
+            "floorArea": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "numberOfRooms": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "kitchenType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+              ],
+              "type": "string",
+              "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
+              "nullable": true
+            },
+            "isWaterCloset": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "apartmentChangeType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+              ],
+              "type": "string",
+              "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
+              "nullable": true
+            },
+            "commissioningDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "addressNumber": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "apartmentStorey": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "apartmentIdentifierLetterSuffix": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentSubdivisionLetter": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentNumber": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Huoneisto"
+        },
+        "ApartmentEquipment": {
+          "required": [
+            "apartmentEquipmentKey",
+            "apartmentEquipmentType",
+            "numberOfEquipment"
+          ],
+          "type": "object",
+          "properties": {
+            "apartmentEquipmentKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "apartmentEquipmentType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/01",
+                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/02",
+                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/03",
+                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/04",
+                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/05"
+              ],
+              "type": "string",
+              "description": "Huoneiston varusteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste\">http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste</a>",
+              "nullable": true
+            },
+            "numberOfEquipment": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Huoneiston varuste"
+        },
+        "AreaToBeBuiltForSpecificActivities": {
+          "required": [
+            "areaToBeBuiltForSpecificActivitiesKey",
+            "buildingObjectOwner",
+            "buildingObjectType"
+          ],
+          "type": "object",
+          "properties": {
+            "areaToBeBuiltForSpecificActivitiesKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "specificActivitiesAreaType": {
+              "type": "string",
+              "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>",
+              "nullable": true
+            },
+            "networkConnection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/NetworkConnection"
+              },
+              "nullable": true
+            },
+            "completionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "temporary": {
+              "type": "boolean"
+            },
+            "demolitionDeadline": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot",
+              "nullable": true
+            },
+            "administrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö",
+              "nullable": true
+            },
+            "decisionAdministrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö",
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "description": "Rakennuskohteen omistaja",
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "constructionDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionDesign"
+              },
+              "nullable": true
+            },
+            "buildingInformationModel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingInformationModel"
+              },
+              "nullable": true
+            },
+            "specialDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SpecialDesign"
+              },
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Erityistä toimintaa varten rakennettava alue"
+        },
+        "AssemblyFacility": {
+          "required": [
+            "assemblyFacilityKey",
+            "capacityOfAssemblyFacilities"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "geometry": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "assemblyFacilityKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "capacityOfAssemblyFacilities": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Kokoontumistila"
+        },
+        "Building": {
+          "required": [
+            "buildingKey",
+            "buildingObjectOwner",
+            "buildingObjectType",
+            "mainPurpose",
+            "numberOfStoreys"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permanentBuildingIdentifier": {
+              "type": "string",
+              "description": "Pysyvä rakennustunnus (PRT)"
+            },
+            "temporary": {
+              "type": "boolean",
+              "description": "Onko väliaikainen",
+              "nullable": true
+            },
+            "demolitionDeadline": {
+              "type": "string",
+              "description": "Demolition deadline",
+              "format": "date",
+              "nullable": true
+            },
+            "numberOfStoreys": {
+              "type": "integer",
+              "description": "Kerrosluku",
+              "format": "int32",
+              "nullable": true
+            },
+            "buildingSection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingSection"
+              },
+              "description": "Rakennuksen osat",
+              "nullable": true
+            },
+            "mainPurpose": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+              ],
+              "type": "string",
+              "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
+              "nullable": true
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot",
+              "nullable": true
+            },
+            "administrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö"
+            },
+            "decisionAdministrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö",
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "description": "Rakennuskohteen omistaja",
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "addChangeEvent": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "renovationDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuksen tiedot."
+        },
+        "BuildingAttachmentDocument": {
+          "required": [
+            "attachmentDocumentKey",
+            "categoryOfPublicity",
+            "documentDate",
+            "documentIdentifier",
+            "fileKey",
+            "languages",
+            "name",
+            "personalDataContent",
+            "retentionTime"
+          ],
+          "type": "object",
+          "properties": {
+            "attachmentDocumentKey": {
+              "type": "string",
+              "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
+              "format": "uuid"
+            },
+            "documentIdentifier": {
+              "minLength": 1,
+              "type": "string",
+              "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+            },
+            "personalDataContent": {
+              "minLength": 1,
+              "type": "string",
+              "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
+            },
+            "categoryOfPublicity": {
+              "minLength": 1,
+              "type": "string",
+              "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
+            },
+            "accessibility": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "retentionTime": {
+              "minLength": 1,
+              "type": "string",
+              "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
+            },
+            "confirmationDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "languages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
+            },
+            "fileKey": {
+              "type": "string",
+              "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
+              "format": "uuid"
+            },
+            "descriptors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Descriptor"
+              },
+              "nullable": true
+            },
+            "documentDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "arrivedDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "attachmentType": {
+              "type": "string",
+              "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
+            },
+            "documentCreatorPersonalIdentityCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "documentCreatorOtherId": {
+              "type": "string",
+              "nullable": true
+            },
+            "documentCreatorFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "documentCreatorFamilyName": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Liiteasiakirja"
+        },
+        "BuildingInformationModel": {
+          "required": [
+            "buildingInformationModelKey",
+            "buildingInformationModelType"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingInformationModelKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "buildingInformationModelType": {
+              "type": "string",
+              "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
+            },
+            "document": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            },
+            "referencePoint": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennustietomalli"
+        },
+        "BuildingMaterialOfLoadBearingStructures": {
+          "required": [
+            "buildingMaterialOfLoadBearingStructuresKey",
+            "buildingMaterialOfLoadBearingStructuresType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingMaterialOfLoadBearingStructuresKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "buildingMaterialOfLoadBearingStructuresType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/00",
+                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/01",
+                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/02",
+                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/03",
+                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/04",
+                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/99"
+              ],
+              "type": "string",
+              "description": "Kantavan rakenteen rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine\">http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine</a>"
+            },
+            "isPrimary": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Kantavien rakenteiden rakennusaine"
+        },
+        "BuildingObjectChange": {
+          "required": [
+            "buildingObjectChangeKey"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingObjectChangeKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "volumeChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "grossFloorAreaChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "permittedBuildingAreaChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "totalAreaChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "floorAreaChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "basementAreaChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "numberOfStoreysChange": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuskohteen muutos"
+        },
+        "BuildingObjectLocationData": {
+          "required": [
+            "buildingObjectLocationDataKey"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingObjectLocationDataKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "votingDistrictNumber": {
+              "type": "string"
+            },
+            "pointLocation": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ]
+            },
+            "geometry": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuskohteen sijaintitiedot"
+        },
+        "BuildingObjectOwner": {
+          "required": [
+            "buildingObjectOwnerKey",
+            "differentOwner",
+            "ownerOperator"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingObjectOwnerKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "ownerOperator": {
+              "required": [
+                "isPerson"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Operator"
+                }
+              ],
+              "description": ""
+            },
+            "differentOwner": {
+              "type": "boolean",
+              "description": ""
+            },
+            "tenureStatus": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "ownerContactOperator": {
+              "required": [
+                "isPerson"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Operator"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "ownerType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/04",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/05",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/06",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/07",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/08",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/09",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/10",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/11",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/12",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/13",
+                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/14"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen omistajan laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/OmistajanLahde"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuskohteen omistaja"
+        },
+        "BuildingPermitApplication": {
+          "required": [
+            "applicationContent",
+            "lifeCycleState",
+            "permitApplicationKey"
+          ],
+          "type": "object",
+          "properties": {
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+              ],
+              "type": "string",
+              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+              "nullable": true
+            },
+            "applicationContent": {
+              "type": "string"
+            },
+            "dateOfReception": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "callForDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CallForDeviation"
+              },
+              "nullable": true
+            },
+            "permitApplicationKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permitApplicationType": {
+              "type": "string",
+              "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakentamislupahakemus"
+        },
+        "BuildingPermitDecision": {
+          "required": [
+            "buildingPermitDecisionKey",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "acceptedDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AcceptedDeviation"
+              },
+              "nullable": true
+            },
+            "permitRegulation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PermitRegulation"
+              },
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+            },
+            "decisionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfValidityOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "decisionDocument": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
+                }
+              ],
+              "description": "Liiteasiakirja",
+              "nullable": true
+            },
+            "decisionArticle": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "publicNoticeDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "decisionText": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "guidingStatute": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GuidingStatute"
+              },
+              "nullable": true
+            },
+            "relatedPermit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "decisionMakerType": {
+              "type": "string",
+              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+              "nullable": true
+            },
+            "decisionMakerFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "decisionMakerName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "buildingPermitDecisionKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permitApplicationType": {
+              "type": "string",
+              "nullable": true
+            },
+            "constructionToBeStartedBy": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "constructionToBeCompletedBy": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "constructionToBeStartedByExtension": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "constructionToBeCompletedByExtension": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "engagingParty": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EngagingParty"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakentamislupapäätös"
+        },
+        "BuildingSection": {
+          "required": [
+            "buildingSectionKey",
+            "lifeCycleState",
+            "partitionReason",
+            "usageData"
+          ],
+          "type": "object",
+          "properties": {
+            "buildingSectionKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+              ],
+              "type": "string",
+              "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih",
+              "nullable": true
+            },
+            "completionDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "protectionMethod": {
+              "type": "string",
+              "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
+              "nullable": true
+            },
+            "cultureHistoricalSignificance": {
+              "type": "string",
+              "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
+              "nullable": true
+            },
+            "materialData": {
+              "required": [
+                "constructionMethod",
+                "buildingMaterialOfLoadBearingStructures",
+                "facadeMaterial",
+                "wideBodiedBuilding"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/MaterialData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "energyData": {
+              "required": [
+                "energyDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/EnergyData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "interiorData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InteriorData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "exteriorData": {
+              "required": [
+                "shape"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ExteriorData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "buildingServicesEngineeringData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "usageData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/UsageData"
+                }
+              ],
+              "description": ""
+            },
+            "equipment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Equipment"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "entrance": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Entrance"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "assemblyFacility": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AssemblyFacility"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "elevator": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Elevator"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "apartment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Apartment"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "constructionDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionDesign"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "buildingInformationModel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingInformationModel"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "specialDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SpecialDesign"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "partitionReason": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+              ],
+              "type": "string",
+              "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
+            },
+            "partitionDescription": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "civilDefenceShelter": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CivilDefenceShelter"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "relatedFinishedBuildingSection": {
+              "type": "string",
+              "description": "",
+              "format": "uuid",
+              "nullable": true
+            },
+            "demolitionDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "reasonForDemolition": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+              ],
+              "type": "string",
+              "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuksen osa"
+        },
+        "BuildingServicesEngineeringData": {
+          "type": "object",
+          "properties": {
+            "ventilationMethod": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VentilationMethod"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "sewerageMethodType": {
+              "type": "string",
+              "description": "Jätevesien käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/jatevesienkasittely",
+              "nullable": true
+            },
+            "householdWaterType": {
+              "type": "string",
+              "description": "Talousveden laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/talousvesi",
+              "nullable": true
+            },
+            "networkConnection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/NetworkConnection"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "stormWaterTreatmentType": {
+              "type": "string",
+              "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/hulevedenkasittely",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Talotekniikkatiedot"
+        },
+        "BuildingSite": {
+          "required": [
+            "stormWaterTreatmentType",
+            "tenure"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "geometry": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "buildingSiteKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "area": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "stormWaterTreatmentType": {
+              "type": "string",
+              "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
+              "nullable": true
+            },
+            "buildingSiteAddress": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "spatialPlan": {
+              "type": "string",
+              "nullable": true
+            },
+            "statusOfPlan": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/01",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/02",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/03",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/04",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/05",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/06",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/07",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/08",
+                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/09"
+              ],
+              "type": "string",
+              "description": "Kaavatilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaava\">http://uri.suomi.fi/codelist/vtj/Rake_kaava</a>",
+              "nullable": true
+            },
+            "tenure": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/1",
+                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/2",
+                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
+              ],
+              "type": "string",
+              "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuspaikka"
+        },
+        "CalculatoryDeliveredEnergyUsage": {
+          "required": [
+            "calculatoryDeliveredEnergyUsageKey",
+            "deliveredEnergyType",
+            "energyAmountYearly"
+          ],
+          "type": "object",
+          "properties": {
+            "calculatoryDeliveredEnergyUsageKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "deliveredEnergyType": {
+              "type": "string",
+              "description": "Ostoenergian laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ostoenergia\">http://uri.suomi.fi/codelist/rytj/ostoenergia</a>"
+            },
+            "energyAmountYearly": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Energiankulutus"
+        },
+        "CallForDeviation": {
+          "required": [
+            "callForDeviationKey",
+            "contentOfDeviation",
+            "deviationType"
+          ],
+          "type": "object",
+          "properties": {
+            "callForDeviationKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "deviationType": {
+              "type": "string",
+              "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
+            },
+            "contentOfDeviation": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+            }
+          },
+          "additionalProperties": false,
+          "description": "Määräyksestä poikkeaminen"
+        },
+        "ChangeInformationAdministrativeLocationUnit": {
+          "type": "object",
+          "properties": {
+            "administrativeLocationUnitKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "unitIdentifier": {
+              "type": "string",
+              "nullable": true
+            },
+            "propertyIdentifier": {
+              "type": "string"
+            },
+            "unseparatedParcelIdentifier": {
+              "type": "string",
+              "nullable": true
+            },
+            "property": {
+              "required": [
+                "municipalityNumber",
+                "propertyIdentifier",
+                "status",
+                "type",
+                "relationToBaseProperty"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Property"
+                }
+              ],
+              "description": "Kiinteistö",
+              "nullable": true
+            },
+            "parcel": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/UnseparatedParcel"
+                }
+              ],
+              "description": "Määräala",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationApartment": {
+          "type": "object",
+          "properties": {
+            "apartmentKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
+                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
+              ],
+              "type": "string",
+              "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
+              "nullable": true
+            },
+            "apartmentEquipment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ApartmentEquipment"
+              },
+              "nullable": true
+            },
+            "apartmentIdentifier": {
+              "type": "string"
+            },
+            "apartmentType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+              ],
+              "type": "string",
+              "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+            },
+            "floorArea": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "numberOfRooms": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "kitchenType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+              ],
+              "type": "string",
+              "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
+              "nullable": true
+            },
+            "isWaterCloset": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "apartmentChangeType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+              ],
+              "type": "string",
+              "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
+              "nullable": true
+            },
+            "commissioningDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "addressNumber": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "apartmentStorey": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "housingType": {
+              "type": "string",
+              "nullable": true
+            },
+            "occupancyOfApartment": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentIdentifierLetterSuffix": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentSubdivisionLetter": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentNumber": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationAreaToBeBuiltForSpecificActivities": {
+          "type": "object",
+          "properties": {
+            "areaToBeBuiltForSpecificActivitiesKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "specificActivitiesAreaType": {
+              "type": "string",
+              "nullable": true
+            },
+            "networkConnection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/NetworkConnection"
+              },
+              "nullable": true
+            },
+            "completionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "temporary": {
+              "type": "boolean"
+            },
+            "demolitionDeadline": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string"
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot",
+              "nullable": true
+            },
+            "administrativeLocationUnit": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+                }
+              ],
+              "nullable": true
+            },
+            "decisionAdministrativeLocationUnit": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+                }
+              ],
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "constructionDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionDesign"
+              },
+              "nullable": true
+            },
+            "buildingInformationModel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingInformationModel"
+              },
+              "nullable": true
+            },
+            "specialDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SpecialDesign"
+              },
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuilding": {
+          "type": "object",
+          "properties": {
+            "buildingKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permanentBuildingIdentifier": {
+              "type": "string",
+              "description": "Pysyvä rakennustunnus (PRT)"
+            },
+            "temporary": {
+              "type": "boolean",
+              "description": "Onko väliaikainen",
+              "nullable": true
+            },
+            "demolitionDeadline": {
+              "type": "string",
+              "description": "Demolition deadline",
+              "format": "date",
+              "nullable": true
+            },
+            "numberOfStoreys": {
+              "type": "integer",
+              "description": "Kerrosluku",
+              "format": "int32",
+              "nullable": true
+            },
+            "buildingSection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationBuildingSection"
+              },
+              "description": "Rakennuksen osat",
+              "nullable": true
+            },
+            "mainPurpose": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+              ],
+              "type": "string",
+              "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
+              "nullable": true
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot",
+              "nullable": true
+            },
+            "administrativeLocationUnit": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+                }
+              ]
+            },
+            "decisionAdministrativeLocationUnit": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+                }
+              ],
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "description": "Rakennuskohteen omistaja",
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "addChangeEvent": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "renovationDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "mainPurpose1994": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "numberOfNewApartments": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "numberOfDeletedApartments": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingChangeDiffDto": {
+          "type": "object",
+          "properties": {
+            "changeType": {
+              "type": "string"
+            },
+            "objectKey": {
+              "nullable": true
+            },
+            "objectType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentKey": {
+              "nullable": true
+            },
+            "parentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentChain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ParentTypeKey"
+              }
+            },
+            "objectState": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
+                }
+              ],
+              "nullable": true
+            },
+            "objectStatePrev": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingChangeInfoCollectionDto": {
+          "type": "object",
+          "properties": {
+            "lastSeen": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PaginationToken"
+                }
+              ],
+              "nullable": true
+            },
+            "upToDate": {
+              "type": "boolean"
+            },
+            "changes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoDto"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingChangeInfoDto": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "eventTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "objectKey": { },
+            "objectState": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
+                }
+              ],
+              "nullable": true
+            },
+            "diff": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationBuildingChangeDiffDto"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingPermitIssue": {
+          "required": [
+            "lifeCycleState",
+            "municipalityNumber"
+          ],
+          "type": "object",
+          "properties": {
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+              "nullable": true
+            },
+            "municipalityNumber": {
+              "type": "string"
+            },
+            "permanentPermitIdentifier": {
+              "type": "string"
+            },
+            "decision": {
+              "required": [
+                "buildingPermitDecisionKey",
+                "lifeCycleState"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingPermitDecision"
+                }
+              ],
+              "description": "Rakentamislupapäätös",
+              "nullable": true
+            },
+            "extensionDecision": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ExtensionDecision"
+              },
+              "nullable": true
+            },
+            "changePermit": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangePermit"
+              },
+              "nullable": true
+            },
+            "buildingPermitApplication": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingPermitApplication"
+              },
+              "description": "Rakentamislupahakemus",
+              "nullable": true
+            },
+            "constructionAction": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationConstructionAction"
+              }
+            },
+            "buildingSite": {
+              "required": [
+                "stormWaterTreatmentType",
+                "tenure"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingSite"
+                }
+              ],
+              "description": "Rakennuspaikka",
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            },
+            "constructionProject": {
+              "required": [
+                "constructionProjectKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ConstructionProject"
+                }
+              ],
+              "description": "Rakentamishanke",
+              "nullable": true
+            },
+            "updateType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+              ],
+              "type": "string",
+              "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+              "nullable": true
+            },
+            "updateDescription": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "dateOfInitiation": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingPermitIssueChangeDiffDto": {
+          "type": "object",
+          "properties": {
+            "changeType": {
+              "type": "string"
+            },
+            "objectKey": {
+              "nullable": true
+            },
+            "objectType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentKey": {
+              "nullable": true
+            },
+            "parentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentChain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ParentTypeKey"
+              }
+            },
+            "objectState": {
+              "required": [
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              ],
+              "nullable": true
+            },
+            "objectStatePrev": {
+              "required": [
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingPermitIssueChangeInfoCollectionDto": {
+          "type": "object",
+          "properties": {
+            "lastSeen": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PaginationToken"
+                }
+              ],
+              "nullable": true
+            },
+            "upToDate": {
+              "type": "boolean"
+            },
+            "changes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoDto"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingPermitIssueChangeInfoDto": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "eventTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "objectKey": { },
+            "objectState": {
+              "required": [
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              ],
+              "nullable": true
+            },
+            "diff": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeDiffDto"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationBuildingSection": {
+          "type": "object",
+          "properties": {
+            "buildingSectionKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+              ],
+              "type": "string",
+              "nullable": true
+            },
+            "completionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "protectionMethod": {
+              "type": "string",
+              "nullable": true
+            },
+            "cultureHistoricalSignificance": {
+              "type": "string",
+              "nullable": true
+            },
+            "materialData": {
+              "required": [
+                "constructionMethod",
+                "buildingMaterialOfLoadBearingStructures",
+                "facadeMaterial",
+                "wideBodiedBuilding"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/MaterialData"
+                }
+              ],
+              "description": "Materiaalitiedot",
+              "nullable": true
+            },
+            "energyData": {
+              "required": [
+                "energyDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/EnergyData"
+                }
+              ],
+              "description": "Energiatiedot",
+              "nullable": true
+            },
+            "interiorData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InteriorData"
+                }
+              ],
+              "description": "Sisätilojen tiedot",
+              "nullable": true
+            },
+            "exteriorData": {
+              "required": [
+                "shape"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ExteriorData"
+                }
+              ],
+              "description": "Ulkokuoren tiedot",
+              "nullable": true
+            },
+            "buildingServicesEngineeringData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+                }
+              ],
+              "description": "Talotekniikkatiedot",
+              "nullable": true
+            },
+            "usageData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/UsageData"
+                }
+              ],
+              "description": "Rakennuksen käyttötiedot"
+            },
+            "equipment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Equipment"
+              },
+              "nullable": true
+            },
+            "entrance": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Entrance"
+              },
+              "nullable": true
+            },
+            "assemblyFacility": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AssemblyFacility"
+              },
+              "nullable": true
+            },
+            "elevator": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Elevator"
+              },
+              "nullable": true
+            },
+            "apartment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangeInformationApartment"
+              },
+              "nullable": true
+            },
+            "constructionDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionDesign"
+              },
+              "nullable": true
+            },
+            "buildingInformationModel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingInformationModel"
+              },
+              "nullable": true
+            },
+            "specialDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SpecialDesign"
+              },
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            },
+            "partitionReason": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+              ],
+              "type": "string"
+            },
+            "partitionDescription": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "civilDefenceShelter": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CivilDefenceShelter"
+              },
+              "nullable": true
+            },
+            "relatedFinishedBuildingSection": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
+            },
+            "demolitionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "reasonForDemolition": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+              ],
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationConstructionAction": {
+          "type": "object",
+          "properties": {
+            "constructionActionKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "constructionActionType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+              ],
+              "type": "string",
+              "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+              "nullable": true
+            },
+            "buildingObjectChange": {
+              "required": [
+                "buildingObjectChangeKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectChange"
+                }
+              ],
+              "description": "Rakennuskohteen muutos",
+              "nullable": true
+            },
+            "descriptionOfAction": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "areaUndergoingChanges": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "reasonForDemolition": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+              ],
+              "type": "string",
+              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+              "nullable": true
+            },
+            "renovation": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "renovationRate": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "building": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
+                }
+              ],
+              "nullable": true
+            },
+            "structure": {
+              "required": [
+                "structureMainPurpose",
+                "buildingObjectType",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationStructure"
+                }
+              ],
+              "nullable": true
+            },
+            "areaToBeBuiltForSpecificActivities": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+                }
+              ],
+              "nullable": true
+            },
+            "startDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "completionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "commissioningDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "statusOfConstructionAction": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+              ],
+              "type": "string",
+              "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+              "nullable": true
+            },
+            "fullyApprovedForUse": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "businessConstruction": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "changeType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+              ],
+              "type": "string",
+              "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+              "nullable": true
+            },
+            "dvvPermitIdentifier": {
+              "type": "string",
+              "nullable": true
+            },
+            "expiryDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "locatedOnUnseparatedParcel": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangeInformationStructure": {
+          "required": [
+            "buildingObjectOwner",
+            "buildingObjectType",
+            "structureMainPurpose"
+          ],
+          "type": "object",
+          "properties": {
+            "structureKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permanentStructureIdentifier": {
+              "type": "string"
+            },
+            "temporary": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "demolitionDeadline": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "numberOfStoreys": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "structureSection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/StructureSection"
+              },
+              "nullable": true
+            },
+            "structureMainPurpose": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+              ],
+              "type": "string",
+              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot",
+              "nullable": true
+            },
+            "administrativeLocationUnit": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+                }
+              ]
+            },
+            "decisionAdministrativeLocationUnit": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+                }
+              ],
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "description": "Rakennuskohteen omistaja",
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ChangePermit": {
+          "required": [
+            "changePermitKey",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "acceptedDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AcceptedDeviation"
+              },
+              "nullable": true
+            },
+            "permitRegulation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PermitRegulation"
+              },
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+            },
+            "decisionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfValidityOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "decisionDocument": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
+                }
+              ],
+              "description": "Liiteasiakirja",
+              "nullable": true
+            },
+            "decisionArticle": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "publicNoticeDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "decisionText": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "guidingStatute": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GuidingStatute"
+              },
+              "nullable": true
+            },
+            "relatedPermit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "decisionMakerType": {
+              "type": "string",
+              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+              "nullable": true
+            },
+            "decisionMakerFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "decisionMakerName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "changePermitKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Muutospäätös"
+        },
+        "CivilDefenceShelter": {
+          "required": [
+            "civilDefenceShelterCapacity",
+            "civilDefenceShelterClass",
+            "civilDefenceShelterKey",
+            "civilDefenceShelterShared"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "geometry": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "civilDefenceShelterKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "civilDefenceShelterClass": {
+              "type": "string",
+              "description": "Väestönsuojan luokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka\">http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka</a>",
+              "nullable": true
+            },
+            "civilDefenceShelterCapacity": {
+              "type": "integer",
+              "description": "Väestönsuojan suojapaikkojen määrä",
+              "format": "int32"
+            },
+            "civilDefenceShelterShared": {
+              "type": "boolean"
+            },
+            "civilDefenceShelterAdditionalInformation": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "civilDefenceShelterOtherBuildings": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CivilDefenceShelterOtherBuildings"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Väestönsuoja"
+        },
+        "CivilDefenceShelterOtherBuildings": {
+          "required": [
+            "civilDefenceShelterOtherBuildingsKey",
+            "civilDefenceShelterPointedCapacity",
+            "permanentBuildingIdentifier"
+          ],
+          "type": "object",
+          "properties": {
+            "civilDefenceShelterOtherBuildingsKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permanentBuildingIdentifier": {
+              "type": "string"
+            },
+            "civilDefenceShelterPointedCapacity": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Väestönsuojan muut rakennukset"
+        },
+        "ConstructionAction": {
+          "required": [
+            "constructionActionKey",
+            "constructionActionType",
+            "statusOfConstructionAction"
+          ],
+          "type": "object",
+          "properties": {
+            "constructionActionKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "constructionActionType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+              ],
+              "type": "string",
+              "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+              "nullable": true
+            },
+            "buildingObjectChange": {
+              "required": [
+                "buildingObjectChangeKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectChange"
+                }
+              ],
+              "description": "Rakennuskohteen muutos",
+              "nullable": true
+            },
+            "descriptionOfAction": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "areaUndergoingChanges": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "reasonForDemolition": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+              ],
+              "type": "string",
+              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+              "nullable": true
+            },
+            "renovation": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "renovationRate": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "building": {
+              "required": [
+                "buildingKey",
+                "numberOfStoreys",
+                "mainPurpose",
+                "buildingObjectType",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Building"
+                }
+              ],
+              "description": "Rakennuksen tiedot.",
+              "nullable": true
+            },
+            "finishedBuilding": {
+              "required": [
+                "buildingKey",
+                "numberOfStoreys",
+                "mainPurpose",
+                "buildingObjectType",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Building"
+                }
+              ],
+              "description": "Rakennuksen tiedot.",
+              "nullable": true
+            },
+            "structure": {
+              "required": [
+                "structureKey",
+                "permanentStructureIdentifier",
+                "structureMainPurpose",
+                "buildingObjectType",
+                "administrativeLocationUnit",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              ],
+              "description": "Rakennelma",
+              "nullable": true
+            },
+            "finishedStructure": {
+              "required": [
+                "structureKey",
+                "permanentStructureIdentifier",
+                "structureMainPurpose",
+                "buildingObjectType",
+                "administrativeLocationUnit",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              ],
+              "description": "Rakennelma",
+              "nullable": true
+            },
+            "areaToBeBuiltForSpecificActivities": {
+              "required": [
+                "areaToBeBuiltForSpecificActivitiesKey",
+                "buildingObjectType",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+                }
+              ],
+              "description": "Erityistä toimintaa varten rakennettava alue",
+              "nullable": true
+            },
+            "startDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "completionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "commissioningDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "statusOfConstructionAction": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+              ],
+              "type": "string",
+              "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+              "nullable": true
+            },
+            "fullyApprovedForUse": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "businessConstruction": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "changeType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+              ],
+              "type": "string",
+              "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+              "nullable": true
+            },
+            "dvvPermitIdentifier": {
+              "type": "string",
+              "nullable": true
+            },
+            "expiryDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "finishedAreaToBeBuiltForSpecificActivities": {
+              "required": [
+                "areaToBeBuiltForSpecificActivitiesKey",
+                "buildingObjectType",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+                }
+              ],
+              "description": "Erityistä toimintaa varten rakennettava alue",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakentamistoimenpide"
+        },
+        "ConstructionDesign": {
+          "required": [
+            "constructionDesignKey",
+            "constructionDesignType",
+            "document"
+          ],
+          "type": "object",
+          "properties": {
+            "constructionDesignKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "constructionDesignType": {
+              "type": "string",
+              "description": "Rakennusssuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/raksuunlajit\">http://uri.suomi.fi/codelist/rytj/raksuunlajit</a>"
+            },
+            "document": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennussuunnitelma"
+        },
+        "ConstructionProject": {
+          "required": [
+            "constructionProjectKey"
+          ],
+          "type": "object",
+          "properties": {
+            "constructionProjectKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "descriptionOfConstructionProject": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "startDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "endDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "planner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Planner"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "foreman": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Foreman"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "inspection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Inspection"
+              },
+              "description": "",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakentamishanke"
+        },
+        "ContactAddress": {
+          "required": [
+            "addressKey"
+          ],
+          "type": "object",
+          "properties": {
+            "addressKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "addressName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "numberPartOfAddressNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "subdivisionLetterOfAddressNumber": {
+              "type": "string",
+              "nullable": true
+            },
+            "postalCode": {
+              "type": "string",
+              "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
+              "nullable": true
+            },
+            "location": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "numberPartOfAddressNumber2": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "subdivisionLetterOfAddressNumber2": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentIdentifierLetterSuffix": {
+              "type": "string",
+              "nullable": true
+            },
+            "apartmentIdentifierNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "apartmentIdentifierSubdivisionLetter": {
+              "type": "string",
+              "nullable": true
+            },
+            "additionalAddressAttribute": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "c_O": {
+              "type": "string",
+              "nullable": true
+            },
+            "poBoxAddress": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "countryCode": {
+              "type": "string",
+              "description": "Maakoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
+              "nullable": true
+            },
+            "foreignAddress": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "foreignPostalAddress": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "additionalForeignAddress": {
+              "type": "string",
+              "nullable": true
+            },
+            "postalAddress": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "contactAddressType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/03",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/04",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/05",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/06",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/07",
+                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/08"
+              ],
+              "type": "string",
+              "description": "Yhteysosoitteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji\">http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji</a>"
+            },
+            "source": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/01",
+                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/02",
+                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/03",
+                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/04"
+              ],
+              "type": "string",
+              "description": "Tietolähde. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tietolahde\">http://uri.suomi.fi/codelist/rytj/tietolahde</a>"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Yhteysosoite"
+        },
+        "CoolingEnergySource": {
+          "required": [
+            "coolingEnergySourceKey",
+            "coolingEnergySourceType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "coolingEnergySourceKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "coolingEnergySourceType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/01",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/02",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/03",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/04",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/05",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/06",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/07",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/08"
+              ],
+              "type": "string",
+              "description": "Jäähdytysenergian lähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytys\">http://uri.suomi.fi/codelist/rytj/jaahdytys</a>"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Jäähdytysenergian lähde"
+        },
+        "CoolingMethod": {
+          "required": [
+            "coolingMethodKey",
+            "coolingMethodType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "coolingMethodKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "coolingMethodType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/01",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/02",
+                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/03"
+              ],
+              "type": "string",
+              "description": "Jäähdytystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytystapa\">http://uri.suomi.fi/codelist/rytj/jaahdytystapa</a>"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Jäähdytystapa"
+        },
+        "DemolitionPermitApplication": {
+          "required": [
+            "applicationContent",
+            "demolitionPermitApplicationKey",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+              ],
+              "type": "string",
+              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+              "nullable": true
+            },
+            "applicationContent": {
+              "type": "string"
+            },
+            "dateOfReception": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "callForDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CallForDeviation"
+              },
+              "nullable": true
+            },
+            "demolitionPermitApplicationKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permitApplicationType": {
+              "type": "string",
+              "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "PurkamislupaHakemus"
+        },
+        "DemolitionPermitDecision": {
+          "required": [
+            "demolitionPermitDecisionKey",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "acceptedDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AcceptedDeviation"
+              },
+              "nullable": true
+            },
+            "permitRegulation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PermitRegulation"
+              },
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+            },
+            "decisionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfValidityOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "decisionDocument": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
+                }
+              ],
+              "description": "Liiteasiakirja",
+              "nullable": true
+            },
+            "decisionArticle": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "publicNoticeDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "decisionText": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "guidingStatute": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GuidingStatute"
+              },
+              "nullable": true
+            },
+            "relatedPermit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "decisionMakerType": {
+              "type": "string",
+              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+              "nullable": true
+            },
+            "decisionMakerFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "decisionMakerName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "demolitionPermitDecisionKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permitApplicationType": {
+              "type": "string",
+              "nullable": true
+            },
+            "constructionToBeStartedBy": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "constructionToBeCompletedBy": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "constructionToBeStartedByExtension": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "constructionToBeCompletedByExtension": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "engagingParty": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EngagingParty"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakentamislupapäätös"
+        },
+        "DemolitionPermitIssue": {
+          "required": [
+            "demolitionDecision",
+            "demolitionPermitApplication",
+            "lifeCycleState",
+            "municipalityNumber"
+          ],
+          "type": "object",
+          "properties": {
+            "dateOfInitiation": {
+              "type": "string",
+              "description": "Vireilletulopäivä",
+              "format": "date",
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+              "nullable": true
+            },
+            "municipalityNumber": {
+              "type": "string"
+            },
+            "demolitionPermitApplication": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DemolitionPermitApplication"
+              },
+              "description": "Purkamislupahakemus",
+              "nullable": true
+            },
+            "demolitionDecision": {
+              "required": [
+                "demolitionPermitDecisionKey",
+                "lifeCycleState"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DemolitionPermitDecision"
+                }
+              ],
+              "description": "Purkamislupapäätös",
+              "nullable": true
+            },
+            "extensionDecision": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ExtensionDecision"
+              },
+              "nullable": true
+            },
+            "changePermit": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ChangePermit"
+              },
+              "nullable": true
+            },
+            "buildingSite": {
+              "required": [
+                "stormWaterTreatmentType",
+                "tenure"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingSite"
+                }
+              ],
+              "description": "Rakennuspaikka",
+              "nullable": true
+            },
+            "constructionAction": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionAction"
+              },
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            },
+            "constructionProject": {
+              "required": [
+                "constructionProjectKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ConstructionProject"
+                }
+              ],
+              "description": "Rakentamishanke",
+              "nullable": true
+            },
+            "updateType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+              ],
+              "type": "string",
+              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+              "nullable": true
+            },
+            "updateDescription": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "permanentPermitIdentifier": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Purkamislupa-asia"
+        },
+        "DemolitionPermitIssueChangeDiffDto": {
+          "type": "object",
+          "properties": {
+            "changeType": {
+              "type": "string"
+            },
+            "objectKey": {
+              "nullable": true
+            },
+            "objectType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentKey": {
+              "nullable": true
+            },
+            "parentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentChain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ParentTypeKey"
+              }
+            },
+            "objectState": {
+              "required": [
+                "demolitionPermitApplication",
+                "demolitionDecision",
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DemolitionPermitIssue"
+                }
+              ],
+              "description": "Purkamislupa-asia",
+              "nullable": true
+            },
+            "objectStatePrev": {
+              "required": [
+                "demolitionPermitApplication",
+                "demolitionDecision",
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DemolitionPermitIssue"
+                }
+              ],
+              "description": "Purkamislupa-asia",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DemolitionPermitIssueChangeInfoCollectionDto": {
+          "type": "object",
+          "properties": {
+            "lastSeen": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PaginationToken"
+                }
+              ],
+              "nullable": true
+            },
+            "upToDate": {
+              "type": "boolean"
+            },
+            "changes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoDto"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "DemolitionPermitIssueChangeInfoDto": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "eventTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "objectKey": { },
+            "objectState": {
+              "required": [
+                "demolitionPermitApplication",
+                "demolitionDecision",
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DemolitionPermitIssue"
+                }
+              ],
+              "description": "Purkamislupa-asia",
+              "nullable": true
+            },
+            "diff": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DemolitionPermitIssueChangeDiffDto"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Descriptor": {
+          "type": "object",
+          "properties": {
+            "descriptorIdentifier": {
+              "type": "string",
+              "nullable": true
+            },
+            "vocabulary": {
+              "type": "string",
+              "nullable": true
+            },
+            "descriptor": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DeviationObject": {
+          "required": [
+            "address",
+            "buildingObjectOwner",
+            "deviationObjectKey"
+          ],
+          "type": "object",
+          "properties": {
+            "deviationObjectKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+            },
+            "totalArea": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot"
+            },
+            "administrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö"
+            },
+            "decisionAdministrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö",
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "description": "Rakennuskohteen omistaja"
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              }
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Poikkeamisen kohde"
+        },
+        "DeviationPermitApplication": {
+          "required": [
+            "applicationContent",
+            "constructionDesign",
+            "deviationPermitApplicationKey",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+              ],
+              "type": "string",
+              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+              "nullable": true
+            },
+            "applicationContent": {
+              "type": "string"
+            },
+            "dateOfReception": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "callForDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CallForDeviation"
+              },
+              "nullable": true
+            },
+            "deviationPermitApplicationKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "buildingInformationModel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingInformationModel"
+              }
+            },
+            "constructionDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionDesign"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "description": "Poikkeamislupahakemus"
+        },
+        "DeviationPermitDecision": {
+          "required": [
+            "decisionInForceUntil",
+            "deviationPermitDecisionKey",
+            "engagingParty",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "acceptedDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AcceptedDeviation"
+              },
+              "nullable": true
+            },
+            "permitRegulation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PermitRegulation"
+              },
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+            },
+            "decisionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfValidityOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "decisionDocument": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
+                }
+              ],
+              "description": "Liiteasiakirja",
+              "nullable": true
+            },
+            "decisionArticle": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "publicNoticeDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "decisionText": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "guidingStatute": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GuidingStatute"
+              },
+              "nullable": true
+            },
+            "relatedPermit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "decisionMakerType": {
+              "type": "string",
+              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+              "nullable": true
+            },
+            "decisionMakerFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "decisionMakerName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "deviationPermitDecisionKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "expiryDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "engagingParty": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EngagingParty"
+              },
+              "description": ""
+            },
+            "decisionInForceUntil": {
+              "type": "string",
+              "description": "",
+              "format": "date"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Poikkeamislupapäätös"
+        },
+        "DeviationPermitIssue": {
+          "required": [
+            "deviationPermitApplication",
+            "deviationPermitDecision",
+            "lifeCycleState",
+            "municipalityNumber",
+            "permanentPermitIdentifier"
+          ],
+          "type": "object",
+          "properties": {
+            "dateOfInitiation": {
+              "type": "string",
+              "description": "Vireilletulopäivä",
+              "format": "date",
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+              "nullable": true
+            },
+            "municipalityNumber": {
+              "type": "string"
+            },
+            "permanentPermitIdentifier": {
+              "type": "string"
+            },
+            "recordNumber": {
+              "type": "string"
+            },
+            "deviationPermitDecision": {
+              "required": [
+                "deviationPermitDecisionKey",
+                "engagingParty",
+                "decisionInForceUntil",
+                "lifeCycleState"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DeviationPermitDecision"
+                }
+              ],
+              "description": "Poikkeamislupapäätös"
+            },
+            "deviationPermitApplication": {
+              "required": [
+                "deviationPermitApplicationKey",
+                "constructionDesign",
+                "lifeCycleState",
+                "applicationContent"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DeviationPermitApplication"
+                }
+              ],
+              "description": "Poikkeamislupahakemus"
+            },
+            "deviationObject": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DeviationObject"
+              }
+            },
+            "buildingSite": {
+              "required": [
+                "stormWaterTreatmentType",
+                "tenure"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingSite"
+                }
+              ],
+              "description": "Rakennuspaikka"
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "nullable": true
+            },
+            "updateType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+              ],
+              "type": "string",
+              "nullable": true
+            },
+            "updateDescription": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Poikkeamislupa-asia"
+        },
+        "DeviationPermitIssueChangeDiffDto": {
+          "type": "object",
+          "properties": {
+            "changeType": {
+              "type": "string"
+            },
+            "objectKey": {
+              "nullable": true
+            },
+            "objectType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentKey": {
+              "nullable": true
+            },
+            "parentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentChain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ParentTypeKey"
+              }
+            },
+            "objectState": {
+              "required": [
+                "permanentPermitIdentifier",
+                "deviationPermitDecision",
+                "deviationPermitApplication",
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              ],
+              "description": "Poikkeamislupa-asia",
+              "nullable": true
+            },
+            "objectStatePrev": {
+              "required": [
+                "permanentPermitIdentifier",
+                "deviationPermitDecision",
+                "deviationPermitApplication",
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              ],
+              "description": "Poikkeamislupa-asia",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DeviationPermitIssueChangeInfoCollectionDto": {
+          "type": "object",
+          "properties": {
+            "lastSeen": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PaginationToken"
+                }
+              ],
+              "nullable": true
+            },
+            "upToDate": {
+              "type": "boolean"
+            },
+            "changes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoDto"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "DeviationPermitIssueChangeInfoDto": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "eventTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "objectKey": { },
+            "objectState": {
+              "required": [
+                "permanentPermitIdentifier",
+                "deviationPermitDecision",
+                "deviationPermitApplication",
+                "lifeCycleState",
+                "municipalityNumber"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              ],
+              "description": "Poikkeamislupa-asia",
+              "nullable": true
+            },
+            "diff": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DeviationPermitIssueChangeDiffDto"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ElectricalEnergySource": {
+          "required": [
+            "electricalEnergySourceKey",
+            "electricalEnergySourceType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "electricalEnergySourceKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "electricalEnergySourceType": {
+              "type": "string",
+              "description": "Sähköenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde\">http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde</a>"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Sähköenergian lähde"
+        },
+        "Elevator": {
+          "required": [
+            "elevatorKey",
+            "elevatorType",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "geometry": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "elevatorKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "elevatorType": {
+              "type": "string",
+              "description": "Hissin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hissi\">http://uri.suomi.fi/codelist/rytj/hissi</a>"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
+              ],
+              "type": "string",
+              "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
+              "nullable": true
+            },
+            "insideLength": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "insideWidth": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "doorOpeningWidth": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "doorOpeningHeight": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "passengerCapacity": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "loadCapacity": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Hissi"
+        },
+        "EnergyData": {
+          "required": [
+            "energyDataKey"
+          ],
+          "type": "object",
+          "properties": {
+            "energyDataKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "energyRating": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/04",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/05",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/06",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/07",
+                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/08"
+              ],
+              "type": "string",
+              "description": "Energialuokka. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Energialuokka",
+              "nullable": true
+            },
+            "computationalEnergyEfficiencyComparand": {
+              "type": "number",
+              "description": "",
+              "format": "double",
+              "nullable": true
+            },
+            "heatingMethod": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/HeatingMethod"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "heatingEnergySource": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/HeatingEnergySource"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "coolingMethod": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CoolingMethod"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "coolingEnergySource": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CoolingEnergySource"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "electricalEnergySource": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ElectricalEnergySource"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "netHeatedArea": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "heatedVolume": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "calculatoryDeliveredEnergyUsage": {
+              "required": [
+                "calculatoryDeliveredEnergyUsageKey",
+                "deliveredEnergyType",
+                "energyAmountYearly"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/CalculatoryDeliveredEnergyUsage"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "energyRatingSubindex": {
+              "type": "string",
+              "description": "Energiatehokkuusluokan alaindeksi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Energiatiedot"
+        },
+        "EngagingParty": {
+          "required": [
+            "engagingPartyKey",
+            "isPerson"
+          ],
+          "type": "object",
+          "properties": {
+            "engagingPartyKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "personalIdentityCode": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "businessId": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "otherId": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "isPerson": {
+              "type": "boolean",
+              "description": ""
+            },
+            "firstName": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "familyName": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "organizationName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "applicantContactOperator": {
+              "required": [
+                "isPerson"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Operator"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "languageCode": {
+              "type": "string",
+              "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
+              "nullable": true
+            },
+            "nationalityCode": {
+              "type": "string",
+              "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
+              "nullable": true
+            },
+            "deathDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Hankkeeseen ryhtyvä"
+        },
+        "Entrance": {
+          "required": [
+            "entranceKey",
+            "entranceType",
+            "isPrimary",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "geometry": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "entranceKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            },
+            "entranceType": {
+              "type": "string",
+              "description": "Sisäänkäynnin tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sisaankaynti\">http://uri.suomi.fi/codelist/rytj/sisaankaynti</a>"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
+                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
+              ],
+              "type": "string",
+              "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
+              "nullable": true
+            },
+            "addressOfEntrance": {
+              "type": "string",
+              "nullable": true
+            },
+            "isAccessible": {
+              "type": "boolean",
+              "description": "Kerrosluku"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Sisäänkäynti"
+        },
+        "Equipment": {
+          "required": [
+            "equipmentKey",
+            "equipmentType"
+          ],
+          "type": "object",
+          "properties": {
+            "equipmentKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "equipmentType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/01",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/02",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/03",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/04",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/05",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/06",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/07",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/08",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/09",
+                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/10"
+              ],
+              "type": "string",
+              "description": "Rakennuksen varuste. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rakennusvaruste"
+            },
+            "equipmentCount": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Varuste"
+        },
+        "ExtensionDecision": {
+          "required": [
+            "extensionDecisionKey",
+            "lifeCycleState"
+          ],
+          "type": "object",
+          "properties": {
+            "acceptedDeviation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AcceptedDeviation"
+              },
+              "nullable": true
+            },
+            "permitRegulation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PermitRegulation"
+              },
+              "nullable": true
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+              ],
+              "type": "string",
+              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+            },
+            "decisionDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "dateOfValidityOfDecision": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "decisionDocument": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
+                }
+              ],
+              "description": "Liiteasiakirja",
+              "nullable": true
+            },
+            "decisionArticle": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "publicNoticeDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "decisionText": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "guidingStatute": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GuidingStatute"
+              },
+              "nullable": true
+            },
+            "relatedPermit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "decisionMakerType": {
+              "type": "string",
+              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+              "nullable": true
+            },
+            "decisionMakerFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "decisionMakerName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "extensionDecisionKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Jatkoaikapäätös"
+        },
+        "ExteriorData": {
+          "required": [
+            "shape"
+          ],
+          "type": "object",
+          "properties": {
+            "numberOfStoreys": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "height": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "flightObstacle": {
+              "type": "boolean",
+              "description": "",
+              "nullable": true
+            },
+            "shape": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "description": ""
+            },
+            "relationToGroundLevel": {
+              "type": "string",
+              "description": "Suhde maan pintaan. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Suhde_pintaan",
+              "nullable": true
+            },
+            "volume": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "grossFloorArea": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "permittedBuildingArea": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            },
+            "totalArea": {
+              "type": "integer",
+              "description": "",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Ulkokuoren tiedot"
+        },
+        "FacadeMaterial": {
+          "required": [
+            "facadeMaterialKey",
+            "facadeMaterialType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "facadeMaterialKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "facadeMaterialType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/00",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/01",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/02",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/03",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/04",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/05",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/06",
+                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/99"
+              ],
+              "type": "string",
+              "description": "Julkisivun rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine\">http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine</a>"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Julkisivumateriaali"
+        },
+        "Foreman": {
+          "required": [
+            "familyName",
+            "firstName",
+            "foremanKey"
+          ],
+          "type": "object",
+          "properties": {
+            "foremanKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "foremanRole": {
+              "type": "string",
+              "description": "Työnjohtajan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli\">http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli</a>"
+            },
+            "foremanCompetence": {
+              "type": "string",
+              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+            },
+            "responsibilityStartDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "responsibilityEndDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "buildingReference": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ForemanBuildingReference"
+              },
+              "nullable": true
+            },
+            "structureReference": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ForemanStructureReference"
+              },
+              "nullable": true
+            },
+            "specificAreaReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            },
+            "requiredCompetence": {
+              "type": "string",
+              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+            },
+            "personalIdentityCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "otherId": {
+              "type": "string",
+              "nullable": true
+            },
+            "firstName": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Työnjohtaja"
+        },
+        "ForemanBuildingReference": {
+          "required": [
+            "permanentBuildingIdentifierReference"
+          ],
+          "type": "object",
+          "properties": {
+            "permanentBuildingIdentifierReference": {
+              "type": "string"
+            },
+            "buildingSectionReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennusviite"
+        },
+        "ForemanStructureReference": {
+          "required": [
+            "permanentStructureIdentifierReference"
+          ],
+          "type": "object",
+          "properties": {
+            "permanentStructureIdentifierReference": {
+              "type": "string"
+            },
+            "buildingSectionReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennelmaviite"
+        },
+        "GeoJsonGeometry": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Tuetut geometriatyypit"
+            }
+          },
+          "additionalProperties": false,
+          "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
+        },
+        "GeoJsonLineStringGeometry": {
+          "required": [
+            "coordinates",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
+          ],
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "format": "double"
+                }
+              },
+              "description": "Koordinaatit",
+              "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+            },
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+            }
+          },
+          "additionalProperties": false,
+          "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+        },
+        "GeoJsonMultiLineStringGeometry": {
+          "required": [
+            "coordinates",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
+          ],
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                }
+              },
+              "description": "Koordinaatit",
+              "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
+            },
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+            }
+          },
+          "additionalProperties": false,
+          "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+        },
+        "GeoJsonMultiPointGeometry": {
+          "required": [
+            "coordinates",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
+          ],
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "format": "double"
+                }
+              },
+              "description": "Koordinaatit",
+              "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+            },
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
+            }
+          },
+          "additionalProperties": false,
+          "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+        },
+        "GeoJsonMultiPolygonGeometry": {
+          "required": [
+            "coordinates",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
+          ],
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number",
+                      "format": "double"
+                    }
+                  }
+                }
+              },
+              "description": "Koordinaatit",
+              "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
+            },
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
+            }
+          },
+          "additionalProperties": false,
+          "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+        },
+        "GeoJsonPointGeometry": {
+          "required": [
+            "coordinates",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
+          ],
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "description": "Koordinaatit",
+              "example": "[100.0, 0.0]"
+            },
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
+            }
+          },
+          "additionalProperties": false,
+          "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+        },
+        "GeoJsonPolygonGeometry": {
+          "required": [
+            "coordinates",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/GeoJsonGeometry"
+            }
+          ],
+          "properties": {
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                }
+              },
+              "description": "Koordinaatit",
+              "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+            },
+            "type": {
+              "enum": [
+                "Point",
+                "MultiPoint",
+                "LineString",
+                "MultiLineString",
+                "Polygon",
+                "MultiPolygon"
+              ],
+              "type": "string",
+              "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
+            }
+          },
+          "additionalProperties": false,
+          "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+        },
+        "GetChangeInfo": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
+            },
+            "objectKey": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GetInitialInfo": {
+          "type": "object",
+          "properties": {
+            "lastObjectKey": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GuidingStatute": {
+          "required": [
+            "guidingStatuteKey"
+          ],
+          "type": "object",
+          "properties": {
+            "guidingStatuteKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "statuteName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "statuteCollectionNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "statuteCollectionYear": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "chapter": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "section": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "subSection": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "paragraph": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "subParagraph": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Säädösviite"
+        },
+        "HealthReport": {
+          "type": "object",
+          "properties": {
+            "status": {
+              "enum": [
+                "Unhealthy",
+                "Degraded",
+                "Healthy"
+              ],
+              "type": "string",
+              "readOnly": true
+            },
+            "totalDuration": {
+              "type": "string",
+              "format": "date-span",
+              "readOnly": true
+            },
+            "entries": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/HealthReportEntry"
+              },
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "HealthReportEntry": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "type": "string",
+              "format": "date-span",
+              "readOnly": true
+            },
+            "status": {
+              "enum": [
+                "Unhealthy",
+                "Degraded",
+                "Healthy"
+              ],
+              "type": "string",
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "HeatingEnergySource": {
+          "required": [
+            "heatingEnergySourceKey",
+            "heatingEnergySourceType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "heatingEnergySourceKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "heatingEnergySourceType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/01",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/02",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/03",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/04",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/05",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/06",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/07",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/08",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/09",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/10",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/11",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1101",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1102",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1103",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1104",
+                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/99"
+              ],
+              "type": "string",
+              "description": "Lämmitysenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde\">http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde</a>",
+              "nullable": true
+            },
+            "isPrimary": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Lämmitysenergianlähde"
+        },
+        "HeatingMethod": {
+          "required": [
+            "heatingMethodKey",
+            "heatingMethodType",
+            "isPrimary"
+          ],
+          "type": "object",
+          "properties": {
+            "heatingMethodKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "heatingMethodType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/01",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/02",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/03",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/04",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/05",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/06",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/07",
+                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/99"
+              ],
+              "type": "string",
+              "description": "Lämmitystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitystapa\">http://uri.suomi.fi/codelist/rytj/lammitystapa</a>",
+              "nullable": true
+            },
+            "isPrimary": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Lämmitystapa"
+        },
+        "InitialInformationCollection": {
+          "type": "object",
+          "properties": {
+            "next": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InitialInformationNextInfo"
+                }
+              ],
+              "nullable": true
+            },
+            "eventId": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
+            },
+            "items": {
+              "type": "array",
+              "items": { }
+            }
+          },
+          "additionalProperties": false
+        },
+        "InitialInformationNextInfo": {
+          "type": "object",
+          "properties": {
+            "lastObjectKey": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Inspection": {
+          "required": [
+            "inspectionCarriedOutByFirstName",
+            "inspectionCarriedOutByLastName",
+            "inspectionDate",
+            "inspectionKey",
+            "inspectionType",
+            "personsPresent",
+            "requiredByPermitRegulations"
+          ],
+          "type": "object",
+          "properties": {
+            "inspectionKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "inspectionType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
+                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
+              ],
+              "type": "string",
+              "description": ""
+            },
+            "inspectionDate": {
+              "type": "string",
+              "description": "",
+              "format": "date"
+            },
+            "requiredByPermitRegulations": {
+              "type": "boolean",
+              "description": ""
+            },
+            "partiality": {
+              "type": "string",
+              "description": ""
+            },
+            "inspectionStatus": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
+                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
+                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
+              ],
+              "type": "string",
+              "description": ""
+            },
+            "buildingReference": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/InspectionBuildingReference"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "structureReference": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/InspectionStructureReference"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "specificAreaReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "buildingObjectChange": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "specificationOfObjectOfInspection": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "inspectionRemarks": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "inspectionCarriedOutByFirstName": {
+              "type": "string",
+              "description": ""
+            },
+            "inspectionCarriedOutByLastName": {
+              "type": "string",
+              "description": ""
+            },
+            "personsPresent": {
+              "type": "string",
+              "description": ""
+            },
+            "buildingsAttachmentDocument": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "description": "",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Katselmus"
+        },
+        "InspectionBuildingReference": {
+          "required": [
+            "permanentBuildingIdentifierReference"
+          ],
+          "type": "object",
+          "properties": {
+            "permanentBuildingIdentifierReference": {
+              "type": "string"
+            },
+            "buildingSectionReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "InspectionStructureReference": {
+          "required": [
+            "permanentStructureIdentifierReference"
+          ],
+          "type": "object",
+          "properties": {
+            "permanentStructureIdentifierReference": {
+              "type": "string"
+            },
+            "buildingSectionReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "InteriorData": {
+          "type": "object",
+          "properties": {
+            "floorArea": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "basementArea": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Sisätilojen tiedot"
+        },
+        "LanguageString": {
+          "type": "object",
+          "properties": {
+            "fin": {
+              "type": "string",
+              "description": "suomi",
+              "nullable": true
+            },
+            "swe": {
+              "type": "string",
+              "description": "ruotsi",
+              "nullable": true
+            },
+            "smn": {
+              "type": "string",
+              "description": "inarinsaame",
+              "nullable": true
+            },
+            "sms": {
+              "type": "string",
+              "description": "koltansaame",
+              "nullable": true
+            },
+            "sme": {
+              "type": "string",
+              "description": "pohjoissaame",
+              "nullable": true
+            },
+            "eng": {
+              "type": "string",
+              "description": "englanti",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+        },
+        "MaterialData": {
+          "required": [
+            "buildingMaterialOfLoadBearingStructures",
+            "constructionMethod",
+            "facadeMaterial",
+            "wideBodiedBuilding"
+          ],
+          "type": "object",
+          "properties": {
+            "constructionMethod": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/01",
+                "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/02"
+              ],
+              "type": "string",
+              "description": "Rakentamistapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_runkotapa\">http://uri.suomi.fi/codelist/vtj/Rake_runkotapa</a>",
+              "nullable": true
+            },
+            "buildingMaterialOfLoadBearingStructures": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingMaterialOfLoadBearingStructures"
+              },
+              "description": "Kantavien rakenteiden rakennusaine"
+            },
+            "facadeMaterial": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/FacadeMaterial"
+              }
+            },
+            "fireClass": {
+              "type": "string",
+              "description": "Paloluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Paloluokka\">http://uri.suomi.fi/codelist/rytj/Paloluokka</a>",
+              "nullable": true
+            },
+            "wideBodiedBuilding": {
+              "type": "boolean"
+            },
+            "reusableMaterialAmount": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Materiaalitiedot"
+        },
+        "NetworkConnection": {
+          "required": [
+            "networkConnectionKey",
+            "networkConnectionType"
+          ],
+          "type": "object",
+          "properties": {
+            "networkConnectionKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "networkConnectionType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/01",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/02",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/03",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/04",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/05",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/06",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/07",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/08",
+                "http://uri.suomi.fi/codelist/rytj/verkliit/code/09"
+              ],
+              "type": "string",
+              "description": "Verkostoliittymän laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/verkliit\">http://uri.suomi.fi/codelist/rytj/verkliit</a>",
+              "nullable": true
+            },
+            "connected": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "connectionPoint": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Verkostoliittymä"
+        },
+        "Operator": {
+          "required": [
+            "isPerson"
+          ],
+          "type": "object",
+          "properties": {
+            "personalIdentityCode": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "businessId": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "otherId": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "isPerson": {
+              "type": "boolean",
+              "description": ""
+            },
+            "firstName": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "familyName": {
+              "type": "string",
+              "description": "",
+              "nullable": true
+            },
+            "organizationName": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "operatorAddress": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ContactAddress"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "languageCode": {
+              "type": "string",
+              "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
+              "nullable": true
+            },
+            "nationalityCode": {
+              "type": "string",
+              "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
+              "nullable": true
+            },
+            "deathDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Toimija"
+        },
+        "OperatorChangeDiffDto": {
+          "type": "object",
+          "properties": {
+            "changeType": {
+              "type": "string"
+            },
+            "objectKey": {
+              "nullable": true
+            },
+            "objectType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentKey": {
+              "nullable": true
+            },
+            "parentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentChain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ParentTypeKey"
+              }
+            },
+            "objectState": {
+              "required": [
+                "isPerson"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Operator"
+                }
+              ],
+              "description": "Toimija",
+              "nullable": true
+            },
+            "objectStatePrev": {
+              "required": [
+                "isPerson"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Operator"
+                }
+              ],
+              "description": "Toimija",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "OperatorChangeInfoCollectionDto": {
+          "type": "object",
+          "properties": {
+            "lastSeen": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PaginationToken"
+                }
+              ],
+              "nullable": true
+            },
+            "upToDate": {
+              "type": "boolean"
+            },
+            "changes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperatorChangeInfoDto"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "OperatorChangeInfoDto": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "eventTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "objectKey": { },
+            "objectState": {
+              "required": [
+                "isPerson"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Operator"
+                }
+              ],
+              "description": "Toimija",
+              "nullable": true
+            },
+            "diff": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperatorChangeDiffDto"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "PaginationToken": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid",
+              "nullable": true
+            },
+            "objectKey": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ParentTypeKey": {
+          "type": "object",
+          "properties": {
+            "parentType": {
+              "type": "string"
+            },
+            "parentKey": { }
+          },
+          "additionalProperties": false
+        },
+        "PermitRegulation": {
+          "required": [
+            "permitRegulationKey",
+            "permitRegulationType"
+          ],
+          "type": "object",
+          "properties": {
+            "permitRegulationKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permitRegulationType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M01",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0101",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0102",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0103",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0104",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0105",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0106",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0107",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0108",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0109",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0110",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M02",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0201",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0202",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M03",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0301",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0302",
+                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M04"
+              ],
+              "type": "string",
+              "description": "Lupamääräys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen\">http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen</a>"
+            },
+            "textOfPermitRegulation": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Lupamääräys"
+        },
+        "Planner": {
+          "required": [
+            "familyName",
+            "firstName",
+            "plannerKey"
+          ],
+          "type": "object",
+          "properties": {
+            "plannerKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "plannerRole": {
+              "type": "string",
+              "description": "Suunnittelijan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli\">http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli</a>"
+            },
+            "plannerCompetence": {
+              "type": "string",
+              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+            },
+            "responsibilityStartDate": {
+              "type": "string",
+              "format": "date"
+            },
+            "responsibilityEndDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "buildingReference": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PlannerBuildingReference"
+              },
+              "nullable": true
+            },
+            "structureReference": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PlannerStructureReference"
+              },
+              "nullable": true
+            },
+            "specificAreaReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            },
+            "requiredCompetence": {
+              "type": "string",
+              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+            },
+            "personalIdentityCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "otherId": {
+              "type": "string",
+              "nullable": true
+            },
+            "firstName": {
+              "type": "string"
+            },
+            "familyName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Suunnittelija"
+        },
+        "PlannerBuildingReference": {
+          "required": [
+            "permanentBuildingIdentifierReference"
+          ],
+          "type": "object",
+          "properties": {
+            "permanentBuildingIdentifierReference": {
+              "type": "string"
+            },
+            "buildingSectionReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "PlannerStructureReference": {
+          "required": [
+            "permanentStructureIdentifierReference"
+          ],
+          "type": "object",
+          "properties": {
+            "permanentStructureIdentifierReference": {
+              "type": "string"
+            },
+            "buildingSectionReference": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ProblemDetails": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "title": {
+              "type": "string",
+              "nullable": true
+            },
+            "status": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "detail": {
+              "type": "string",
+              "nullable": true
+            },
+            "instance": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": { }
+        },
+        "Property": {
+          "required": [
+            "municipalityNumber",
+            "propertyIdentifier",
+            "relationToBaseProperty",
+            "status",
+            "type"
+          ],
+          "type": "object",
+          "properties": {
+            "municipalityNumber": {
+              "type": "string"
+            },
+            "propertyIdentifier": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string",
+              "nullable": true
+            },
+            "status": {
+              "type": "string"
+            },
+            "registrationDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "endDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "landArea": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "geometry": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/RyhtiGeometry"
+                }
+              ],
+              "nullable": true
+            },
+            "type": {
+              "type": "string"
+            },
+            "relationToBaseProperty": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Kiinteistö"
+        },
+        "Purpose": {
+          "required": [
+            "isPrimary",
+            "purposeKey",
+            "type"
+          ],
+          "type": "object",
+          "properties": {
+            "purposeKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+              ],
+              "type": "string",
+              "description": "Käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Käyttötarkoitus"
+        },
+        "RyhtiGeometry": {
+          "required": [
+            "geometry",
+            "srid"
+          ],
+          "type": "object",
+          "properties": {
+            "srid": {
+              "enum": [
+                "3067",
+                "3873",
+                "3874",
+                "3875",
+                "3876",
+                "3877",
+                "3878",
+                "3879",
+                "3880",
+                "3881",
+                "3882",
+                "3883",
+                "3884",
+                "3885"
+              ],
+              "type": "string",
+              "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
+            },
+            "geometry": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/GeoJsonPointGeometry"
+                },
+                {
+                  "$ref": "#/components/schemas/GeoJsonMultiPointGeometry"
+                },
+                {
+                  "$ref": "#/components/schemas/GeoJsonLineStringGeometry"
+                },
+                {
+                  "$ref": "#/components/schemas/GeoJsonMultiLineStringGeometry"
+                },
+                {
+                  "$ref": "#/components/schemas/GeoJsonPolygonGeometry"
+                },
+                {
+                  "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
+                }
+              ],
+              "description": "Geometria GeoJson rakenteella: https://geojson.org/"
+            }
+          },
+          "additionalProperties": false
+        },
+        "SpecialDesign": {
+          "required": [
+            "specialDesignKey",
+            "specialDesignType"
+          ],
+          "type": "object",
+          "properties": {
+            "specialDesignKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "specialDesignType": {
+              "type": "string",
+              "description": "Erityissuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/erityissuun\">http://uri.suomi.fi/codelist/rytj/erityissuun</a>"
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "document": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            }
+          },
+          "additionalProperties": false,
+          "description": "Erityissuunnitelma"
+        },
+        "Structure": {
+          "required": [
+            "administrativeLocationUnit",
+            "buildingObjectOwner",
+            "buildingObjectType",
+            "permanentStructureIdentifier",
+            "structureKey",
+            "structureMainPurpose"
+          ],
+          "type": "object",
+          "properties": {
+            "structureKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "permanentStructureIdentifier": {
+              "type": "string"
+            },
+            "temporary": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "demolitionDeadline": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "numberOfStoreys": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "structureSection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/StructureSection"
+              },
+              "nullable": true
+            },
+            "structureMainPurpose": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+              ],
+              "type": "string",
+              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
+            },
+            "buildingObjectType": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+              ],
+              "type": "string",
+              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+            },
+            "location": {
+              "required": [
+                "buildingObjectLocationDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+                }
+              ],
+              "description": "Rakennuskohteen sijaintitiedot",
+              "nullable": true
+            },
+            "administrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö"
+            },
+            "decisionAdministrativeLocationUnit": {
+              "required": [
+                "administrativeLocationUnitKey",
+                "propertyIdentifier"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+                }
+              ],
+              "description": "Hallinnollinen sijaintiyksikkö",
+              "nullable": true
+            },
+            "buildingObjectOwner": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingObjectOwner"
+              },
+              "description": "Rakennuskohteen omistaja",
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Address"
+              },
+              "nullable": true
+            },
+            "name": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "description": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennelma"
+        },
+        "StructureChangeDiffDto": {
+          "type": "object",
+          "properties": {
+            "changeType": {
+              "type": "string"
+            },
+            "objectKey": {
+              "nullable": true
+            },
+            "objectType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentKey": {
+              "nullable": true
+            },
+            "parentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "parentChain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ParentTypeKey"
+              }
+            },
+            "objectState": {
+              "required": [
+                "structureKey",
+                "permanentStructureIdentifier",
+                "structureMainPurpose",
+                "buildingObjectType",
+                "administrativeLocationUnit",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              ],
+              "description": "Rakennelma",
+              "nullable": true
+            },
+            "objectStatePrev": {
+              "required": [
+                "structureKey",
+                "permanentStructureIdentifier",
+                "structureMainPurpose",
+                "buildingObjectType",
+                "administrativeLocationUnit",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              ],
+              "description": "Rakennelma",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "StructureChangeInfoCollectionDto": {
+          "type": "object",
+          "properties": {
+            "lastSeen": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/PaginationToken"
+                }
+              ],
+              "nullable": true
+            },
+            "upToDate": {
+              "type": "boolean"
+            },
+            "changes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/StructureChangeInfoDto"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "StructureChangeInfoDto": {
+          "type": "object",
+          "properties": {
+            "eventId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "eventTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "objectKey": { },
+            "objectState": {
+              "required": [
+                "structureKey",
+                "permanentStructureIdentifier",
+                "structureMainPurpose",
+                "buildingObjectType",
+                "administrativeLocationUnit",
+                "buildingObjectOwner"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              ],
+              "description": "Rakennelma",
+              "nullable": true
+            },
+            "diff": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/StructureChangeDiffDto"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "StructureSection": {
+          "required": [
+            "lifeCycleState",
+            "partitionReason",
+            "structurePurpose",
+            "structureSectionKey"
+          ],
+          "type": "object",
+          "properties": {
+            "structureSectionKey": {
+              "type": "string",
+              "description": "",
+              "format": "uuid"
+            },
+            "lifeCycleState": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+              ],
+              "type": "string",
+              "description": "Rakennelman elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih"
+            },
+            "completionDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "protectionMethod": {
+              "type": "string",
+              "description": "Rakennelman osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
+              "nullable": true
+            },
+            "cultureHistoricalSignificance": {
+              "type": "string",
+              "description": "Rakennelman osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
+              "nullable": true
+            },
+            "materialData": {
+              "required": [
+                "constructionMethod",
+                "buildingMaterialOfLoadBearingStructures",
+                "facadeMaterial",
+                "wideBodiedBuilding"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/MaterialData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "energyData": {
+              "required": [
+                "energyDataKey"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/EnergyData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "exteriorData": {
+              "required": [
+                "shape"
+              ],
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ExteriorData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "buildingServicesEngineeringData": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+                }
+              ],
+              "description": "",
+              "nullable": true
+            },
+            "structurePurpose": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+              ],
+              "type": "string",
+              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus"
+            },
+            "equipment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Equipment"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "constructionDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ConstructionDesign"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "buildingInformationModel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingInformationModel"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "specialDesign": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SpecialDesign"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "attachment": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              },
+              "description": "",
+              "nullable": true
+            },
+            "partitionReason": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+              ],
+              "type": "string",
+              "description": "Rakennelman osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
+            },
+            "partitionDescription": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LanguageString"
+                }
+              ],
+              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+              "nullable": true
+            },
+            "relatedFinishedStructureSection": {
+              "type": "string",
+              "description": "",
+              "format": "uuid",
+              "nullable": true
+            },
+            "demolitionDate": {
+              "type": "string",
+              "description": "",
+              "format": "date",
+              "nullable": true
+            },
+            "reasonForDemolition": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+              ],
+              "type": "string",
+              "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennelman osa"
+        },
+        "UnseparatedParcel": {
+          "type": "object",
+          "properties": {
+            "municipalityNumber": {
+              "type": "string"
+            },
+            "unseparatedParcelIdentifier": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "registrationDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "endDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "type": {
+              "type": "string"
+            },
+            "relationToBaseProperty": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Määräala"
+        },
+        "UsageData": {
+          "type": "object",
+          "properties": {
+            "commissioningDate": {
+              "type": "string",
+              "format": "date",
+              "nullable": true
+            },
+            "usageStatus": {
+              "enum": [
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
+                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
+              ],
+              "type": "string",
+              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+              "nullable": true
+            },
+            "purpose": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Purpose"
+              },
+              "nullable": true
+            },
+            "usefulFloorArea": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "intendedWorkingLife": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "plannedUserCount": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false,
+          "description": "Rakennuksen käyttötiedot"
+        },
+        "ValidationProblemDetails": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "title": {
+              "type": "string",
+              "nullable": true
+            },
+            "status": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "detail": {
+              "type": "string",
+              "nullable": true
+            },
+            "instance": {
+              "type": "string",
+              "nullable": true
+            },
+            "errors": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": { }
+        },
+        "VentilationMethod": {
+          "required": [
+            "isPrimary",
+            "ventilationMethodKey",
+            "ventilationMethodType"
+          ],
+          "type": "object",
+          "properties": {
+            "ventilationMethodKey": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ventilationMethodType": {
+              "type": "string",
+              "description": "Ilmanvaihtotavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ilmanvaihto\">http://uri.suomi.fi/codelist/rytj/ilmanvaihto</a>"
+            },
+            "isPrimary": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Ilmanvaihtotapa"
         }
+      },
+      "securitySchemes": {
+        "Bearer": {
+          "type": "apiKey",
+          "description": "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\"",
+          "name": "Authorization",
+          "in": "header"
+        },
+        "oauth2": {
+          "type": "oauth2",
+          "flows": {
+            "clientCredentials": {
+              "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
+              "scopes": {
+                "ryhti.changeinformation.read": "Muutostietojen lukuoikeus.",
+                "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
+                "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus",
+                "ryhti.changeinformation.building.owners.all": "Omistajatietojen lukuoikeus, ml turvakiellon alaiset henkilöt.",
+                "ryhti.changeinformation.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia henkilöitä.",
+                "ryhti.changeinformation.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin."
+              }
+            }
+          }
+        }
+      }
     },
     "security": [
-        {
-            "Bearer": []
-        },
-        {
-            "oauth2": []
-        }
+      {
+        "Bearer": [ ]
+      },
+      {
+        "oauth2": [ ]
+      }
     ]
-}
+  }

--- a/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
@@ -1,8943 +1,9932 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "Ryhti API",
-      "description": "<h2>Rakennetun ympäristön OpenApi kuvaukset </h2>\r\nEnsimmäisen vaiheen rakentamisen OpenApi rajapinnat kumppanitestaukseen.\r\n\r\n<b>HUOM!</b> Rajapintakuvaukset voivat vielä muuttua kumppanitestauksen ja kommenttien perusteella.\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
-      "contact": {
-        "name": "Feedback",
-        "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
-      },
-      "license": {
-        "name": "CC BY 4.0",
-        "url": "https://creativecommons.org/licenses/by/4.0/"
-      },
-      "version": "1"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Ryhti API",
+    "description": "<h2>Rakennetun ympäristön OpenApi kuvaukset </h2>\r\nEnsimmäisen vaiheen rakentamisen OpenApi rajapinnat kumppanitestaukseen.\r\n\r\n<b>HUOM!</b> Rajapintakuvaukset voivat vielä muuttua kumppanitestauksen ja kommenttien perusteella.\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
+    "contact": {
+      "name": "Feedback",
+      "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
     },
-    "servers": [
-      {
-        "url": "/building"
+    "license": {
+      "name": "CC BY 4.0",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
+    },
+    "version": "1"
+  },
+  "servers": [
+    {
+      "url": "/building"
+    }
+  ],
+  "paths": {
+    "/api/Authenticate": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Hae OAuth2 -token käyttäen client credentials tunnusta ja salaisuutta.",
+        "description": "ClientId välitetään querysting parametrina ja clientSecrect http bodyssä. <b>X-Token-Expires-In</b> http headerissa palautuu tokenin voimassaoloaika sekunneissa.",
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "query",
+            "description": "OAuth clientId.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "OAuth clientSecret välitetään http bodyssä heittomerkkien sisällä. Esim. ```\"minunsalaisuus\"```",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth token, joka pitää välittää Authorization headerissä muissa api-kutsuissa.\r\n            ```X-Token-Expires-In``` http header kertoo sekunneissa tokeninen voimassaoloajan.\r\n            Muita api-rajapintoja kutsuttaessa lisää kutsuun Authorization header seuraavasti: ```Authorization: Bearer [token]```",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
       }
-    ],
-    "paths": {
-      "/api/Authenticate": {
-        "post": {
-          "tags": [
-            "Authentication"
-          ],
-          "summary": "Hae OAuth2 -token käyttäen client credentials tunnusta ja salaisuutta.",
-          "description": "ClientId välitetään querysting parametrina ja clientSecrect http bodyssä. <b>X-Token-Expires-In</b> http headerissa palautuu tokenin voimassaoloaika sekunneissa.",
-          "parameters": [
-            {
-              "name": "clientId",
-              "in": "query",
-              "description": "OAuth clientId.",
-              "schema": {
-                "type": "string"
-              }
+    },
+    "/api/Building/{permanentBuildingIdentifier}": {
+      "get": {
+        "tags": [
+          "Building"
+        ],
+        "summary": "Hae rakennuksen kaikki tiedot Ryhdin REST-rajapinnasta.",
+        "parameters": [
+          {
+            "name": "permanentBuildingIdentifier",
+            "in": "path",
+            "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          "requestBody": {
-            "description": "OAuth clientSecret välitetään http bodyssä heittomerkkien sisällä. Esim. ```\"minunsalaisuus\"```",
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakennuskohteen haku onnistui.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
                 }
               },
               "text/json": {
                 "schema": {
-                  "type": "string"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "OAuth token, joka pitää välittää Authorization headerissä muissa api-kutsuissa.\r\n            ```X-Token-Expires-In``` http header kertoo sekunneissa tokeninen voimassaoloajan.\r\n            Muita api-rajapintoja kutsuttaessa lisää kutsuun Authorization header seuraavasti: ```Authorization: Bearer [token]```",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/Building/{permanentBuildingIdentifier}": {
-        "get": {
-          "tags": [
-            "Building"
-          ],
-          "summary": "Hae rakennuksen kaikki tiedot Ryhdin REST-rajapinnasta.",
-          "parameters": [
-            {
-              "name": "permanentBuildingIdentifier",
-              "in": "path",
-              "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Rakennuskohteen haku onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Building"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Building"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Building"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/BuildingGeneralized/{permanentBuildingIdentifier}": {
-        "get": {
-          "tags": [
-            "Building"
-          ],
-          "summary": "Hae karkeutettu rakennustieto.",
-          "parameters": [
-            {
-              "name": "permanentBuildingIdentifier",
-              "in": "path",
-              "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Rakennuskohteen haku onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Building"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Building"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Building"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/BuildingObject/Validate": {
-        "post": {
-          "tags": [
-            "BuildingObject"
-          ],
-          "summary": "Validoi uusi rakennuskohde ilman lupaa.",
-          "requestBody": {
-            "description": "Rakennuskohde-asian tiedot.",
+          "404": {
+            "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingObjectIssue"
-                    }
-                  ],
-                  "description": "Rakennuskohdeasia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingObjectIssue"
-                    }
-                  ],
-                  "description": "Rakennuskohdeasia"
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingObjectIssue"
-                    }
-                  ],
-                  "description": "Rakennuskohdeasia"
-                }
-              }
-            },
-            "required": true
-          },
-          "responses": {
-            "200": {
-              "description": "Rakennuskohteen validointi onnisti."
-            },
-            "400": {
-              "description": "Rakennuskohteen validointi epäonnistui virheellisen kutsun johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Rakennuskohteen validointi epäonnistui virheellisen tiedon johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/BuildingObject/{buildingObjectId}": {
-        "post": {
-          "tags": [
-            "BuildingObject"
-          ],
-          "summary": "Tallenna rakennuskohde ilman lupaa.",
-          "parameters": [
-            {
-              "name": "buildingObjectId",
-              "in": "path",
-              "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Rakennuskohde-asian tiedot.",
-            "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingObjectIssue"
-                    }
-                  ],
-                  "description": "Rakennuskohdeasia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingObjectIssue"
-                    }
-                  ],
-                  "description": "Rakennuskohdeasia"
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingObjectIssue"
-                    }
-                  ],
-                  "description": "Rakennuskohdeasia"
-                }
-              }
-            },
-            "required": true
-          },
-          "responses": {
-            "201": {
-              "description": "Rakennuskohteen tallentaminen onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Rakennuskohteen tallentaminen epäonnistui virheellisen kutsun johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Rakennuskohteen tallentaminen epäonnistui virheellisen tiedon johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/BuildingOwnersAll/{permanentBuildingIdentifier}": {
-        "get": {
-          "tags": [
-            "BuildingOwners"
-          ],
-          "summary": "Hae rakennuksen omistajatiedot ml. turvakiellon alaiset tiedot.",
-          "parameters": [
-            {
-              "name": "permanentBuildingIdentifier",
-              "in": "path",
-              "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Omistajatietojen haku onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetBuildingOwnerResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetBuildingOwnerResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetBuildingOwnerResponse"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea rakennuskohteen omistajatietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/BuildingOwners/{permanentBuildingIdentifier}": {
-        "get": {
-          "tags": [
-            "BuildingOwners"
-          ],
-          "summary": "Hae rakennuksen omistajatiedot ilman turvakiellon alaisia tietoja.",
-          "parameters": [
-            {
-              "name": "permanentBuildingIdentifier",
-              "in": "path",
-              "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Omistajatietojen haku onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetBuildingOwnerResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetBuildingOwnerResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetBuildingOwnerResponse"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea rakennuskohteen omistajatietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope."
-            }
-          }
-        }
-      },
-      "/api/BuildingPermit/Validate": {
-        "post": {
-          "tags": [
-            "BuildingPermit"
-          ],
-          "summary": "Validoi uusi rakentamislupa-asia.",
-          "requestBody": {
-            "content": {
               "application/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "Validointi onnistui"
-            },
-            "400": {
-              "description": "Rakentamislupa-asian validointi epäonnistui virheellisen kutsun johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Rakentamislupa-asian validointi epäonnistui virheellisen tiedon johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           }
         }
-      },
-      "/api/BuildingPermit/{buildingPermitId}": {
-        "post": {
-          "tags": [
-            "BuildingPermit"
-          ],
-          "summary": "Tallenna uusi rakentamislupa-asia.",
-          "parameters": [
-            {
-              "name": "buildingPermitId",
-              "in": "path",
-              "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
+      }
+    },
+    "/api/BuildingGeneralized/{permanentBuildingIdentifier}": {
+      "get": {
+        "tags": [
+          "Building"
+        ],
+        "summary": "Hae karkeutettu rakennustieto.",
+        "parameters": [
+          {
+            "name": "permanentBuildingIdentifier",
+            "in": "path",
+            "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          "requestBody": {
-            "description": "Rakentamislupa-asia kokonaisuudessaan.",
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakennuskohteen haku onnistui.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "$ref": "#/components/schemas/ChangeInformationBuilding"
                 }
               }
             }
           },
-          "responses": {
-            "201": {
-              "description": "Rakentamislupa-asian tallentaminen onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
+          "404": {
+            "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "400": {
-              "description": "Rakentamislupa-asian tallentaminen epäonnistui",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "422": {
-              "description": "Rakentamislupa-asian tallentaminen epäonnistui",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           }
+        }
+      }
+    },
+    "/api/BuildingObject/Validate": {
+      "post": {
+        "tags": [
+          "BuildingObject"
+        ],
+        "summary": "Validoi uusi rakennuskohde ilman lupaa.",
+        "requestBody": {
+          "description": "Rakennuskohde-asian tiedot.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "buildingObjectIssueKey",
+                  "constructionAction",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingObjectIssue"
+                  }
+                ],
+                "description": "Rakennuskohdeasia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "buildingObjectIssueKey",
+                  "constructionAction",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingObjectIssue"
+                  }
+                ],
+                "description": "Rakennuskohdeasia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "buildingObjectIssueKey",
+                  "constructionAction",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingObjectIssue"
+                  }
+                ],
+                "description": "Rakennuskohdeasia"
+              }
+            }
+          },
+          "required": true
         },
-        "get": {
-          "tags": [
-            "BuildingPermit"
-          ],
-          "summary": "Hae rakentamislupa-asia.",
-          "parameters": [
-            {
-              "name": "buildingPermitId",
-              "in": "path",
-              "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
+        "responses": {
+          "200": {
+            "description": "Rakennuskohteen validointi onnisti."
+          },
+          "400": {
+            "description": "Rakennuskohteen validointi epäonnistui virheellisen kutsun johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "Rakentamisluvan hakeminen onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
+          },
+          "422": {
+            "description": "Rakennuskohteen validointi epäonnistui virheellisen tiedon johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/BuildingObject/{buildingObjectId}": {
+      "post": {
+        "tags": [
+          "BuildingObject"
+        ],
+        "summary": "Tallenna rakennuskohde ilman lupaa.",
+        "parameters": [
+          {
+            "name": "buildingObjectId",
+            "in": "path",
+            "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Rakennuskohde-asian tiedot.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "buildingObjectIssueKey",
+                  "constructionAction",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingObjectIssue"
+                  }
+                ],
+                "description": "Rakennuskohdeasia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "buildingObjectIssueKey",
+                  "constructionAction",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingObjectIssue"
+                  }
+                ],
+                "description": "Rakennuskohdeasia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "buildingObjectIssueKey",
+                  "constructionAction",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingObjectIssue"
+                  }
+                ],
+                "description": "Rakennuskohdeasia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Rakennuskohteen tallentaminen onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Rakennuskohteen tallentaminen epäonnistui virheellisen kutsun johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rakennuskohteen tallentaminen epäonnistui virheellisen tiedon johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/BuildingOwnersAll/{permanentBuildingIdentifier}": {
+      "get": {
+        "tags": [
+          "BuildingOwners"
+        ],
+        "summary": "Hae rakennusten omistajatiedot ml. turvakiellon alaiset tiedot.",
+        "parameters": [
+          {
+            "name": "permanentBuildingIdentifier",
+            "in": "path",
+            "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Omistajatietojen haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBuildingOwnerResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBuildingOwnerResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBuildingOwnerResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakennusta ei löydy tai siihen ei ole käyttöoikeutta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Kyselyssä liian monta tunnusta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/BuildingOwners/{permanentBuildingIdentifier}": {
+      "get": {
+        "tags": [
+          "BuildingOwners"
+        ],
+        "summary": "Hae rakennusten omistajatiedot ilman turvakiellon alaisia tietoja.",
+        "parameters": [
+          {
+            "name": "permanentBuildingIdentifier",
+            "in": "path",
+            "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Omistajatietojen haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBuildingOwnerResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBuildingOwnerResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBuildingOwnerResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakennusta ei löydy tai siihen ei ole käyttöoikeutta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Kyselyssä liian monta tunnusta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/BuildingPermit/Validate": {
+      "post": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Validoi uusi rakentamislupa-asia.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
+                ],
+                "description": "Rakentamislupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "text/json": {
-                  "schema": {
+                ],
+                "description": "Rakentamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                }
-              }
-            },
-            "404": {
-              "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             }
           }
         },
-        "put": {
-          "tags": [
-            "BuildingPermit"
-          ],
-          "summary": "Päivitä rakentamislupa-asiaa.",
-          "parameters": [
-            {
-              "name": "buildingPermitId",
-              "in": "path",
-              "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Rakentamislupa-asia kokonaisuudessaan. Huom. Tiedot jotka puuttuvat sanomasta poistetaan Ryhdistä.",
+        "responses": {
+          "200": {
+            "description": "Validointi onnistui"
+          },
+          "400": {
+            "description": "Rakentamislupa-asian validointi epäonnistui virheellisen kutsun johdosta.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "Rakentamislupa-asia päivittäminen onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
+          "422": {
+            "description": "Rakentamislupa-asian validointi epäonnistui virheellisen tiedon johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
-              }
-            },
-            "400": {
-              "description": "Rakentamislupa-asia päivittäminen epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
-              }
-            },
-            "422": {
-              "description": "Rakentamislupa-asia päivittäminen epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
               }
             }
           }
         }
-      },
-      "/api/BuildingPermitGeneralized/{buildingPermitId}": {
-        "get": {
-          "tags": [
-            "BuildingPermit"
-          ],
-          "summary": "Hae karkeutettu rakentamislupa-asia.",
-          "parameters": [
-            {
-              "name": "buildingPermitId",
-              "in": "path",
-              "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Karkeutetun rakentamisluvan hakeminen onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
+      }
+    },
+    "/api/BuildingPermit/{buildingPermitId}": {
+      "post": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Tallenna uusi rakentamislupa-asia.",
+        "parameters": [
+          {
+            "name": "buildingPermitId",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
-        }
-      },
-      "/api/DemolitionPermit/Validate": {
-        "post": {
-          "tags": [
-            "DemolitionPermit"
-          ],
-          "summary": "Validoi uusi purkamislupa-asia.",
-          "requestBody": {
-            "description": "Purkamislupa-asia kokonaisuudessaan.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
-                }
-              }
-            },
-            "required": true
-          },
-          "responses": {
-            "200": {
-              "description": "Purkamislupa-asian validointi onnistui."
-            },
-            "400": {
-              "description": "Purkamislupa-asian validointi epäonnistui virheellisen kutsun johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Purkamislupa-asian validointi epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/DemolitionPermit/{demolitionPermitId}": {
-        "post": {
-          "tags": [
-            "DemolitionPermit"
-          ],
-          "summary": "Tallenna uusi purkamislupa-asia.",
-          "parameters": [
-            {
-              "name": "demolitionPermitId",
-              "in": "path",
-              "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
-              "required": true,
+        ],
+        "requestBody": {
+          "description": "Rakentamislupa-asia kokonaisuudessaan.",
+          "content": {
+            "application/json": {
               "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Purkamislupa-asia kokonaisuudessaan.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
-                }
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
+                  }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             },
-            "required": true
-          },
-          "responses": {
-            "201": {
-              "description": "Purkamislupa-asian tallennus onnistui. Paluuarvona Uri luotuun resurssiin.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             },
-            "400": {
-              "description": "Purkamislupa-asian tallennus epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Purkamislupa-asian tallennus epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             }
           }
         },
-        "get": {
-          "tags": [
-            "DemolitionPermit"
-          ],
-          "summary": "Hae purkamislupa-asia. Määrittely kesken. Rakenne tarkentuu myöhemmin.",
-          "parameters": [
-            {
-              "name": "demolitionPermitId",
-              "in": "path",
-              "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Purkamislupa löytyi ja se palautettiin."
-            },
-            "400": {
-              "description": "Purkamisluvan hakeminen epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Purkamisluvan haku epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "put": {
-          "tags": [
-            "DemolitionPermit"
-          ],
-          "summary": "Päivitä purkamislupa-asiaa. Määrittely kesken. Rakenne tarkentuu myöhemmin.",
-          "parameters": [
-            {
-              "name": "demolitionPermitId",
-              "in": "path",
-              "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Purkamislupa-asia kokonaisuudessaan.",
+        "responses": {
+          "201": {
+            "description": "Rakentamislupa-asian tallentaminen onnistui.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
+                  "type": "string",
+                  "format": "uri"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Rakentamislupa-asian tallentaminen epäonnistui",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
-              "application/*+json": {
+              "application/json": {
                 "schema": {
-                  "required": [
-                    "demolitionPermitApplication",
-                    "demolitionDecision",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DemolitionPermitIssue"
-                    }
-                  ],
-                  "description": "Purkamislupa-asia"
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "required": true
+            }
           },
-          "responses": {
-            "200": {
-              "description": "Purkamisluvan päivitys onnistui."
-            },
-            "400": {
-              "description": "Purkamisluvan päivitys epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "422": {
+            "description": "Rakentamislupa-asian tallentaminen epäonnistui",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
-              }
-            },
-            "422": {
-              "description": "Purkamisluvan päivitys epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
               }
             }
           }
         }
       },
-      "/api/DeviationPermit/Validate": {
-        "post": {
-          "tags": [
-            "DeviationPermit"
-          ],
-          "summary": "Validoi uusi poikkeamislupa-asia.",
-          "requestBody": {
+      "get": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Hae rakentamislupa-asia.",
+        "parameters": [
+          {
+            "name": "buildingPermitId",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakentamisluvan hakeminen onnistui.",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "Validointi onnistui."
-            },
-            "400": {
-              "description": "Poikkeamisluvan validointi epäonnistui virheellisen kutsun johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+          "404": {
+            "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "422": {
-              "description": "Poikkeamisluvan validointi epäonnistui virheellisen tiedon johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
           }
         }
       },
-      "/api/DeviationPermit/{permanentPermitId}": {
-        "post": {
-          "tags": [
-            "DeviationPermit"
-          ],
-          "summary": "Tallenna uusi poikkeamislupa-asia.",
-          "parameters": [
-            {
-              "name": "permanentPermitId",
-              "in": "path",
-              "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
-              "required": true,
+      "put": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Päivitä rakentamislupa-asiaa.",
+        "parameters": [
+          {
+            "name": "buildingPermitId",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Rakentamislupa-asia kokonaisuudessaan. Huom. Tiedot jotka puuttuvat sanomasta poistetaan Ryhdistä.",
+          "content": {
+            "application/json": {
               "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Poikkeamislupa-asia kokonaisuudessaan.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
-                }
-              }
-            }
-          },
-          "responses": {
-            "201": {
-              "description": "Poikkeamislupa-asian tallennus onnistui. Paluuarvona Uri luotuun resurssiin.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             },
-            "400": {
-              "description": "Poikkeamislupa-asian tallennus epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             },
-            "422": {
-              "description": "Poikkeamislupa-asian tallennus epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             }
           }
         },
-        "get": {
-          "tags": [
-            "DeviationPermit"
-          ],
-          "summary": "Hae poikkeamislupa-asia.",
-          "parameters": [
-            {
-              "name": "permanentPermitId",
-              "in": "path",
-              "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
+        "responses": {
+          "200": {
+            "description": "Rakentamislupa-asia päivittäminen onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
               }
             }
-          ],
-          "responses": {
-            "200": {
-              "description": "Poikkeamislupa-asia löytyi ja se palautettiin.",
-              "content": {
-                "text/plain": {
-                  "schema": {
+          },
+          "400": {
+            "description": "Rakentamislupa-asia päivittäminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rakentamislupa-asia päivittäminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/BuildingPermitGeneralized/{buildingPermitId}": {
+      "get": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Hae karkeutettu rakentamislupa-asia.",
+        "parameters": [
+          {
+            "name": "buildingPermitId",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Karkeutetun rakentamisluvan hakeminen onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DemolitionPermit/Validate": {
+      "post": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Validoi uusi purkamislupa-asia.",
+        "requestBody": {
+          "description": "Purkamislupa-asia kokonaisuudessaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Purkamislupa-asian validointi onnistui."
+          },
+          "400": {
+            "description": "Purkamislupa-asian validointi epäonnistui virheellisen kutsun johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamislupa-asian validointi epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DemolitionPermit/{demolitionPermitId}": {
+      "post": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Tallenna uusi purkamislupa-asia.",
+        "parameters": [
+          {
+            "name": "demolitionPermitId",
+            "in": "path",
+            "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Purkamislupa-asia kokonaisuudessaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Purkamislupa-asian tallennus onnistui. Paluuarvona Uri luotuun resurssiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Purkamislupa-asian tallennus epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamislupa-asian tallennus epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Hae purkamislupa-asia. Määrittely kesken. Rakenne tarkentuu myöhemmin.",
+        "parameters": [
+          {
+            "name": "demolitionPermitId",
+            "in": "path",
+            "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Purkamislupa löytyi ja se palautettiin."
+          },
+          "400": {
+            "description": "Purkamisluvan hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamisluvan haku epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Päivitä purkamislupa-asiaa. Määrittely kesken. Rakenne tarkentuu myöhemmin.",
+        "parameters": [
+          {
+            "name": "demolitionPermitId",
+            "in": "path",
+            "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Purkamislupa-asia kokonaisuudessaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "demolitionPermitApplication",
+                  "demolitionDecision",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DemolitionPermitIssue"
+                  }
+                ],
+                "description": "Purkamislupa-asia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Purkamisluvan päivitys onnistui."
+          },
+          "400": {
+            "description": "Purkamisluvan päivitys epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamisluvan päivitys epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DeviationPermit/Validate": {
+      "post": {
+        "tags": [
+          "DeviationPermit"
+        ],
+        "summary": "Validoi uusi poikkeamislupa-asia.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/DeviationPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/DeviationPermitIssue"
                   }
-                },
-                "text/json": {
-                  "schema": {
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
                     "$ref": "#/components/schemas/DeviationPermitIssue"
                   }
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Validointi onnistui."
+          },
+          "400": {
+            "description": "Poikkeamisluvan validointi epäonnistui virheellisen kutsun johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "404": {
-              "description": "Poikkeamuslupa-asiaa ei löytynyt pysyvällä tunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
+            }
+          },
+          "422": {
+            "description": "Poikkeamisluvan validointi epäonnistui virheellisen tiedon johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
               }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            }
+          }
+        }
+      }
+    },
+    "/api/DeviationPermit/{permanentPermitId}": {
+      "post": {
+        "tags": [
+          "DeviationPermit"
+        ],
+        "summary": "Tallenna uusi poikkeamislupa-asia.",
+        "parameters": [
+          {
+            "name": "permanentPermitId",
+            "in": "path",
+            "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Poikkeamislupa-asia kokonaisuudessaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeviationPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
+                ],
+                "description": "Poikkeamislupa-asia"
               }
             },
-            "403": {
-              "description": "Ei oikeutta lukea poikkeamuslupa-asian tietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeviationPermitIssue"
                   }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeviationPermitIssue"
                   }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Poikkeamislupa-asian tallennus onnistui. Paluuarvona Uri luotuun resurssiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Poikkeamislupa-asian tallennus epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Poikkeamislupa-asian tallennus epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DeviationPermit"
+        ],
+        "summary": "Hae poikkeamislupa-asia.",
+        "parameters": [
+          {
+            "name": "permanentPermitId",
+            "in": "path",
+            "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Poikkeamislupa-asia löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Poikkeamuslupa-asiaa ei löytynyt pysyvällä tunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea poikkeamuslupa-asian tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DeviationPermit"
+        ],
+        "summary": "Päivitä poikkeamislupa-asiaa.",
+        "parameters": [
+          {
+            "name": "permanentPermitId",
+            "in": "path",
+            "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Poikkeamislupa-asia kokonaisuudessaan. Puuttuvat tiedot poistetaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeviationPermitIssue"
+                  }
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeviationPermitIssue"
+                  }
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "deviationPermitDecision",
+                  "deviationPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/DeviationPermitIssue"
+                  }
+                ],
+                "description": "Poikkeamislupa-asia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Poikkeamislupa-asia päivitys onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Poikkeamislupa-asia Päivitys epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Poikkeamislupa-asia päivitys epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/File": {
+      "post": {
+        "tags": [
+          "Document"
+        ],
+        "parameters": [
+          {
+            "name": "municipalityId",
+            "in": "query",
+            "description": "Jos käyttäjällä on oikeus useampaan kuntaan tulee pyynnön sisältää kuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "regionId",
+            "in": "query",
+            "description": "Jos käyttäjällä on oikeus useampaan maakuntaan tulee pyynnön sisältää maakuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
                   }
                 }
               }
             }
           }
         },
-        "put": {
-          "tags": [
-            "DeviationPermit"
-          ],
-          "summary": "Päivitä poikkeamislupa-asiaa.",
-          "parameters": [
-            {
-              "name": "permanentPermitId",
-              "in": "path",
-              "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Poikkeamislupa-asia kokonaisuudessaan. Puuttuvat tiedot poistetaan.",
+        "responses": {
+          "201": {
+            "description": "Created",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
+                  "type": "string",
+                  "format": "uri"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "deviationPermitDecision",
-                    "deviationPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/DeviationPermitIssue"
-                    }
-                  ],
-                  "description": "Poikkeamislupa-asia"
-                }
-              }
-            },
-            "required": true
-          },
-          "responses": {
-            "200": {
-              "description": "Poikkeamislupa-asia päivitys onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Poikkeamislupa-asia Päivitys epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Poikkeamislupa-asia päivitys epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
+                  "type": "string",
+                  "format": "uri"
                 }
               }
             }
           }
         }
-      },
-      "/api/File": {
-        "post": {
-          "tags": [
-            "Document"
-          ],
-          "parameters": [
-            {
-              "name": "municipalityId",
-              "in": "query",
-              "description": "Jos käyttäjällä on oikeus useampaan kuntaan tulee pyynnön sisältää kuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+      }
+    },
+    "/api/DvvBuildingPermit/{permanentPermitIdentifier}": {
+      "put": {
+        "tags": [
+          "DvvBuildingPermit"
+        ],
+        "summary": "Keskeneräisten rakennushankkeiden päivitys.",
+        "parameters": [
+          {
+            "name": "permanentPermitIdentifier",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
               "schema": {
-                "type": "string"
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
+                  }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             },
-            {
-              "name": "regionId",
-              "in": "query",
-              "description": "Jos käyttäjällä on oikeus useampaan maakuntaan tulee pyynnön sisältää maakuntaId, jolle tiedosto tuodaan. Vain toinen id on sallittu.",
+            "text/json": {
               "schema": {
-                "type": "string"
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
+                  }
+                ],
+                "description": "Rakentamislupa-asia"
               }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "multipart/form-data": {
-                "schema": {
-                  "required": [
-                    "file"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "file": {
-                      "type": "string",
-                      "format": "binary"
-                    }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "decision",
+                  "buildingPermitApplication",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BuildingPermitIssue"
                   }
-                }
-              }
-            }
-          },
-          "responses": {
-            "201": {
-              "description": "Created",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
+                ],
+                "description": "Rakentamislupa-asia"
               }
             }
           }
-        }
-      },
-      "/api/DvvBuildingPermit/{permanentPermitIdentifier}": {
-        "put": {
-          "tags": [
-            "DvvBuildingPermit"
-          ],
-          "summary": "Keskeneräisten rakennushankkeiden päivitys.",
-          "parameters": [
-            {
-              "name": "permanentPermitIdentifier",
-              "in": "path",
-              "description": "",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
+        },
+        "responses": {
+          "200": {
             "description": "",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "type": "string",
+                  "format": "uri"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "decision",
-                    "buildingPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/BuildingPermitIssue"
-                    }
-                  ],
-                  "description": "Rakentamislupa-asia"
+                  "type": "string",
+                  "format": "uri"
                 }
               }
             }
           },
-          "responses": {
-            "200": {
-              "description": "",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ForemenPlanners/{permanentPermitIdentifier}": {
-        "get": {
-          "tags": [
-            "ForemenPlanners"
-          ],
-          "summary": "Hae työnjohtajien ja suunnittelijoiden tiedot.",
-          "parameters": [
-            {
-              "name": "permanentPermitIdentifier",
-              "in": "path",
-              "description": "Rakentamislupa-asian pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Työnjohtajien ja sunnittelijoiden tietojen haku onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetForemenPlannersResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetForemenPlannersResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/GetForemenPlannersResponse"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "Lupa-asiaa ei löytynyt pysyvällä tunnuksella.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "Käyttäjältä puuttuu tarvittava scope.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "Ei oikeutta lukea lupa-asian tietoja.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/LandscapeWorkPermit/Validate": {
-        "post": {
-          "tags": [
-            "LandscapeWorkPermit"
-          ],
-          "summary": "Validoi uusi maisematyölupa-asia.",
-          "requestBody": {
+          "400": {
+            "description": "",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
-            },
-            "required": true
+            }
           },
-          "responses": {
-            "200": {
-              "description": "Maisematyölupa-asian validointi onnistui."
-            },
-            "400": {
-              "description": "Maisematyölupa-asian validointi epäonnistui virheellisen kutsun johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Maisematyölupa-asian validointi epäonnistui virheellisen tiedon johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/LandscapeWorkPermit/{landscapeWorkPermitIssueId}": {
-        "post": {
-          "tags": [
-            "LandscapeWorkPermit"
-          ],
-          "summary": "Tallenna uusi maisematyölupa-asia.",
-          "parameters": [
-            {
-              "name": "landscapeWorkPermitIssueId",
-              "in": "path",
-              "description": "Maisematyölupa-asian pysyvä tunniste.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Maisematyölupa-asia kokonaisuudessaan.",
+          "422": {
+            "description": "",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
               "application/json": {
                 "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
               }
-            },
-            "required": true
-          },
-          "responses": {
-            "201": {
-              "description": "Maisematyölupa-asian tallennus onnistui. Paluuarvona Uri luotuun resurssiin.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Maisematyölupa-asian tallennus epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Maisematyölupa-asian tallennus epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "put": {
-          "tags": [
-            "LandscapeWorkPermit"
-          ],
-          "summary": "Päivitä maisematyölupa-asiaa.",
-          "parameters": [
-            {
-              "name": "landscapeWorkPermitIssueId",
-              "in": "path",
-              "description": "Maisematyölupa-asian pysyvä yksilöivä tunnus.",
-              "required": true,
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Maisematyölupa-asia kokonaisuudessaan. Puuttuvat tiedot poistetaan.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "required": [
-                    "landscapeWorkPermitDecision",
-                    "landscapeWorkPermitApplication",
-                    "dateOfInitiation"
-                  ],
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
-                    }
-                  ],
-                  "description": "Maisematyölupa-asia"
-                }
-              }
-            },
-            "required": true
-          },
-          "responses": {
-            "200": {
-              "description": "Maisematyölupa-asia päivitys onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Maisematyölupa-asia Päivitys epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Maisematyölupa-asia päivitys epäonnistui virheellisten tietojen johdosta.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/PermanentIdentifiers/BuildingIdentifier": {
-        "post": {
-          "tags": [
-            "PermanentIdentifiers"
-          ],
-          "summary": "Luo uusi pysyvä rakennustunnus (PRT).",
-          "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
-          "requestBody": {
-            "description": "Parametrit, jotka tarvitaan pysyvän rakennustunnuksen varaamiseen.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentBuildingIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentBuildingIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentBuildingIdentifierCommand"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "Pysyvän rakennustunnuksen palautuminen onnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "201": {
-              "description": "Pysyvä rakennustunnus luotu ja varattu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Pysyvän rakennustunnuksen luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Pysyvän rakennustunnuksen luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/PermanentIdentifiers/ApartmentIdentifier": {
-        "post": {
-          "tags": [
-            "PermanentIdentifiers"
-          ],
-          "summary": "Luo uusi pysyvä huoneistotunnus (PHT).",
-          "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
-          "requestBody": {
-            "description": "Parametrit, jotka tarvitaan pysyvän huoneistotunnuksen varaamiseen.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentApartmentIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentApartmentIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentApartmentIdentifierCommand"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "Huoneistotunnus palautettu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "201": {
-              "description": "Pysyvä huoneistotunnus luotu ja varattu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Pysyvän huoneistotunnuksen luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Pysyvän huoneistotunnuksen luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/PermanentIdentifiers/BuildingPermitIdentifier": {
-        "post": {
-          "tags": [
-            "PermanentIdentifiers"
-          ],
-          "summary": "Luo uusi pysyvä rakentamislupatunnus (PLT).",
-          "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
-          "requestBody": {
-            "description": "Parametrit, jotka tarvitaan pysyvän rakentamislupatunnuksen varaamiseen.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentPermitIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentPermitIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentPermitIdentifierCommand"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "Rakentamislupatunnus palautettu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "201": {
-              "description": "Pysyvä rakentamislupatunnus luotu ja varattu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Pysyvän rakentamislupatunnus luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Pysyvän rakentamislupatunnus luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/PermanentIdentifiers/StructureIdentifier": {
-        "post": {
-          "tags": [
-            "PermanentIdentifiers"
-          ],
-          "summary": "Luo uusi pysyvä rakennelmatunnus (PRKT).",
-          "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
-          "requestBody": {
-            "description": "Parametrit, jotka tarvitaan pysyvän rakennelmatunnuksen varaamiseen.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentStructureIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentStructureIdentifierCommand"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetPermanentStructureIdentifierCommand"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "Rakennelmatunnus palautettu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "201": {
-              "description": "Rakennelmatunnus luotu ja varattu onnistuneesti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Pysyvän rakennelmatunnuksen luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Pysyvän rakennelmatunnuksen luonti epäonnistui.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/Status/health": {
-        "get": {
-          "tags": [
-            "Status"
-          ],
-          "summary": "Get service health report",
-          "description": "Provides an indication about the health of the API",
-          "responses": {
-            "200": {
-              "description": "API is healthy or in a degraded but functional state",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/HealthReport"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/HealthReport"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/HealthReport"
-                  }
-                }
-              }
-            },
-            "503": {
-              "description": "API is unhealthy"
             }
           }
         }
       }
     },
-    "components": {
-      "schemas": {
-        "AcceptedDeviation": {
-          "required": [
-            "acceptedDeviationKey",
-            "contentOfDeviation"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "deviationType": {
-              "type": "string",
-              "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
-            },
-            "contentOfDeviation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            }
-          },
-          "additionalProperties": false,
-          "description": "Luvan yhteydessä myönnettävä poikkeaminen"
-        },
-        "Address": {
-          "required": [
-            "addressKey",
-            "addressName",
-            "addressNumber",
-            "postalCode"
-          ],
-          "type": "object",
-          "properties": {
-            "addressKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "addressName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "numberPartOfAddressNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "postalCode": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "numberPartOfAddressNumber2": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber2": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Osoite"
-        },
-        "AdministrativeLocationUnit": {
-          "required": [
-            "administrativeLocationUnitKey",
-            "propertyIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "administrativeLocationUnitKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "unitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "propertyIdentifier": {
-              "maxLength": 14,
-              "minLength": 14,
+    "/api/ForemenPlanners/{permanentPermitIdentifier}": {
+      "get": {
+        "tags": [
+          "ForemenPlanners"
+        ],
+        "summary": "Hae työnjohtajien ja suunnittelijoiden tiedot.",
+        "parameters": [
+          {
+            "name": "permanentPermitIdentifier",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
               "type": "string"
-            },
-            "unseparatedParcelIdentifier": {
-              "type": "string",
-              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Työnjohtajien ja sunnittelijoiden tietojen haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetForemenPlannersResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetForemenPlannersResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetForemenPlannersResponse"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Hallinnollinen sijaintiyksikkö"
-        },
-        "Apartment": {
-          "required": [
-            "addressNumber",
-            "apartmentChangeType",
-            "apartmentIdentifier",
-            "apartmentKey",
-            "apartmentType",
-            "lifeCycleState",
-            "numberOfRooms"
-          ],
-          "type": "object",
-          "properties": {
-            "apartmentKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-              ],
-              "type": "string",
-              "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>"
-            },
-            "apartmentEquipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ApartmentEquipment"
+          "404": {
+            "description": "Lupa-asiaa ei löytynyt pysyvällä tunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               },
-              "nullable": true
-            },
-            "apartmentIdentifier": {
-              "minLength": 1,
-              "pattern": "^[2|8][0-9]{8}[0-9A-Z]$",
-              "type": "string"
-            },
-            "apartmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-              ],
-              "type": "string",
-              "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
-            },
-            "floorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "numberOfRooms": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "kitchenType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-              ],
-              "type": "string",
-              "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-              "nullable": true
-            },
-            "isWaterCloset": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "apartmentChangeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-              ],
-              "type": "string",
-              "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>"
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "apartmentStorey": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentNumber": {
-              "type": "integer",
-              "format": "int32"
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Huoneisto"
-        },
-        "ApartmentEquipment": {
-          "required": [
-            "apartmentEquipmentKey",
-            "apartmentEquipmentType",
-            "numberOfEquipment"
-          ],
-          "type": "object",
-          "properties": {
-            "apartmentEquipmentKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "apartmentEquipmentType": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/01",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/02",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/03",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/04",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/05"
-              ],
-              "type": "string",
-              "description": "Huoneiston varusteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste\">http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste</a>"
-            },
-            "numberOfEquipment": {
-              "type": "integer",
-              "format": "int32"
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Huoneiston varuste"
-        },
-        "AreaToBeBuiltForSpecificActivities": {
-          "required": [
-            "address",
-            "administrativeLocationUnit",
-            "areaToBeBuiltForSpecificActivitiesKey",
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "location",
-            "specificActivitiesAreaType",
-            "temporary"
-          ],
-          "type": "object",
-          "properties": {
-            "areaToBeBuiltForSpecificActivitiesKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "specificActivitiesAreaType": {
-              "type": "string",
-              "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>"
-            },
-            "networkConnection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/NetworkConnection"
+          "403": {
+            "description": "Ei oikeutta lukea lupa-asian tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               },
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "temporary": {
-              "type": "boolean"
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot"
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
               },
-              "description": "Rakennuskohteen omistaja"
-            },
-            "address": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/LandscapeWorkPermit/Validate": {
+      "post": {
+        "tags": [
+          "LandscapeWorkPermit"
+        ],
+        "summary": "Validoi uusi maisematyölupa-asia.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
               }
             },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Erityistä toimintaa varten rakennettava alue"
-        },
-        "AssemblyFacility": {
-          "required": [
-            "assemblyFacilityKey",
-            "capacityOfAssemblyFacilities"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "assemblyFacilityKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "capacityOfAssemblyFacilities": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Kokoontumistila"
-        },
-        "Building": {
-          "required": [
-            "administrativeLocationUnit",
-            "buildingKey",
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "buildingSection",
-            "mainPurpose",
-            "numberOfStoreys",
-            "permanentBuildingIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentBuildingIdentifier": {
-              "maxLength": 10,
-              "minLength": 10,
-              "type": "string",
-              "description": "Pysyvä rakennustunnus (PRT)"
-            },
-            "temporary": {
-              "type": "boolean",
-              "description": "Onko väliaikainen",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "description": "Demolition deadline",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "description": "Kerrosluku",
-              "format": "int32"
-            },
-            "buildingSection": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingSection"
-              },
-              "description": "Rakennuksen osat"
-            },
-            "mainPurpose": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-              ],
-              "type": "string",
-              "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja"
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "addChangeEvent": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuksen tiedot."
-        },
-        "BuildingAttachmentDocument": {
-          "required": [
-            "accessibility",
-            "attachmentDocumentKey",
-            "categoryOfPublicity",
-            "confirmationDate",
-            "documentDate",
-            "documentIdentifier",
-            "fileKey",
-            "languages",
-            "name",
-            "personalDataContent",
-            "retentionTime"
-          ],
-          "type": "object",
-          "properties": {
-            "attachmentDocumentKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
-              "format": "uuid"
-            },
-            "documentIdentifier": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "personalDataContent": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
-            },
-            "categoryOfPublicity": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
-            },
-            "accessibility": {
-              "type": "boolean"
-            },
-            "retentionTime": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
-            },
-            "confirmationDate": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "languages": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
-            },
-            "fileKey": {
-              "type": "string",
-              "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
-              "format": "uuid"
-            },
-            "descriptors": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Descriptor"
-              },
-              "nullable": true
-            },
-            "documentDate": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "arrivedDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "attachmentType": {
-              "type": "string",
-              "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
-            },
-            "documentCreatorPersonalIdentityCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentCreatorOtherId": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentCreatorFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentCreatorFamilyName": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Liiteasiakirja"
-        },
-        "BuildingInformationModel": {
-          "required": [
-            "buildingInformationModelKey",
-            "buildingInformationModelType",
-            "document"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingInformationModelKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingInformationModelType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
-            },
-            "document": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
               }
             },
-            "referencePoint": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ]
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Rakennustietomalli"
+          "required": true
         },
-        "BuildingMaterialOfLoadBearingStructures": {
-          "required": [
-            "buildingMaterialOfLoadBearingStructuresKey",
-            "buildingMaterialOfLoadBearingStructuresType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingMaterialOfLoadBearingStructuresKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingMaterialOfLoadBearingStructuresType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/00",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/01",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/02",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/03",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/04",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/99"
-              ],
-              "type": "string",
-              "description": "Kantavan rakenteen rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine\">http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
+        "responses": {
+          "200": {
+            "description": "Maisematyölupa-asian validointi onnistui."
           },
-          "additionalProperties": false,
-          "description": "Kantavien rakenteiden rakennusaine"
-        },
-        "BuildingObjectChange": {
-          "required": [
-            "buildingObjectChangeKey",
-            "grossFloorAreaChange",
-            "totalAreaChange",
-            "volumeChange"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectChangeKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "volumeChange": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "grossFloorAreaChange": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "permittedBuildingAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "totalAreaChange": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "floorAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "basementAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "numberOfStoreysChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuskohteen muutos"
-        },
-        "BuildingObjectIssue": {
-          "required": [
-            "buildingObjectIssueKey",
-            "constructionAction",
-            "municipalityNumber"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectIssueKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "constructionAction": {
-              "required": [
-                "constructionActionType",
-                "statusOfConstructionAction"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionAction"
+          "400": {
+            "description": "Maisematyölupa-asian validointi epäonnistui virheellisen kutsun johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
-              ],
-              "description": "Rakentamistoimenpide"
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
               },
-              "nullable": true
-            },
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Rakennuskohdeasia"
-        },
-        "BuildingObjectLocationData": {
-          "required": [
-            "buildingObjectLocationDataKey",
-            "pointLocation"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectLocationDataKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "votingDistrictNumber": {
-              "type": "string"
-            },
-            "pointLocation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
+          "422": {
+            "description": "Maisematyölupa-asian validointi epäonnistui virheellisen tiedon johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
                 }
-              ]
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/LandscapeWorkPermit/{landscapeWorkPermitIssueId}": {
+      "post": {
+        "tags": [
+          "LandscapeWorkPermit"
+        ],
+        "summary": "Tallenna uusi maisematyölupa-asia.",
+        "parameters": [
+          {
+            "name": "landscapeWorkPermitIssueId",
+            "in": "path",
+            "description": "Maisematyölupa-asian pysyvä tunniste.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Maisematyölupa-asia kokonaisuudessaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
             },
-            "geometry": {
-              "type": "array",
-              "items": {
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Maisematyölupa-asian tallennus onnistui. Paluuarvona Uri luotuun resurssiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Maisematyölupa-asian tallennus epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Maisematyölupa-asian tallennus epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "LandscapeWorkPermit"
+        ],
+        "summary": "Hae maisematyölupa-asia.",
+        "parameters": [
+          {
+            "name": "landscapeWorkPermitIssueId",
+            "in": "path",
+            "description": "Maisematyölupa-asian pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Maisematyölupa-asia löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Maisematyölupa-asia hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Maisematyölupa-asia haku epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "LandscapeWorkPermit"
+        ],
+        "summary": "Päivitä maisematyölupa-asiaa.",
+        "parameters": [
+          {
+            "name": "landscapeWorkPermitIssueId",
+            "in": "path",
+            "description": "Maisematyölupa-asian pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Maisematyölupa-asia kokonaisuudessaan. Puuttuvat tiedot poistetaan.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "permanentPermitIdentifier",
+                  "landscapeWorkPermitDecision",
+                  "landscapeWorkPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "lifeCycleState",
+                  "municipalityNumber"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                  }
+                ],
+                "description": "Maisematyölupa-asia"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Maisematyölupa-asia päivitys onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Maisematyölupa-asia Päivitys epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Maisematyölupa-asia päivitys epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PermanentIdentifiers/BuildingIdentifier": {
+      "post": {
+        "tags": [
+          "PermanentIdentifiers"
+        ],
+        "summary": "Luo uusi pysyvä rakennustunnus (PRT).",
+        "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
+        "requestBody": {
+          "description": "Parametrit, jotka tarvitaan pysyvän rakennustunnuksen varaamiseen.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentBuildingIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentBuildingIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentBuildingIdentifierCommand"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pysyvän rakennustunnuksen palautuminen onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Pysyvä rakennustunnus luotu ja varattu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentBuildingIdentifierResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Pysyvän rakennustunnuksen luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Pysyvän rakennustunnuksen luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PermanentIdentifiers/ApartmentIdentifier": {
+      "post": {
+        "tags": [
+          "PermanentIdentifiers"
+        ],
+        "summary": "Luo uusi pysyvä huoneistotunnus (PHT).",
+        "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
+        "requestBody": {
+          "description": "Parametrit, jotka tarvitaan pysyvän huoneistotunnuksen varaamiseen.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentApartmentIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentApartmentIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentApartmentIdentifierCommand"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Huoneistotunnus palautettu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Pysyvä huoneistotunnus luotu ja varattu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentApartmentIdentifierResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Pysyvän huoneistotunnuksen luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Pysyvän huoneistotunnuksen luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PermanentIdentifiers/BuildingPermitIdentifier": {
+      "post": {
+        "tags": [
+          "PermanentIdentifiers"
+        ],
+        "summary": "Luo uusi pysyvä rakentamislupatunnus (PLT).",
+        "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
+        "requestBody": {
+          "description": "Parametrit, jotka tarvitaan pysyvän rakentamislupatunnuksen varaamiseen.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentPermitIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentPermitIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentPermitIdentifierCommand"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rakentamislupatunnus palautettu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Pysyvä rakentamislupatunnus luotu ja varattu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentPermitIdentifierResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Pysyvän rakentamislupatunnus luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Pysyvän rakentamislupatunnus luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/PermanentIdentifiers/StructureIdentifier": {
+      "post": {
+        "tags": [
+          "PermanentIdentifiers"
+        ],
+        "summary": "Luo uusi pysyvä rakennelmatunnus (PRKT).",
+        "description": "Rajapinta on idempotenttinen eli se palauttaa saman tunnuksen samoilla parametreilla.",
+        "requestBody": {
+          "description": "Parametrit, jotka tarvitaan pysyvän rakennelmatunnuksen varaamiseen.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentStructureIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentStructureIdentifierCommand"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetPermanentStructureIdentifierCommand"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rakennelmatunnus palautettu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Rakennelmatunnus luotu ja varattu onnistuneesti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermanentStructureIdentifierResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Pysyvän rakennelmatunnuksen luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Pysyvän rakennelmatunnuksen luonti epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Status/health": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "summary": "Get service health report",
+        "description": "Provides an indication about the health of the API",
+        "responses": {
+          "200": {
+            "description": "API is healthy or in a degraded but functional state",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthReport"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthReport"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthReport"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "API is unhealthy"
+          }
+        }
+      }
+    },
+    "/api/Structure/{permanentStructureIdentifier}": {
+      "get": {
+        "tags": [
+          "Structure"
+        ],
+        "summary": "Hae rakennelman kaikki tiedot Ryhdin REST-rajapinnasta.",
+        "parameters": [
+          {
+            "name": "permanentStructureIdentifier",
+            "in": "path",
+            "description": "Rakennelman pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakennelman haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakennelmaa ei löytynyt pysyvällä rakennelmatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakennelman tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AcceptedDeviation": {
+        "required": [
+          "acceptedDeviationKey",
+          "contentOfDeviation"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deviationType": {
+            "type": "string",
+            "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
+          },
+          "contentOfDeviation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Luvan yhteydessä myönnettävä poikkeaminen"
+      },
+      "Address": {
+        "required": [
+          "addressKey"
+        ],
+        "type": "object",
+        "properties": {
+          "addressKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "addressName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "numberPartOfAddressNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
+            "nullable": true
+          },
+          "location": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/RyhtiGeometry"
-              },
-              "nullable": true
-            }
+              }
+            ],
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennuskohteen sijaintitiedot"
-        },
-        "BuildingObjectOwner": {
-          "required": [
-            "buildingObjectOwnerKey",
-            "differentOwner",
-            "ownerOperator"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectOwnerKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "ownerOperator": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": ""
-            },
-            "differentOwner": {
-              "type": "boolean",
-              "description": ""
-            },
-            "tenureStatus": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "ownerContactOperator": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "ownerType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/09",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/10",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/11",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/12",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/13",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/14"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen omistajan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/OmistajanLahde\">http://uri.suomi.fi/codelist/rytj/OmistajanLahde</a>"
-            }
+          "numberPartOfAddressNumber2": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennuskohteen omistaja"
+          "subdivisionLetterOfAddressNumber2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
         },
-        "BuildingPermitApplication": {
-          "required": [
-            "applicationContent",
-            "dateOfReception",
-            "lifeCycleState",
-            "permitApplicationKey",
-            "permitApplicationType"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+        "additionalProperties": false,
+        "description": "Osoite"
+      },
+      "AdministrativeLocationUnit": {
+        "required": [
+          "administrativeLocationUnitKey",
+          "propertyIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "administrativeLocationUnitKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "unitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "unseparatedParcelIdentifier": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hallinnollinen sijaintiyksikkö"
+      },
+      "Apartment": {
+        "required": [
+          "addressNumber",
+          "apartmentKey",
+          "apartmentType",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "apartmentKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
+            ],
+            "type": "string",
+            "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "apartmentEquipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApartmentEquipment"
             },
-            "applicationContent": {
-              "minLength": 1,
+            "nullable": true
+          },
+          "apartmentIdentifier": {
+            "type": "string"
+          },
+          "apartmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+            ],
+            "type": "string",
+            "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+          },
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "numberOfRooms": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "kitchenType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+            ],
+            "type": "string",
+            "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
+            "nullable": true
+          },
+          "isWaterCloset": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "apartmentChangeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+            ],
+            "type": "string",
+            "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "apartmentStorey": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Huoneisto"
+      },
+      "ApartmentEquipment": {
+        "required": [
+          "apartmentEquipmentKey",
+          "apartmentEquipmentType",
+          "numberOfEquipment"
+        ],
+        "type": "object",
+        "properties": {
+          "apartmentEquipmentKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "apartmentEquipmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/01",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/02",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/03",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/04",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/05"
+            ],
+            "type": "string",
+            "description": "Huoneiston varusteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste\">http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste</a>",
+            "nullable": true
+          },
+          "numberOfEquipment": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Huoneiston varuste"
+      },
+      "AreaToBeBuiltForSpecificActivities": {
+        "required": [
+          "areaToBeBuiltForSpecificActivitiesKey",
+          "buildingObjectOwner",
+          "buildingObjectType"
+        ],
+        "type": "object",
+        "properties": {
+          "areaToBeBuiltForSpecificActivitiesKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specificActivitiesAreaType": {
+            "type": "string",
+            "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
+            },
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Erityistä toimintaa varten rakennettava alue"
+      },
+      "AssemblyFacility": {
+        "required": [
+          "assemblyFacilityKey",
+          "capacityOfAssemblyFacilities"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "assemblyFacilityKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "capacityOfAssemblyFacilities": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kokoontumistila"
+      },
+      "Building": {
+        "required": [
+          "buildingKey",
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "mainPurpose",
+          "numberOfStoreys"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string",
+            "description": "Pysyvä rakennustunnus (PRT)"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Onko väliaikainen",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "description": "Demolition deadline",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "description": "Kerrosluku",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingSection"
+            },
+            "description": "Rakennuksen osat",
+            "nullable": true
+          },
+          "mainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string",
+            "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö"
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuksen tiedot."
+      },
+      "BuildingAttachmentDocument": {
+        "required": [
+          "attachmentDocumentKey",
+          "categoryOfPublicity",
+          "documentDate",
+          "documentIdentifier",
+          "fileKey",
+          "languages",
+          "name",
+          "personalDataContent",
+          "retentionTime"
+        ],
+        "type": "object",
+        "properties": {
+          "attachmentDocumentKey": {
+            "type": "string",
+            "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
+            "format": "uuid"
+          },
+          "documentIdentifier": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          },
+          "personalDataContent": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
+          },
+          "categoryOfPublicity": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
+          },
+          "accessibility": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "retentionTime": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
+          },
+          "confirmationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "dateOfReception": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
-            },
-            "permitApplicationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitApplicationType": {
-              "type": "string",
-              "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>"
-            }
+            "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
           },
-          "additionalProperties": false,
-          "description": "Rakentamislupahakemus"
-        },
-        "BuildingPermitDecision": {
-          "required": [
-            "buildingPermitDecisionKey"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "buildingPermitDecisionKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitApplicationType": {
-              "type": "string",
-              "nullable": true
-            },
-            "constructionToBeStartedBy": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedBy": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeStartedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
-              },
-              "nullable": true
-            }
+          "fileKey": {
+            "type": "string",
+            "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
+            "format": "uuid"
           },
-          "additionalProperties": false,
-          "description": "Rakentamislupapäätös"
+          "descriptors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Descriptor"
+            },
+            "nullable": true
+          },
+          "documentDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "arrivedDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "attachmentType": {
+            "type": "string",
+            "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
+          },
+          "documentCreatorPersonalIdentityCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCreatorOtherId": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCreatorFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCreatorFamilyName": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "BuildingPermitIssue": {
-          "required": [
-            "buildingPermitApplication",
-            "buildingSite",
-            "constructionAction",
-            "dateOfInitiation",
-            "decision",
-            "lifeCycleState",
-            "municipalityNumber",
-            "permanentPermitIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date",
-              "nullable": true
+        "additionalProperties": false,
+        "description": "Liiteasiakirja"
+      },
+      "BuildingInformationModel": {
+        "required": [
+          "buildingInformationModelKey",
+          "buildingInformationModelType"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingInformationModelKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModelType": {
+            "type": "string",
+            "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
             },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>"
-            },
-            "municipalityNumber": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "permanentPermitIdentifier": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "decision": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingPermitDecision"
-                }
-              ],
-              "description": "Rakentamislupapäätös",
-              "nullable": true
-            },
-            "extensionDecision": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExtensionDecision"
-              },
-              "nullable": true
-            },
-            "changePermit": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangePermit"
-              },
-              "nullable": true
-            },
-            "buildingPermitApplication": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingPermitApplication"
-              },
-              "description": "Rakentamislupahakemus",
-              "nullable": true
-            },
-            "constructionAction": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
+            "nullable": true
+          },
+          "referencePoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennustietomalli"
+      },
+      "BuildingMaterialOfLoadBearingStructures": {
+        "required": [
+          "buildingMaterialOfLoadBearingStructuresKey",
+          "buildingMaterialOfLoadBearingStructuresType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingMaterialOfLoadBearingStructuresKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingMaterialOfLoadBearingStructuresType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/00",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/01",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/02",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/03",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/04",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/99"
+            ],
+            "type": "string",
+            "description": "Kantavan rakenteen rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine\">http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine</a>"
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kantavien rakenteiden rakennusaine"
+      },
+      "BuildingObjectChange": {
+        "required": [
+          "buildingObjectChangeKey"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectChangeKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "volumeChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "grossFloorAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "permittedBuildingAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "totalAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "floorAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "basementAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfStoreysChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuskohteen muutos"
+      },
+      "BuildingObjectIssue": {
+        "required": [
+          "buildingObjectIssueKey",
+          "constructionAction",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectIssueKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionAction": {
+            "required": [
+              "constructionActionKey",
+              "constructionActionType",
+              "statusOfConstructionAction"
+            ],
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/ConstructionAction"
               }
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka"
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "constructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionProject"
-                }
-              ],
-              "description": "Rakentamishanke",
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
+            ],
+            "description": "Rakentamistoimenpide"
           },
-          "additionalProperties": false,
-          "description": "Rakentamislupa-asia"
-        },
-        "BuildingSection": {
-          "required": [
-            "buildingSectionKey",
-            "buildingServicesEngineeringData",
-            "energyData",
-            "exteriorData",
-            "interiorData",
-            "lifeCycleState",
-            "materialData",
-            "partitionReason",
-            "usageData"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingSectionKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-              ],
-              "type": "string",
-              "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/rakelinvaih\">http://uri.suomi.fi/codelist/rakrek/rakelinvaih</a>"
-            },
-            "completionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "protectionMethod": {
-              "type": "string",
-              "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suojtapa\">http://uri.suomi.fi/codelist/rytj/suojtapa</a>",
-              "nullable": true
-            },
-            "cultureHistoricalSignificance": {
-              "type": "string",
-              "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/kulthistmer\">http://uri.suomi.fi/codelist/rakrek/kulthistmer</a>",
-              "nullable": true
-            },
-            "materialData": {
-              "required": [
-                "constructionMethod",
-                "buildingMaterialOfLoadBearingStructures",
-                "wideBodiedBuilding"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/MaterialData"
-                }
-              ],
-              "description": ""
-            },
-            "energyData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EnergyData"
-                }
-              ],
-              "description": ""
-            },
-            "interiorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/InteriorData"
-                }
-              ],
-              "description": ""
-            },
-            "exteriorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ExteriorData"
-                }
-              ],
-              "description": ""
-            },
-            "buildingServicesEngineeringData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                }
-              ],
-              "description": ""
-            },
-            "usageData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/UsageData"
-                }
-              ],
-              "description": ""
-            },
-            "equipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Equipment"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "entrance": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Entrance"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "assemblyFacility": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AssemblyFacility"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "elevator": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Elevator"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "apartment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Apartment"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "partitionReason": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-              ],
-              "type": "string",
-              "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji\">http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji</a>"
-            },
-            "partitionDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "civilDefenceShelter": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CivilDefenceShelter"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "relatedFinishedBuildingSection": {
-              "type": "string",
-              "description": "",
-              "format": "uuid",
-              "nullable": true
-            },
-            "demolitionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuksen osa"
-        },
-        "BuildingServicesEngineeringData": {
-          "type": "object",
-          "properties": {
-            "ventilationMethod": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/VentilationMethod"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "sewerageMethodType": {
-              "type": "string",
-              "description": "Jätevesien käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jatevesienkasittely\">http://uri.suomi.fi/codelist/rytj/jatevesienkasittely</a>",
-              "nullable": true
-            },
-            "householdWaterType": {
-              "type": "string",
-              "description": "Talousveden laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/talousvesi\">http://uri.suomi.fi/codelist/rytj/talousvesi</a>",
-              "nullable": true
-            },
-            "networkConnection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/NetworkConnection"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "stormWaterTreatmentType": {
-              "type": "string",
-              "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Talotekniikkatiedot"
-        },
-        "BuildingSite": {
-          "required": [
-            "buildingSiteAddress",
-            "buildingSiteKey",
-            "statusOfPlan",
-            "stormWaterTreatmentType",
-            "tenure"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingSiteKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "area": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "stormWaterTreatmentType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>"
-            },
-            "buildingSiteAddress": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
               }
-            },
-            "spatialPlan": {
-              "type": "string",
-              "nullable": true
-            },
-            "statusOfPlan": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/01",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/02",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/03",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/04",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/05",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/06",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/07",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/08",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/09"
-              ],
-              "type": "string",
-              "description": "Kaavatilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaava\">http://uri.suomi.fi/codelist/vtj/Rake_kaava</a>"
-            },
-            "tenure": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/1",
-                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/2",
-                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
-              ],
-              "type": "string",
-              "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>"
-            }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennuspaikka"
-        },
-        "CalculatoryDeliveredEnergyUsage": {
-          "required": [
-            "calculatoryDeliveredEnergyUsageKey",
-            "deliveredEnergyType",
-            "energyAmountYearly"
-          ],
-          "type": "object",
-          "properties": {
-            "calculatoryDeliveredEnergyUsageKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
             },
-            "deliveredEnergyType": {
-              "type": "string",
-              "description": "Ostoenergian laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ostoenergia\">http://uri.suomi.fi/codelist/rytj/ostoenergia</a>"
-            },
-            "energyAmountYearly": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Energiankulutus"
+          "municipalityNumber": {
+            "type": "string"
+          }
         },
-        "CallForDeviation": {
-          "required": [
-            "callForDeviationKey",
-            "contentOfDeviation",
-            "deviationType"
-          ],
-          "type": "object",
-          "properties": {
-            "callForDeviationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "deviationType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
-            },
-            "contentOfDeviation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            }
+        "additionalProperties": false,
+        "description": "Rakennuskohdeasia"
+      },
+      "BuildingObjectLocationData": {
+        "required": [
+          "buildingObjectLocationDataKey"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectLocationDataKey": {
+            "type": "string",
+            "format": "uuid"
           },
-          "additionalProperties": false,
-          "description": "Määräyksestä poikkeaminen"
-        },
-        "ChangeInformationAdministrativeLocationUnit": {
-          "type": "object",
-          "properties": {
-            "administrativeLocationUnitKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "unitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "propertyIdentifier": {
-              "type": "string"
-            },
-            "unseparatedParcelIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "property": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Property"
-                }
-              ],
-              "description": "Kiinteistö",
-              "nullable": true
-            },
-            "parcel": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/UnseparatedParcel"
-                }
-              ],
-              "description": "Määräala",
-              "nullable": true
-            }
+          "votingDistrictNumber": {
+            "type": "string"
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationApartment": {
-          "type": "object",
-          "properties": {
-            "apartmentKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-              ],
-              "type": "string",
-              "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "apartmentEquipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ApartmentEquipment"
-              },
-              "nullable": true
-            },
-            "apartmentIdentifier": {
-              "type": "string"
-            },
-            "apartmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-              ],
-              "type": "string",
-              "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
-            },
-            "floorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "numberOfRooms": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "kitchenType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-              ],
-              "type": "string",
-              "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-              "nullable": true
-            },
-            "isWaterCloset": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "apartmentChangeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-              ],
-              "type": "string",
-              "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "apartmentStorey": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "housingType": {
-              "type": "string",
-              "nullable": true
-            },
-            "occupancyOfApartment": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentNumber": {
-              "type": "integer",
-              "format": "int32"
-            }
+          "pointLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ]
           },
-          "additionalProperties": false
+          "geometry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RyhtiGeometry"
+            },
+            "nullable": true
+          }
         },
-        "ChangeInformationAreaToBeBuiltForSpecificActivities": {
-          "type": "object",
-          "properties": {
-            "areaToBeBuiltForSpecificActivitiesKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "specificActivitiesAreaType": {
-              "type": "string",
-              "nullable": true
-            },
-            "networkConnection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/NetworkConnection"
-              },
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "temporary": {
-              "type": "boolean"
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            }
+        "additionalProperties": false,
+        "description": "Rakennuskohteen sijaintitiedot"
+      },
+      "BuildingObjectOwner": {
+        "required": [
+          "buildingObjectOwnerKey",
+          "differentOwner",
+          "ownerOperator"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectOwnerKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationStructure": {
-          "required": [
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "structureMainPurpose"
-          ],
-          "type": "object",
-          "properties": {
-            "structureKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentStructureIdentifier": {
-              "type": "string"
-            },
-            "temporary": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "structureSection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/StructureSection"
-              },
-              "nullable": true
-            },
-            "structureMainPurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string",
-              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ]
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja",
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
+          "ownerOperator": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": ""
           },
-          "additionalProperties": false
-        },
-        "ChangePermit": {
-          "required": [
-            "changePermitKey"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "changePermitKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            }
+          "differentOwner": {
+            "type": "boolean",
+            "description": ""
           },
-          "additionalProperties": false,
-          "description": "Muutospäätös"
-        },
-        "CivilDefenceShelter": {
-          "required": [
-            "civilDefenceShelterCapacity",
-            "civilDefenceShelterClass",
-            "civilDefenceShelterKey",
-            "civilDefenceShelterShared"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "civilDefenceShelterKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "civilDefenceShelterClass": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Väestönsuojan luokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka\">http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka</a>"
-            },
-            "civilDefenceShelterCapacity": {
-              "type": "integer",
-              "description": "Väestönsuojan suojapaikkojen määrä",
-              "format": "int32"
-            },
-            "civilDefenceShelterShared": {
-              "type": "boolean"
-            },
-            "civilDefenceShelterAdditionalInformation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "civilDefenceShelterOtherBuildings": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CivilDefenceShelterOtherBuildings"
-              },
-              "nullable": true
-            }
+          "tenureStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Väestönsuoja"
-        },
-        "CivilDefenceShelterOtherBuildings": {
-          "required": [
-            "civilDefenceShelterOtherBuildingsKey",
-            "permanentBuildingIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "civilDefenceShelterOtherBuildingsKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentBuildingIdentifier": {
-              "maxLength": 10,
-              "minLength": 10,
-              "type": "string"
-            },
-            "civilDefenceShelterPointedCapacity": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32"
-            }
+          "ownerContactOperator": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Väestönsuojan muut rakennukset"
+          "ownerType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/09",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/10",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/11",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/12",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/13",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/14"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen omistajan laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/OmistajanLahde"
+          }
         },
-        "ConstructionAction": {
-          "required": [
-            "building",
-            "constructionActionKey",
-            "constructionActionType",
-            "descriptionOfAction",
-            "renovation",
-            "statusOfConstructionAction"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionActionKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "constructionActionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>"
-            },
-            "buildingObjectChange": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectChange"
-                }
-              ],
-              "description": "Rakennuskohteen muutos",
-              "nullable": true
-            },
-            "descriptionOfAction": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "areaUndergoingChanges": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-              "nullable": true
-            },
-            "renovation": {
-              "type": "boolean"
-            },
-            "renovationRate": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "building": {
-              "required": [
-                "buildingKey",
-                "numberOfStoreys",
-                "mainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Building"
-                }
-              ],
-              "description": "Rakennuksen tiedot."
-            },
-            "finishedBuilding": {
-              "required": [
-                "buildingKey",
-                "numberOfStoreys",
-                "mainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Building"
-                }
-              ],
-              "description": "Rakennuksen tiedot.",
-              "nullable": true
-            },
-            "structure": {
-              "required": [
-                "structureMainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            },
-            "finishedStructure": {
-              "required": [
-                "structureMainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            },
-            "areaToBeBuiltForSpecificActivities": {
-              "required": [
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-                }
-              ],
-              "description": "Erityistä toimintaa varten rakennettava alue",
-              "nullable": true
-            },
-            "startDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "statusOfConstructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-              "nullable": true
-            },
-            "fullyApprovedForUse": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "businessConstruction": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "changeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-              ],
-              "type": "string",
-              "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-              "nullable": true
-            },
-            "dvvPermitIdentifier": {
-              "pattern": "^[0-9]{8}[-][0-9]{11}$",
-              "type": "string",
-              "nullable": true
-            },
-            "expiryDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "finishedAreaToBeBuiltForSpecificActivities": {
-              "required": [
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-                }
-              ],
-              "description": "Erityistä toimintaa varten rakennettava alue",
-              "nullable": true
-            }
+        "additionalProperties": false,
+        "description": "Rakennuskohteen omistaja"
+      },
+      "BuildingPermitApplication": {
+        "required": [
+          "applicationContent",
+          "lifeCycleState",
+          "permitApplicationKey"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakentamistoimenpide"
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "permitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          }
         },
-        "ConstructionDesign": {
-          "required": [
-            "constructionDesignKey",
-            "document"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionDesignKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
+        "additionalProperties": false,
+        "description": "Rakentamislupahakemus"
+      },
+      "BuildingPermitDecision": {
+        "required": [
+          "buildingPermitDecisionKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
             },
-            "constructionDesignType": {
-              "type": "string",
-              "description": "Rakennusssuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/raksuunlajit\">http://uri.suomi.fi/codelist/rytj/raksuunlajit</a>"
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
             },
-            "document": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
               }
-            }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennussuunnitelma"
-        },
-        "ConstructionProject": {
-          "required": [
-            "constructionProjectKey"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionProjectKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "descriptionOfConstructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "startDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "endDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "planner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Planner"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "foreman": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Foreman"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "inspection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Inspection"
-              },
-              "description": "",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakentamishanke"
-        },
-        "ContactAddress": {
-          "required": [
-            "addressKey",
-            "postalCode"
-          ],
-          "type": "object",
-          "properties": {
-            "addressKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "addressName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "numberPartOfAddressNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "postalCode": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "numberPartOfAddressNumber2": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber2": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentIdentifierNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "apartmentIdentifierSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalAddressAttribute": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "c_O": {
-              "type": "string",
-              "nullable": true
-            },
-            "poBoxAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "countryCode": {
-              "type": "string",
-              "description": "Maakoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-              "nullable": true
-            },
-            "foreignAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "foreignPostalAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "additionalForeignAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "postalAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "contactAddressType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/06",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/07",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/08"
-              ],
-              "type": "string",
-              "description": "Yhteysosoitteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji\">http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji</a>"
-            },
-            "source": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/01",
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/02",
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/03",
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/04"
-              ],
-              "type": "string",
-              "description": "Tietolähde. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tietolahde\">http://uri.suomi.fi/codelist/rytj/tietolahde</a>"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Yhteysosoite"
-        },
-        "CoolingEnergySource": {
-          "required": [
-            "coolingEnergySourceKey",
-            "coolingEnergySourceType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "coolingEnergySourceKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "coolingEnergySourceType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/01",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/02",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/03",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/04",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/05",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/06",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/07",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/08"
-              ],
-              "type": "string",
-              "description": "Jäähdytysenergian lähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytys\">http://uri.suomi.fi/codelist/rytj/jaahdytys</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Jäähdytysenergian lähde"
-        },
-        "CoolingMethod": {
-          "required": [
-            "coolingMethodKey",
-            "coolingMethodType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "coolingMethodKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "coolingMethodType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/01",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/02",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/03"
-              ],
-              "type": "string",
-              "description": "Jäähdytystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytystapa\">http://uri.suomi.fi/codelist/rytj/jaahdytystapa</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Jäähdytystapa"
-        },
-        "CustomValidationError": {
-          "type": "object",
-          "properties": {
-            "ruleId": {
-              "type": "string",
-              "nullable": true
-            },
-            "message": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            },
-            "classKey": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "CustomValidationProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            },
-            "errors": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CustomValidationError"
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
-            },
-            "warnings": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CustomValidationError"
-              }
-            }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": { }
-        },
-        "DemolitionPermitApplication": {
-          "required": [
-            "applicationContent",
-            "dateOfReception",
-            "demolitionPermitApplicationKey",
-            "lifeCycleState",
-            "permitApplicationType"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
             },
-            "applicationContent": {
-              "minLength": 1,
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "dateOfReception": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "buildingPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
             },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamislupapäätös"
+      },
+      "BuildingPermitIssue": {
+        "required": [
+          "buildingPermitApplication",
+          "decision",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "decision": {
+            "required": [
+              "buildingPermitDecisionKey",
+              "lifeCycleState"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
             },
-            "demolitionPermitApplicationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
             },
-            "permitApplicationType": {
-              "type": "string",
-              "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>"
+            "nullable": true
+          },
+          "buildingPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPermitApplication"
+            },
+            "description": "Rakentamislupahakemus",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionAction"
             }
           },
-          "additionalProperties": false,
-          "description": "PurkamislupaHakemus"
-        },
-        "DemolitionPermitDecision": {
-          "required": [
-            "constructionToBeCompletedBy",
-            "constructionToBeStartedBy",
-            "dateOfDecision",
-            "decisionDate",
-            "decisionDocument",
-            "decisionMakerName",
-            "decisionMakerType",
-            "decisionText",
-            "demolitionPermitDecisionKey",
-            "engagingParty",
-            "permitApplicationType"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfDecision": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja"
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>"
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "demolitionPermitDecisionKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitApplicationType": {
-              "type": "string"
-            },
-            "constructionToBeStartedBy": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "constructionToBeCompletedBy": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "constructionToBeStartedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
               }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamislupa-asia"
+      },
+      "BuildingSection": {
+        "required": [
+          "buildingSectionKey",
+          "lifeCycleState",
+          "partitionReason",
+          "usageData"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "exteriorData": {
+            "required": [
+              "shape"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "usageData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsageData"
+              }
+            ],
+            "description": ""
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Apartment"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string",
+            "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "description": "",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuksen osa"
+      },
+      "BuildingServicesEngineeringData": {
+        "type": "object",
+        "properties": {
+          "ventilationMethod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VentilationMethod"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "sewerageMethodType": {
+            "type": "string",
+            "description": "Jätevesien käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/jatevesienkasittely",
+            "nullable": true
+          },
+          "householdWaterType": {
+            "type": "string",
+            "description": "Talousveden laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/talousvesi",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "stormWaterTreatmentType": {
+            "type": "string",
+            "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/hulevedenkasittely",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Talotekniikkatiedot"
+      },
+      "BuildingSite": {
+        "required": [
+          "stormWaterTreatmentType",
+          "tenure"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingSiteKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "area": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "stormWaterTreatmentType": {
+            "type": "string",
+            "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
+            "nullable": true
+          },
+          "buildingSiteAddress": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "spatialPlan": {
+            "type": "string",
+            "nullable": true
+          },
+          "statusOfPlan": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/01",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/02",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/03",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/04",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/05",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/06",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/07",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/08",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/09"
+            ],
+            "type": "string",
+            "description": "Kaavatilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaava\">http://uri.suomi.fi/codelist/vtj/Rake_kaava</a>",
+            "nullable": true
+          },
+          "tenure": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/1",
+              "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/2",
+              "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
+            ],
+            "type": "string",
+            "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuspaikka"
+      },
+      "CalculatoryDeliveredEnergyUsage": {
+        "required": [
+          "calculatoryDeliveredEnergyUsageKey",
+          "deliveredEnergyType",
+          "energyAmountYearly"
+        ],
+        "type": "object",
+        "properties": {
+          "calculatoryDeliveredEnergyUsageKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deliveredEnergyType": {
+            "type": "string",
+            "description": "Ostoenergian laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ostoenergia\">http://uri.suomi.fi/codelist/rytj/ostoenergia</a>"
+          },
+          "energyAmountYearly": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Energiankulutus"
+      },
+      "CallForDeviation": {
+        "required": [
+          "callForDeviationKey",
+          "contentOfDeviation",
+          "deviationType"
+        ],
+        "type": "object",
+        "properties": {
+          "callForDeviationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deviationType": {
+            "type": "string",
+            "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
+          },
+          "contentOfDeviation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Määräyksestä poikkeaminen"
+      },
+      "ChangeInformationAdministrativeLocationUnit": {
+        "type": "object",
+        "properties": {
+          "administrativeLocationUnitKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "unitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "unseparatedParcelIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "property": {
+            "required": [
+              "municipalityNumber",
+              "propertyIdentifier",
+              "status",
+              "type",
+              "relationToBaseProperty"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Property"
+              }
+            ],
+            "description": "Kiinteistö",
+            "nullable": true
+          },
+          "parcel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UnseparatedParcel"
+              }
+            ],
+            "description": "Määräala",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationApartment": {
+        "type": "object",
+        "properties": {
+          "apartmentKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
+            ],
+            "type": "string",
+            "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "apartmentEquipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApartmentEquipment"
+            },
+            "nullable": true
+          },
+          "apartmentIdentifier": {
+            "type": "string"
+          },
+          "apartmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+            ],
+            "type": "string",
+            "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+          },
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "numberOfRooms": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "kitchenType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+            ],
+            "type": "string",
+            "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
+            "nullable": true
+          },
+          "isWaterCloset": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "apartmentChangeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+            ],
+            "type": "string",
+            "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "apartmentStorey": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "housingType": {
+            "type": "string",
+            "nullable": true
+          },
+          "occupancyOfApartment": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationAreaToBeBuiltForSpecificActivities": {
+        "type": "object",
+        "properties": {
+          "areaToBeBuiltForSpecificActivitiesKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specificActivitiesAreaType": {
+            "type": "string",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
+            },
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuilding": {
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string",
+            "description": "Pysyvä rakennustunnus (PRT)"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Onko väliaikainen",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "description": "Demolition deadline",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "description": "Kerrosluku",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationBuildingSection"
+            },
+            "description": "Rakennuksen osat",
+            "nullable": true
+          },
+          "mainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string",
+            "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "mainPurpose1994": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfNewApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfDeletedApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingPermitIssue": {
+        "required": [
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "decision": {
+            "required": [
+              "buildingPermitDecisionKey",
+              "lifeCycleState"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "buildingPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPermitApplication"
+            },
+            "description": "Rakentamislupahakemus",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationConstructionAction"
             }
           },
-          "additionalProperties": false,
-          "description": "Rakentamislupapäätös"
-        },
-        "DemolitionPermitIssue": {
-          "required": [
-            "buildingSite",
-            "constructionAction",
-            "dateOfInitiation",
-            "demolitionDecision",
-            "demolitionPermitApplication",
-            "lifeCycleState",
-            "municipalityNumber"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date"
-            },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>"
-            },
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "demolitionPermitApplication": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DemolitionPermitApplication"
-              },
-              "description": "Purkamislupahakemus"
-            },
-            "demolitionDecision": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DemolitionPermitDecision"
-                }
-              ],
-              "description": "Purkamislupapäätös"
-            },
-            "extensionDecision": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExtensionDecision"
-              },
-              "nullable": true
-            },
-            "changePermit": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangePermit"
-              },
-              "nullable": true
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka"
-            },
-            "constructionAction": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionAction"
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
               }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
             },
-            "attachment": {
-              "type": "array",
-              "items": {
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "dateOfInitiation": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingSection": {
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "Materiaalitiedot",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "Energiatiedot",
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "Sisätilojen tiedot",
+            "nullable": true
+          },
+          "exteriorData": {
+            "required": [
+              "shape"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "Ulkokuoren tiedot",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "Talotekniikkatiedot",
+            "nullable": true
+          },
+          "usageData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsageData"
+              }
+            ],
+            "description": "Rakennuksen käyttötiedot"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
+            },
+            "nullable": true
+          },
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
+            },
+            "nullable": true
+          },
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
+            },
+            "nullable": true
+          },
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
+            },
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationApartment"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationConstructionAction": {
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureMainPurpose",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "locatedOnUnseparatedParcel": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationStructure": {
+        "required": [
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "structureMainPurpose"
+        ],
+        "type": "object",
+        "properties": {
+          "structureKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentStructureIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
+          "structureMainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string",
+            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangePermit": {
+        "required": [
+          "changePermitKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "constructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionProject"
-                }
-              ],
-              "description": "Rakentamishanke",
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "permanentPermitIdentifier": {
-              "maxLength": 10,
-              "minLength": 10,
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Purkamislupa-asia"
-        },
-        "Descriptor": {
-          "type": "object",
-          "properties": {
-            "descriptorIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "vocabulary": {
-              "type": "string",
-              "nullable": true
-            },
-            "descriptor": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "DeviationObject": {
-          "required": [
-            "address",
-            "administrativeLocationUnit",
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "deviationObjectKey",
-            "location"
-          ],
-          "type": "object",
-          "properties": {
-            "deviationObjectKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "totalArea": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot"
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja"
-            },
-            "address": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
               }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
             },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
             },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "changePermitKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Muutospäätös"
+      },
+      "CivilDefenceShelter": {
+        "required": [
+          "civilDefenceShelterCapacity",
+          "civilDefenceShelterClass",
+          "civilDefenceShelterKey",
+          "civilDefenceShelterShared"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "civilDefenceShelterKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "civilDefenceShelterClass": {
+            "type": "string",
+            "description": "Väestönsuojan luokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka\">http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka</a>",
+            "nullable": true
+          },
+          "civilDefenceShelterCapacity": {
+            "type": "integer",
+            "description": "Väestönsuojan suojapaikkojen määrä",
+            "format": "int32"
+          },
+          "civilDefenceShelterShared": {
+            "type": "boolean"
+          },
+          "civilDefenceShelterAdditionalInformation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelterOtherBuildings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelterOtherBuildings"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Väestönsuoja"
+      },
+      "CivilDefenceShelterOtherBuildings": {
+        "required": [
+          "civilDefenceShelterOtherBuildingsKey",
+          "civilDefenceShelterPointedCapacity",
+          "permanentBuildingIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "civilDefenceShelterOtherBuildingsKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string"
+          },
+          "civilDefenceShelterPointedCapacity": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Väestönsuojan muut rakennukset"
+      },
+      "ConstructionAction": {
+        "required": [
+          "constructionActionKey",
+          "constructionActionType",
+          "statusOfConstructionAction"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "required": [
+              "buildingKey",
+              "numberOfStoreys",
+              "mainPurpose",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Building"
+              }
+            ],
+            "description": "Rakennuksen tiedot.",
+            "nullable": true
+          },
+          "finishedBuilding": {
+            "required": [
+              "buildingKey",
+              "numberOfStoreys",
+              "mainPurpose",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Building"
+              }
+            ],
+            "description": "Rakennuksen tiedot.",
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "administrativeLocationUnit",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "finishedStructure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "administrativeLocationUnit",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "required": [
+              "areaToBeBuiltForSpecificActivitiesKey",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "description": "Erityistä toimintaa varten rakennettava alue",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "finishedAreaToBeBuiltForSpecificActivities": {
+            "required": [
+              "areaToBeBuiltForSpecificActivitiesKey",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "description": "Erityistä toimintaa varten rakennettava alue",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamistoimenpide"
+      },
+      "ConstructionDesign": {
+        "required": [
+          "constructionDesignKey",
+          "constructionDesignType",
+          "document"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionDesignKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionDesignType": {
+            "type": "string",
+            "description": "Rakennusssuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/raksuunlajit\">http://uri.suomi.fi/codelist/rytj/raksuunlajit</a>"
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennussuunnitelma"
+      },
+      "ConstructionProject": {
+        "required": [
+          "constructionProjectKey"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionProjectKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "descriptionOfConstructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "planner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Planner"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "foreman": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Foreman"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "inspection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Inspection"
+            },
+            "description": "",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamishanke"
+      },
+      "ContactAddress": {
+        "required": [
+          "addressKey"
+        ],
+        "type": "object",
+        "properties": {
+          "addressKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "addressName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "numberPartOfAddressNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
+            "nullable": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "numberPartOfAddressNumber2": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber2": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentIdentifierNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "apartmentIdentifierSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalAddressAttribute": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "c_O": {
+            "type": "string",
+            "nullable": true
+          },
+          "poBoxAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "Maakoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
+            "nullable": true
+          },
+          "foreignAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "foreignPostalAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "additionalForeignAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "contactAddressType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/08"
+            ],
+            "type": "string",
+            "description": "Yhteysosoitteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji\">http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji</a>"
+          },
+          "source": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/01",
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/02",
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/03",
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/04"
+            ],
+            "type": "string",
+            "description": "Tietolähde. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tietolahde\">http://uri.suomi.fi/codelist/rytj/tietolahde</a>"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Yhteysosoite"
+      },
+      "CoolingEnergySource": {
+        "required": [
+          "coolingEnergySourceKey",
+          "coolingEnergySourceType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "coolingEnergySourceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "coolingEnergySourceType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/01",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/02",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/03",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/04",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/05",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/06",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/07",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/08"
+            ],
+            "type": "string",
+            "description": "Jäähdytysenergian lähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytys\">http://uri.suomi.fi/codelist/rytj/jaahdytys</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Jäähdytysenergian lähde"
+      },
+      "CoolingMethod": {
+        "required": [
+          "coolingMethodKey",
+          "coolingMethodType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "coolingMethodKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "coolingMethodType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/01",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/02",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/03"
+            ],
+            "type": "string",
+            "description": "Jäähdytystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytystapa\">http://uri.suomi.fi/codelist/rytj/jaahdytystapa</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Jäähdytystapa"
+      },
+      "CustomValidationError": {
+        "type": "object",
+        "properties": {
+          "ruleId": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "classKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomValidationError"
             }
           },
-          "additionalProperties": false,
-          "description": "Poikkeamisen kohde"
-        },
-        "DeviationPermitApplication": {
-          "required": [
-            "applicationContent",
-            "constructionDesign",
-            "dateOfReception",
-            "deviationPermitApplicationKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "applicationContent": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "dateOfReception": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
-            },
-            "deviationPermitApplicationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              }
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              }
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomValidationError"
             }
-          },
-          "additionalProperties": false,
-          "description": "Poikkeamislupahakemus"
+          }
         },
-        "DeviationPermitDecision": {
-          "required": [
-            "dateOfDecision",
-            "decisionDate",
-            "decisionDocument",
-            "decisionInForceUntil",
-            "decisionMakerName",
-            "decisionMakerType",
-            "decisionText",
-            "deviationPermitDecisionKey",
-            "engagingParty"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfDecision": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja"
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>"
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "deviationPermitDecisionKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "expiryDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
-              },
-              "description": ""
-            },
-            "decisionInForceUntil": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "date"
-            }
+        "additionalProperties": { }
+      },
+      "DemolitionPermitApplication": {
+        "required": [
+          "applicationContent",
+          "demolitionPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Poikkeamislupapäätös"
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "demolitionPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          }
         },
-        "DeviationPermitIssue": {
-          "required": [
-            "buildingSite",
-            "dateOfInitiation",
-            "deviationObject",
-            "deviationPermitApplication",
-            "deviationPermitDecision",
-            "lifeCycleState",
-            "municipalityNumber",
-            "permanentPermitIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date"
+        "additionalProperties": false,
+        "description": "PurkamislupaHakemus"
+      },
+      "DemolitionPermitDecision": {
+        "required": [
+          "demolitionPermitDecisionKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
             },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>"
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
             },
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "permanentPermitIdentifier": {
-              "maxLength": 10,
-              "minLength": 10,
-              "type": "string"
-            },
-            "recordNumber": {
-              "type": "string"
-            },
-            "deviationPermitDecision": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitDecision"
-                }
-              ],
-              "description": "Poikkeamislupapäätös"
-            },
-            "deviationPermitApplication": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitApplication"
-                }
-              ],
-              "description": "Poikkeamislupahakemus"
-            },
-            "deviationObject": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DeviationObject"
-              }
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka"
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Poikkeamislupa-asia"
-        },
-        "ElectricalEnergySource": {
-          "required": [
-            "electricalEnergySourceKey",
-            "electricalEnergySourceType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "electricalEnergySourceKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "electricalEnergySourceType": {
-              "type": "string",
-              "description": "Sähköenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde\">http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Sähköenergian lähde"
-        },
-        "Elevator": {
-          "required": [
-            "elevatorKey",
-            "elevatorType",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "elevatorKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "elevatorType": {
-              "type": "string",
-              "description": "Hissin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hissi\">http://uri.suomi.fi/codelist/rytj/hissi</a>"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
-              ],
-              "type": "string",
-              "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "insideLength": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "insideWidth": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "doorOpeningWidth": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "doorOpeningHeight": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "passengerCapacity": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "loadCapacity": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Hissi"
-        },
-        "EnergyData": {
-          "required": [
-            "energyDataKey",
-            "heatingMethod"
-          ],
-          "type": "object",
-          "properties": {
-            "energyDataKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "energyRating": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/08"
-              ],
-              "type": "string",
-              "description": "Energialuokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Energialuokka\">http://uri.suomi.fi/codelist/rytj/Energialuokka</a>",
-              "nullable": true
-            },
-            "computationalEnergyEfficiencyComparand": {
-              "type": "number",
-              "description": "",
-              "format": "double",
-              "nullable": true
-            },
-            "heatingMethod": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/HeatingMethod"
-              },
-              "description": ""
-            },
-            "heatingEnergySource": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/HeatingEnergySource"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "coolingMethod": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CoolingMethod"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "coolingEnergySource": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CoolingEnergySource"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "electricalEnergySource": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ElectricalEnergySource"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "netHeatedArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "heatedVolume": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "calculatoryDeliveredEnergyUsage": {
-              "required": [
-                "calculatoryDeliveredEnergyUsageKey",
-                "deliveredEnergyType",
-                "energyAmountYearly"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/CalculatoryDeliveredEnergyUsage"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "energyRatingSubindex": {
-              "type": "string",
-              "description": "Energiatehokkuusluokan alaindeksi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi\">http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi</a>",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Energiatiedot"
-        },
-        "EngagingParty": {
-          "required": [
-            "engagingPartyKey",
-            "isPerson"
-          ],
-          "type": "object",
-          "properties": {
-            "engagingPartyKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "personalIdentityCode": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "businessId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "isPerson": {
-              "type": "boolean",
-              "description": ""
-            },
-            "firstName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "familyName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "organizationName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "applicantContactOperator": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "languageCode": {
-              "type": "string",
-              "description": "IETF kielikoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes\">http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes</a>",
-              "nullable": true
-            },
-            "nationalityCode": {
-              "type": "string",
-              "description": "Valtiokoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-              "nullable": true
-            },
-            "deathDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Hankkeeseen ryhtyvä"
-        },
-        "Entrance": {
-          "required": [
-            "entranceKey",
-            "entranceType",
-            "geometry",
-            "isAccessible",
-            "isPrimary",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ]
-            },
-            "entranceKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            },
-            "entranceType": {
-              "type": "string",
-              "description": "Sisäänkäynnin tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sisaankaynti\">http://uri.suomi.fi/codelist/rytj/sisaankaynti</a>"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
-              ],
-              "type": "string",
-              "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "addressOfEntrance": {
-              "type": "string",
-              "nullable": true
-            },
-            "isAccessible": {
-              "type": "boolean",
-              "description": "Kerrosluku"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Sisäänkäynti"
-        },
-        "Equipment": {
-          "required": [
-            "equipmentKey",
-            "equipmentType"
-          ],
-          "type": "object",
-          "properties": {
-            "equipmentKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "equipmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/01",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/02",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/03",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/04",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/05",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/06",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/07",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/08",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/09",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/10"
-              ],
-              "type": "string",
-              "description": "Rakennuksen varuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennusvaruste\">http://uri.suomi.fi/codelist/rytj/rakennusvaruste</a>"
-            },
-            "equipmentCount": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Varuste"
-        },
-        "ExtensionDecision": {
-          "required": [
-            "extensionDecisionKey"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "extensionDecisionKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Jatkoaikapäätös"
-        },
-        "ExteriorData": {
-          "required": [
-            "grossFloorArea",
-            "numberOfStoreys",
-            "totalArea",
-            "volume"
-          ],
-          "type": "object",
-          "properties": {
-            "numberOfStoreys": {
-              "type": "integer",
-              "description": "",
-              "format": "int32"
-            },
-            "height": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "flightObstacle": {
-              "type": "boolean",
-              "description": "",
-              "nullable": true
-            },
-            "shape": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "description": ""
-            },
-            "relationToGroundLevel": {
-              "type": "string",
-              "description": "Suhde maan pintaan. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Suhde_pintaan\">http://uri.suomi.fi/codelist/rytj/Suhde_pintaan</a>",
-              "nullable": true
-            },
-            "volume": {
-              "type": "integer",
-              "description": "",
-              "format": "int32"
-            },
-            "grossFloorArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32"
-            },
-            "permittedBuildingArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "totalArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Ulkokuoren tiedot"
-        },
-        "FacadeMaterial": {
-          "required": [
-            "facadeMaterialKey",
-            "facadeMaterialType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "facadeMaterialKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "facadeMaterialType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/00",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/01",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/02",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/03",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/04",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/05",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/06",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/99"
-              ],
-              "type": "string",
-              "description": "Julkisivun rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine\">http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Julkisivumateriaali"
-        },
-        "Foreman": {
-          "required": [
-            "familyName",
-            "firstName",
-            "foremanKey"
-          ],
-          "type": "object",
-          "properties": {
-            "foremanKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "foremanRole": {
-              "type": "string",
-              "description": "Työnjohtajan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli\">http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli</a>"
-            },
-            "foremanCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "responsibilityStartDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "responsibilityEndDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ForemanBuildingReference"
-              },
-              "nullable": true
-            },
-            "structureReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ForemanStructureReference"
-              },
-              "nullable": true
-            },
-            "specificAreaReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            },
-            "requiredCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "personalIdentityCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "nullable": true
-            },
-            "firstName": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "familyName": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Työnjohtaja"
-        },
-        "ForemanBuildingReference": {
-          "required": [
-            "permanentBuildingIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifierReference": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennusviite"
-        },
-        "ForemanStructureReference": {
-          "required": [
-            "permanentStructureIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifierReference": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennelmaviite"
-        },
-        "ForemenPlannersConstructionProject": {
-          "type": "object",
-          "properties": {
-            "foreman": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Foreman"
-              },
-              "nullable": true
-            },
-            "planner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Planner"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GeneralizedBuilding": {
-          "type": "object",
-          "properties": {
-            "buildingKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentBuildingIdentifier": {
-              "type": "string"
-            },
-            "temporary": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "buildingSection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GeneralizedBuildingSection"
-              },
-              "nullable": true
-            },
-            "mainPurpose": {
-              "type": "string",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ]
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "addChangeEvent": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "mainPurpose1994": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "numberOfNewApartments": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "numberOfDeletedApartments": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GeneralizedBuildingPermitIssue": {
-          "required": [
-            "dateOfInitiation"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date",
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-              "nullable": true
-            },
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "permanentPermitIdentifier": {
-              "type": "string"
-            },
-            "decision": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingPermitDecision"
-                }
-              ],
-              "description": "Rakentamislupapäätös",
-              "nullable": true
-            },
-            "extensionDecision": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExtensionDecision"
-              },
-              "nullable": true
-            },
-            "changePermit": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangePermit"
-              },
-              "nullable": true
-            },
-            "buildingPermitApplication": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingPermitApplication"
-              },
-              "description": "Rakentamislupahakemus",
-              "nullable": true
-            },
-            "constructionAction": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GeneralizedConstructionAction"
               }
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "constructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionProject"
-                }
-              ],
-              "description": "Rakentamishanke",
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "GeneralizedBuildingSection": {
-          "type": "object",
-          "properties": {
-            "buildingSectionKey": {
-              "type": "string",
-              "format": "uuid"
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
             },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "protectionMethod": {
-              "type": "string",
-              "nullable": true
-            },
-            "cultureHistoricalSignificance": {
-              "type": "string",
-              "nullable": true
-            },
-            "materialData": {
-              "required": [
-                "constructionMethod",
-                "buildingMaterialOfLoadBearingStructures",
-                "wideBodiedBuilding"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/MaterialData"
-                }
-              ],
-              "description": "Materiaalitiedot",
-              "nullable": true
-            },
-            "energyData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EnergyData"
-                }
-              ],
-              "description": "Energiatiedot",
-              "nullable": true
-            },
-            "interiorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/InteriorData"
-                }
-              ],
-              "description": "Sisätilojen tiedot",
-              "nullable": true
-            },
-            "exteriorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ExteriorData"
-                }
-              ],
-              "description": "Ulkokuoren tiedot",
-              "nullable": true
-            },
-            "buildingServicesEngineeringData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                }
-              ],
-              "description": "Talotekniikkatiedot",
-              "nullable": true
-            },
-            "usageData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/GeneralizedUsageData"
-                }
-              ]
-            },
-            "equipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Equipment"
-              },
-              "nullable": true
-            },
-            "entrance": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Entrance"
-              },
-              "nullable": true
-            },
-            "assemblyFacility": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AssemblyFacility"
-              },
-              "nullable": true
-            },
-            "elevator": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Elevator"
-              },
-              "nullable": true
-            },
-            "apartment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationApartment"
-              },
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "partitionReason": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-              ],
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "partitionDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
             },
-            "civilDefenceShelter": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CivilDefenceShelter"
-              },
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamislupapäätös"
+      },
+      "DemolitionPermitIssue": {
+        "required": [
+          "demolitionDecision",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
             },
-            "relatedFinishedBuildingSection": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "demolitionPermitDecisionKey",
+              "lifeCycleState"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecision"
+              }
+            ],
+            "description": "Purkamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
             },
-            "demolitionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
             },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "nullable": true
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionAction"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Purkamislupa-asia"
+      },
+      "Descriptor": {
+        "type": "object",
+        "properties": {
+          "descriptorIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "vocabulary": {
+            "type": "string",
+            "nullable": true
+          },
+          "descriptor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeviationObject": {
+        "required": [
+          "address",
+          "buildingObjectOwner",
+          "deviationObjectKey"
+        ],
+        "type": "object",
+        "properties": {
+          "deviationObjectKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "totalArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot"
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö"
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja"
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
             }
           },
-          "additionalProperties": false
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
         },
-        "GeneralizedConstructionAction": {
-          "type": "object",
-          "properties": {
-            "constructionActionKey": {
+        "additionalProperties": false,
+        "description": "Poikkeamisen kohde"
+      },
+      "DeviationPermitApplication": {
+        "required": [
+          "applicationContent",
+          "constructionDesign",
+          "deviationPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "deviationPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            }
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupahakemus"
+      },
+      "DeviationPermitDecision": {
+        "required": [
+          "decisionInForceUntil",
+          "deviationPermitDecisionKey",
+          "engagingParty",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "deviationPermitDecisionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "description": ""
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "description": "",
+            "format": "date"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupapäätös"
+      },
+      "DeviationPermitIssue": {
+        "required": [
+          "deviationPermitApplication",
+          "deviationPermitDecision",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "recordNumber": {
+            "type": "string"
+          },
+          "deviationPermitDecision": {
+            "required": [
+              "deviationPermitDecisionKey",
+              "engagingParty",
+              "decisionInForceUntil",
+              "lifeCycleState"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitDecision"
+              }
+            ],
+            "description": "Poikkeamislupapäätös"
+          },
+          "deviationPermitApplication": {
+            "required": [
+              "deviationPermitApplicationKey",
+              "constructionDesign",
+              "lifeCycleState",
+              "applicationContent"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitApplication"
+              }
+            ],
+            "description": "Poikkeamislupahakemus"
+          },
+          "deviationObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationObject"
+            }
+          },
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupa-asia"
+      },
+      "ElectricalEnergySource": {
+        "required": [
+          "electricalEnergySourceKey",
+          "electricalEnergySourceType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "electricalEnergySourceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "electricalEnergySourceType": {
+            "type": "string",
+            "description": "Sähköenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde\">http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Sähköenergian lähde"
+      },
+      "Elevator": {
+        "required": [
+          "elevatorKey",
+          "elevatorType",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "elevatorKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "elevatorType": {
+            "type": "string",
+            "description": "Hissin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hissi\">http://uri.suomi.fi/codelist/rytj/hissi</a>"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
+            ],
+            "type": "string",
+            "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "insideLength": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "insideWidth": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "doorOpeningWidth": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "doorOpeningHeight": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "passengerCapacity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "loadCapacity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hissi"
+      },
+      "EnergyData": {
+        "required": [
+          "energyDataKey"
+        ],
+        "type": "object",
+        "properties": {
+          "energyDataKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "energyRating": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/08"
+            ],
+            "type": "string",
+            "description": "Energialuokka. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Energialuokka",
+            "nullable": true
+          },
+          "computationalEnergyEfficiencyComparand": {
+            "type": "number",
+            "description": "",
+            "format": "double",
+            "nullable": true
+          },
+          "heatingMethod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HeatingMethod"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "heatingEnergySource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HeatingEnergySource"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "coolingMethod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoolingMethod"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "coolingEnergySource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoolingEnergySource"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "electricalEnergySource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElectricalEnergySource"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "netHeatedArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "heatedVolume": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "calculatoryDeliveredEnergyUsage": {
+            "required": [
+              "calculatoryDeliveredEnergyUsageKey",
+              "deliveredEnergyType",
+              "energyAmountYearly"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CalculatoryDeliveredEnergyUsage"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "energyRatingSubindex": {
+            "type": "string",
+            "description": "Energiatehokkuusluokan alaindeksi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Energiatiedot"
+      },
+      "EngagingParty": {
+        "required": [
+          "engagingPartyKey",
+          "isPerson"
+        ],
+        "type": "object",
+        "properties": {
+          "engagingPartyKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "personalIdentityCode": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "businessId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "isPerson": {
+            "type": "boolean",
+            "description": ""
+          },
+          "firstName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "familyName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "organizationName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "applicantContactOperator": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
+            "nullable": true
+          },
+          "nationalityCode": {
+            "type": "string",
+            "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
+            "nullable": true
+          },
+          "deathDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hankkeeseen ryhtyvä"
+      },
+      "Entrance": {
+        "required": [
+          "entranceKey",
+          "entranceType",
+          "isPrimary",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "entranceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "entranceType": {
+            "type": "string",
+            "description": "Sisäänkäynnin tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sisaankaynti\">http://uri.suomi.fi/codelist/rytj/sisaankaynti</a>"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
+            ],
+            "type": "string",
+            "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "addressOfEntrance": {
+            "type": "string",
+            "nullable": true
+          },
+          "isAccessible": {
+            "type": "boolean",
+            "description": "Kerrosluku"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Sisäänkäynti"
+      },
+      "Equipment": {
+        "required": [
+          "equipmentKey",
+          "equipmentType"
+        ],
+        "type": "object",
+        "properties": {
+          "equipmentKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "equipmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/01",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/02",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/03",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/04",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/05",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/06",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/07",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/08",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/09",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/10"
+            ],
+            "type": "string",
+            "description": "Rakennuksen varuste. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rakennusvaruste"
+          },
+          "equipmentCount": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Varuste"
+      },
+      "ExtensionDecision": {
+        "required": [
+          "extensionDecisionKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "extensionDecisionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Jatkoaikapäätös"
+      },
+      "ExteriorData": {
+        "required": [
+          "shape"
+        ],
+        "type": "object",
+        "properties": {
+          "numberOfStoreys": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "height": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "flightObstacle": {
+            "type": "boolean",
+            "description": "",
+            "nullable": true
+          },
+          "shape": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "description": ""
+          },
+          "relationToGroundLevel": {
+            "type": "string",
+            "description": "Suhde maan pintaan. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Suhde_pintaan",
+            "nullable": true
+          },
+          "volume": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "grossFloorArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "permittedBuildingArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "totalArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Ulkokuoren tiedot"
+      },
+      "FacadeMaterial": {
+        "required": [
+          "facadeMaterialKey",
+          "facadeMaterialType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "facadeMaterialKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "facadeMaterialType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/00",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/01",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/02",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/03",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/04",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/05",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/06",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/99"
+            ],
+            "type": "string",
+            "description": "Julkisivun rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine\">http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Julkisivumateriaali"
+      },
+      "Foreman": {
+        "required": [
+          "familyName",
+          "firstName",
+          "foremanKey"
+        ],
+        "type": "object",
+        "properties": {
+          "foremanKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "foremanRole": {
+            "type": "string",
+            "description": "Työnjohtajan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli\">http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli</a>"
+          },
+          "foremanCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "responsibilityStartDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "responsibilityEndDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ForemanBuildingReference"
+            },
+            "nullable": true
+          },
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ForemanStructureReference"
+            },
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
               "type": "string",
               "format": "uuid"
             },
-            "constructionActionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
-              "nullable": true
-            },
-            "buildingObjectChange": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectChange"
-                }
-              ],
-              "description": "Rakennuskohteen muutos",
-              "nullable": true
-            },
-            "descriptionOfAction": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "areaUndergoingChanges": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-              "nullable": true
-            },
-            "renovation": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationRate": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "building": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/GeneralizedBuilding"
-                }
-              ],
-              "nullable": true
-            },
-            "finishedBuilding": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/GeneralizedBuilding"
-                }
-              ],
-              "nullable": true
-            },
-            "structure": {
-              "required": [
-                "structureMainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationStructure"
-                }
-              ],
-              "nullable": true
-            },
-            "areaToBeBuiltForSpecificActivities": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
-                }
-              ],
-              "nullable": true
-            },
-            "startDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "statusOfConstructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-              "nullable": true
-            },
-            "fullyApprovedForUse": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "businessConstruction": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "changeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-              ],
-              "type": "string",
-              "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-              "nullable": true
-            },
-            "dvvPermitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "expiryDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "locatedOnUnseparatedParcel": {
-              "type": "boolean",
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false
+          "requiredCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "personalIdentityCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "familyName": {
+            "type": "string"
+          }
         },
-        "GeneralizedPurpose": {
-          "type": "object",
-          "properties": {
-            "purposeKey": {
+        "additionalProperties": false,
+        "description": "Työnjohtaja"
+      },
+      "ForemanBuildingReference": {
+        "required": [
+          "permanentBuildingIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
               "type": "string",
               "format": "uuid"
             },
-            "type": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennusviite"
+      },
+      "ForemanStructureReference": {
+        "required": [
+          "permanentStructureIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
               "type": "string",
-              "nullable": true
+              "format": "uuid"
             },
-            "isPrimary": {
-              "type": "boolean",
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennelmaviite"
+      },
+      "ForemenPlannersConstructionProject": {
+        "type": "object",
+        "properties": {
+          "foreman": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Foreman"
+            },
+            "nullable": true
+          },
+          "planner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Planner"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuilding": {
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingSection"
+            },
+            "nullable": true
+          },
+          "mainPurpose": {
+            "type": "string",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "mainPurpose1994": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfNewApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfDeletedApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssue": {
+        "required": [
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "decision": {
+            "required": [
+              "buildingPermitDecisionKey",
+              "lifeCycleState"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "buildingPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPermitApplication"
+            },
+            "description": "Rakentamislupahakemus",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionAction"
             }
           },
-          "additionalProperties": false
-        },
-        "GeneralizedUsageData": {
-          "type": "object",
-          "properties": {
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "usageStatus": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
-              ],
-              "type": "string",
-              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "purpose": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GeneralizedPurpose"
-              },
-              "nullable": true
-            },
-            "usefulFloorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "intendedWorkingLife": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "plannedUserCount": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "GeoJsonGeometry": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Tuetut geometriatyypit"
-            }
-          },
-          "additionalProperties": false,
-          "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
-        },
-        "GeoJsonLineStringGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
         },
-        "GeoJsonMultiLineStringGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingSection": {
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "Materiaalitiedot",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "Energiatiedot",
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "Sisätilojen tiedot",
+            "nullable": true
+          },
+          "exteriorData": {
+            "required": [
+              "shape"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "Ulkokuoren tiedot",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "Talotekniikkatiedot",
+            "nullable": true
+          },
+          "usageData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedUsageData"
+              }
+            ]
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
-        },
-        "GeoJsonMultiPointGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
-        },
-        "GeoJsonMultiPolygonGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "type": "number",
-                      "format": "double"
-                    }
-                  }
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
+            },
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationApartment"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "nullable": true
+          }
         },
-        "GeoJsonPointGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
+        "additionalProperties": false
+      },
+      "GeneralizedConstructionAction": {
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "finishedBuilding": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureMainPurpose",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "locatedOnUnseparatedParcel": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedPurpose": {
+        "type": "object",
+        "properties": {
+          "purposeKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedUsageData": {
+        "type": "object",
+        "properties": {
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "usageStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
+            ],
+            "type": "string",
+            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "purpose": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedPurpose"
+            },
+            "nullable": true
+          },
+          "usefulFloorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "intendedWorkingLife": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedUserCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeoJsonGeometry": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Tuetut geometriatyypit"
+          }
+        },
+        "additionalProperties": false,
+        "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
+      },
+      "GeoJsonLineStringGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
               "type": "array",
               "items": {
                 "type": "number",
                 "format": "double"
-              },
-              "description": "Koordinaatit",
-              "example": "[100.0, 0.0]"
+              }
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
-            }
+            "description": "Koordinaatit",
+            "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
           },
-          "additionalProperties": false,
-          "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+          }
         },
-        "GeoJsonPolygonGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
+        "additionalProperties": false,
+        "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+      },
+      "GeoJsonMultiLineStringGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            },
+            "description": "Koordinaatit",
+            "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
+          },
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+          }
+        },
+        "additionalProperties": false,
+        "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+      },
+      "GeoJsonMultiPointGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "description": "Koordinaatit",
+            "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+          },
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
+          }
+        },
+        "additionalProperties": false,
+        "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+      },
+      "GeoJsonMultiPolygonGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
               "type": "array",
               "items": {
                 "type": "array",
@@ -8948,2695 +9937,2713 @@
                     "format": "double"
                   }
                 }
-              },
-              "description": "Koordinaatit",
-              "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+              }
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
-            }
+            "description": "Koordinaatit",
+            "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
           },
-          "additionalProperties": false,
-          "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
+          }
         },
-        "GetBuildingOwnerResponse": {
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifier": {
-              "type": "string"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string"
-            },
-            "buildingObjectOwners": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetForemenPlannersResponse": {
-          "type": "object",
-          "properties": {
-            "permanentPermitIdentifier": {
-              "type": "string"
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "dateOfInitiation": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "constructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ForemenPlannersConstructionProject"
-                }
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetPermanentApartmentIdentifierCommand": {
-          "required": [
-            "municipalityNumber",
-            "permanentBuildingId"
-          ],
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "permanentPermitId": {
-              "type": "string",
-              "nullable": true
-            },
-            "dvvCaseIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "constructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "permanentBuildingId": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "changeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-              ],
-              "type": "string"
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "apartmentSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "numberOfRooms": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "kitchenType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "floorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "apartmentEquipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ApartmentEquipment"
-              },
-              "nullable": true
-            },
-            "buildingSectionKey": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
-            "apartmentKey": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
-            "isWaterCloset": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "apartmentStorey": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetPermanentBuildingIdentifierCommand": {
-          "required": [
-            "municipalityNumber",
-            "pointLocation",
-            "propertyIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "propertyIdentifier": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "pointLocation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ]
-            },
-            "typeOfPurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-              ],
-              "type": "string"
-            },
-            "dvvCaseIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "constructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "permanentPermitIdentifier": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetPermanentPermitIdentifierCommand": {
-          "required": [
-            "municipalityNumber",
-            "municipalityPermitId",
-            "permitType"
-          ],
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "municipalityPermitId": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "permitType": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/02",
-                "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/03",
-                "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/04"
-              ],
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        "GetPermanentStructureIdentifierCommand": {
-          "required": [
-            "municipalityNumber",
-            "pointLocation",
-            "propertyIdentifier",
-            "purposeType"
-          ],
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "propertyIdentifier": {
-              "minLength": 1,
-              "pattern": "([0-9]{3}){2}([0-9]{4}){2}",
-              "type": "string"
-            },
-            "pointLocation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ]
-            },
-            "purposeType": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string"
-            },
-            "constructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "permanentPermitIdentifier": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GuidingStatute": {
-          "required": [
-            "guidingStatuteKey"
-          ],
-          "type": "object",
-          "properties": {
-            "guidingStatuteKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "statuteName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "statuteCollectionNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "statuteCollectionYear": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "chapter": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "section": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subSection": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "paragraph": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subParagraph": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Säädösviite"
-        },
-        "HealthReport": {
-          "type": "object",
-          "properties": {
-            "status": {
-              "enum": [
-                "Unhealthy",
-                "Degraded",
-                "Healthy"
-              ],
-              "type": "string",
-              "readOnly": true
-            },
-            "totalDuration": {
-              "type": "string",
-              "format": "date-span",
-              "readOnly": true
-            },
-            "entries": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/HealthReportEntry"
-              },
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "HealthReportEntry": {
-          "type": "object",
-          "properties": {
-            "duration": {
-              "type": "string",
-              "format": "date-span",
-              "readOnly": true
-            },
-            "status": {
-              "enum": [
-                "Unhealthy",
-                "Degraded",
-                "Healthy"
-              ],
-              "type": "string",
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "HeatingEnergySource": {
-          "required": [
-            "heatingEnergySourceKey",
-            "heatingEnergySourceType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "heatingEnergySourceKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "heatingEnergySourceType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/01",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/02",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/03",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/04",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/05",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/06",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/07",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/08",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/09",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/10",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/11",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1101",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1102",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1103",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1104",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/99"
-              ],
-              "type": "string",
-              "description": "Lämmitysenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde\">http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lämmitysenergianlähde"
-        },
-        "HeatingMethod": {
-          "required": [
-            "heatingMethodKey",
-            "heatingMethodType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "heatingMethodKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "heatingMethodType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/01",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/02",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/03",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/04",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/05",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/06",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/07",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/99"
-              ],
-              "type": "string",
-              "description": "Lämmitystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitystapa\">http://uri.suomi.fi/codelist/rytj/lammitystapa</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lämmitystapa"
-        },
-        "Inspection": {
-          "required": [
-            "inspectionCarriedOutByFirstName",
-            "inspectionCarriedOutByLastName",
-            "inspectionDate",
-            "inspectionKey",
-            "personsPresent",
-            "requiredByPermitRegulations"
-          ],
-          "type": "object",
-          "properties": {
-            "inspectionKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "inspectionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
-              ],
-              "type": "string",
-              "description": ""
-            },
-            "inspectionDate": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "date"
-            },
-            "requiredByPermitRegulations": {
-              "type": "boolean",
-              "description": ""
-            },
-            "partiality": {
-              "type": "string",
-              "description": ""
-            },
-            "inspectionStatus": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
-                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
-                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
-              ],
-              "type": "string",
-              "description": ""
-            },
-            "buildingReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/InspectionBuildingReference"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "structureReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/InspectionStructureReference"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specificAreaReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "buildingObjectChange": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectChange"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specificationOfObjectOfInspection": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "inspectionRemarks": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "inspectionCarriedOutByFirstName": {
-              "minLength": 1,
-              "type": "string",
-              "description": ""
-            },
-            "inspectionCarriedOutByLastName": {
-              "minLength": 1,
-              "type": "string",
-              "description": ""
-            },
-            "personsPresent": {
-              "minLength": 1,
-              "type": "string",
-              "description": ""
-            },
-            "buildingsAttachmentDocument": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Katselmus"
-        },
-        "InspectionBuildingReference": {
-          "required": [
-            "permanentBuildingIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifierReference": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "InspectionStructureReference": {
-          "required": [
-            "permanentStructureIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifierReference": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "InteriorData": {
-          "required": [
-            "floorArea"
-          ],
-          "type": "object",
-          "properties": {
-            "floorArea": {
+        "additionalProperties": false,
+        "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+      },
+      "GeoJsonPointGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
               "type": "number",
               "format": "double"
             },
-            "basementArea": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
+            "description": "Koordinaatit",
+            "example": "[100.0, 0.0]"
           },
-          "additionalProperties": false,
-          "description": "Sisätilojen tiedot"
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
+          }
         },
-        "LandscapeWorkPermitApplication": {
-          "required": [
-            "applicationContent",
-            "constructionDesign",
-            "dateOfReception",
-            "landscapeWorkPermitApplicationKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "applicationContent": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "dateOfReception": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
-            },
-            "landscapeWorkPermitApplicationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              }
-            }
-          },
-          "additionalProperties": false,
-          "description": "Maisematyölupahakemus"
-        },
-        "LandscapeWorkPermitDecision": {
-          "required": [
-            "dateOfDecision",
-            "decisionDate",
-            "decisionDocument",
-            "decisionInForceUntil",
-            "decisionMakerName",
-            "decisionMakerType",
-            "decisionText",
-            "engagingParty",
-            "landscapeWorkPermitDecisionKey"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfDecision": {
-              "minLength": 1,
-              "type": "string",
-              "format": "date"
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja"
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>"
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "landscapeWorkPermitDecisionKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "constructionToBeStartedBy": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedBy": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
-              },
-              "description": ""
-            },
-            "decisionInForceUntil": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "date"
-            },
-            "constructionToBeStartedByExtension": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedByExtension": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Maisemalupapäätös"
-        },
-        "LandscapeWorkPermitIssue": {
-          "required": [
-            "buildingSite",
-            "constructionAction",
-            "dateOfInitiation",
-            "landscapeWorkPermitApplication",
-            "landscapeWorkPermitDecision",
-            "lifeCycleState",
-            "municipalityNumber",
-            "permanentPermitIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date"
-            },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>"
-            },
-            "municipalityNumber": {
-              "maxLength": 3,
-              "minLength": 3,
-              "type": "string"
-            },
-            "permanentPermitIdentifier": {
-              "maxLength": 10,
-              "minLength": 10,
-              "type": "string"
-            },
-            "landscapeWorkPermitDecision": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LandscapeWorkPermitDecision"
-                }
-              ],
-              "description": "Maisematyölupapäätös"
-            },
-            "landscapeWorkPermitApplication": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/LandscapeWorkPermitApplication"
-              },
-              "description": "Maisematyölupahakemus"
-            },
-            "constructionAction": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionAction"
-              }
-            },
-            "extensionDecision": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExtensionDecision"
-              },
-              "nullable": true
-            },
-            "changePermit": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangePermit"
-              },
-              "nullable": true
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka"
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "constructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionProject"
-                }
-              ],
-              "description": "Rakentamishanke",
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Maisematyölupa-asia"
-        },
-        "LanguageString": {
-          "type": "object",
-          "properties": {
-            "fin": {
-              "type": "string",
-              "description": "suomi",
-              "nullable": true
-            },
-            "swe": {
-              "type": "string",
-              "description": "ruotsi",
-              "nullable": true
-            },
-            "smn": {
-              "type": "string",
-              "description": "inarinsaame",
-              "nullable": true
-            },
-            "sms": {
-              "type": "string",
-              "description": "koltansaame",
-              "nullable": true
-            },
-            "sme": {
-              "type": "string",
-              "description": "pohjoissaame",
-              "nullable": true
-            },
-            "eng": {
-              "type": "string",
-              "description": "englanti",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-        },
-        "MaterialData": {
-          "required": [
-            "buildingMaterialOfLoadBearingStructures",
-            "constructionMethod",
-            "facadeMaterial",
-            "wideBodiedBuilding"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionMethod": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/01",
-                "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/02"
-              ],
-              "type": "string",
-              "description": "Rakentamistapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_runkotapa\">http://uri.suomi.fi/codelist/vtj/Rake_runkotapa</a>",
-              "nullable": true
-            },
-            "buildingMaterialOfLoadBearingStructures": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingMaterialOfLoadBearingStructures"
-              },
-              "description": "Kantavien rakenteiden rakennusaine"
-            },
-            "facadeMaterial": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FacadeMaterial"
-              }
-            },
-            "fireClass": {
-              "type": "string",
-              "description": "Paloluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Paloluokka\">http://uri.suomi.fi/codelist/rytj/Paloluokka</a>",
-              "nullable": true
-            },
-            "wideBodiedBuilding": {
-              "type": "boolean"
-            },
-            "reusableMaterialAmount": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Materiaalitiedot"
-        },
-        "NetworkConnection": {
-          "required": [
-            "networkConnectionKey",
-            "networkConnectionType"
-          ],
-          "type": "object",
-          "properties": {
-            "networkConnectionKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "networkConnectionType": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/01",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/02",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/03",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/04",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/05",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/06",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/07",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/08",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/09"
-              ],
-              "type": "string",
-              "description": "Verkostoliittymän laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/verkliit\">http://uri.suomi.fi/codelist/rytj/verkliit</a>"
-            },
-            "connected": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "connectionPoint": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Verkostoliittymä"
-        },
-        "Operator": {
-          "required": [
-            "isPerson"
-          ],
-          "type": "object",
-          "properties": {
-            "personalIdentityCode": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "businessId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "isPerson": {
-              "type": "boolean",
-              "description": ""
-            },
-            "firstName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "familyName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "organizationName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "operatorAddress": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ContactAddress"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "languageCode": {
-              "type": "string",
-              "description": "IETF kielikoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes\">http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes</a>",
-              "nullable": true
-            },
-            "nationalityCode": {
-              "type": "string",
-              "description": "Valtiokoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-              "nullable": true
-            },
-            "deathDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Toimija"
-        },
-        "PermanentApartmentIdentifierResponse": {
-          "type": "object",
-          "properties": {
-            "permanentApartmentIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "response": {
-              "type": "string",
-              "nullable": true
-            },
-            "created": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "PermanentBuildingIdentifierResponse": {
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "response": {
-              "type": "string",
-              "nullable": true
-            },
-            "created": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "PermanentPermitIdentifierResponse": {
-          "type": "object",
-          "properties": {
-            "permanentPermitIdentifier": {
-              "type": "string"
-            },
-            "response": {
-              "type": "string",
-              "nullable": true
-            },
-            "created": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "PermanentStructureIdentifierResponse": {
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifier": {
-              "type": "string"
-            },
-            "response": {
-              "type": "string",
-              "nullable": true
-            },
-            "created": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        },
-        "PermitRegulation": {
-          "required": [
-            "permitRegulationKey",
-            "permitRegulationType"
-          ],
-          "type": "object",
-          "properties": {
-            "permitRegulationKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitRegulationType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M01",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0101",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0102",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0103",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0104",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0105",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0106",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0107",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0108",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0109",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0110",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M02",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0201",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0202",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M03",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0301",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0302",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M04"
-              ],
-              "type": "string",
-              "description": "Lupamääräys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen\">http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen</a>"
-            },
-            "textOfPermitRegulation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lupamääräys"
-        },
-        "Planner": {
-          "required": [
-            "familyName",
-            "firstName",
-            "plannerKey"
-          ],
-          "type": "object",
-          "properties": {
-            "plannerKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "plannerRole": {
-              "type": "string",
-              "description": "Suunnittelijan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli\">http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli</a>"
-            },
-            "plannerCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "responsibilityStartDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "responsibilityEndDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PlannerBuildingReference"
-              },
-              "nullable": true
-            },
-            "structureReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PlannerStructureReference"
-              },
-              "nullable": true
-            },
-            "specificAreaReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            },
-            "requiredCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "personalIdentityCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "nullable": true
-            },
-            "firstName": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "familyName": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Suunnittelija"
-        },
-        "PlannerBuildingReference": {
-          "required": [
-            "permanentBuildingIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifierReference": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "PlannerStructureReference": {
-          "required": [
-            "permanentStructureIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifierReference": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": { }
-        },
-        "Property": {
-          "required": [
-            "municipalityNumber",
-            "propertyIdentifier",
-            "relationToBaseProperty",
-            "status",
-            "type"
-          ],
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "propertyIdentifier": {
-              "maxLength": 14,
-              "minLength": 14,
-              "type": "string"
-            },
-            "name": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "registrationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "endDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "landArea": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "type": {
-              "minLength": 1,
-              "type": "string"
-            },
-            "relationToBaseProperty": {
-              "minLength": 1,
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Kiinteistö"
-        },
-        "Purpose": {
-          "required": [
-            "isPrimary",
-            "purposeKey",
-            "type"
-          ],
-          "type": "object",
-          "properties": {
-            "purposeKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "type": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-              ],
-              "type": "string",
-              "description": "Käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Käyttötarkoitus"
-        },
-        "RyhtiGeometry": {
-          "required": [
-            "geometry",
-            "srid"
-          ],
-          "type": "object",
-          "properties": {
-            "srid": {
-              "enum": [
-                "3067",
-                "3873",
-                "3874",
-                "3875",
-                "3876",
-                "3877",
-                "3878",
-                "3879",
-                "3880",
-                "3881",
-                "3882",
-                "3883",
-                "3884",
-                "3885"
-              ],
-              "type": "string",
-              "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
-            },
-            "geometry": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/GeoJsonPointGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonMultiPointGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonLineStringGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonMultiLineStringGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonPolygonGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
-                }
-              ],
-              "description": "Geometria GeoJson rakenteella: https://geojson.org/"
-            }
-          },
-          "additionalProperties": false
-        },
-        "SpecialDesign": {
-          "required": [
-            "document",
-            "specialDesignKey",
-            "specialDesignType"
-          ],
-          "type": "object",
-          "properties": {
-            "specialDesignKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "specialDesignType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Erityissuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/erityissuun\">http://uri.suomi.fi/codelist/rytj/erityissuun</a>"
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "document": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            }
-          },
-          "additionalProperties": false,
-          "description": "Erityissuunnitelma"
-        },
-        "Structure": {
-          "required": [
-            "administrativeLocationUnit",
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "permanentStructureIdentifier",
-            "structureKey",
-            "structureMainPurpose",
-            "structureSection"
-          ],
-          "type": "object",
-          "properties": {
-            "structureKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentStructureIdentifier": {
-              "maxLength": 10,
-              "minLength": 10,
-              "type": "string"
-            },
-            "temporary": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "structureSection": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/StructureSection"
-              }
-            },
-            "structureMainPurpose": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string",
-              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja"
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennelma"
-        },
-        "StructureSection": {
-          "required": [
-            "lifeCycleState",
-            "partitionReason",
-            "structureSectionKey"
-          ],
-          "type": "object",
-          "properties": {
-            "structureSectionKey": {
-              "minLength": 1,
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-              ],
-              "type": "string",
-              "description": "Rakennelman elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/rakelinvaih\">http://uri.suomi.fi/codelist/rakrek/rakelinvaih</a>"
-            },
-            "completionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "protectionMethod": {
-              "type": "string",
-              "description": "Rakennelman osan suojatapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suojtapa\">http://uri.suomi.fi/codelist/rytj/suojtapa</a>",
-              "nullable": true
-            },
-            "cultureHistoricalSignificance": {
-              "type": "string",
-              "description": "Rakennelman osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/kulthistmer\">http://uri.suomi.fi/codelist/rakrek/kulthistmer</a>",
-              "nullable": true
-            },
-            "materialData": {
-              "required": [
-                "constructionMethod",
-                "buildingMaterialOfLoadBearingStructures",
-                "wideBodiedBuilding"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/MaterialData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "energyData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EnergyData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "exteriorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ExteriorData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "buildingServicesEngineeringData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "structurePurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string",
-              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-            },
-            "equipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Equipment"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "partitionReason": {
-              "minLength": 1,
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-              ],
-              "type": "string",
-              "description": "Rakennelman osan osittelun laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji\">http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji</a>"
-            },
-            "partitionDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "relatedFinishedStructureSection": {
-              "type": "string",
-              "description": "",
-              "format": "uuid",
-              "nullable": true
-            },
-            "demolitionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennelman osa"
-        },
-        "UnseparatedParcel": {
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "unseparatedParcelIdentifier": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "registrationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "endDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "type": {
-              "type": "string"
-            },
-            "relationToBaseProperty": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Määräala"
-        },
-        "UsageData": {
-          "required": [
-            "purpose"
-          ],
-          "type": "object",
-          "properties": {
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "usageStatus": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
-              ],
-              "type": "string",
-              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "purpose": {
-              "minItems": 1,
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Purpose"
-              }
-            },
-            "usefulFloorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "intendedWorkingLife": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "plannedUserCount": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuksen käyttötiedot"
-        },
-        "VentilationMethod": {
-          "required": [
-            "isPrimary",
-            "ventilationMethodKey",
-            "ventilationMethodType"
-          ],
-          "type": "object",
-          "properties": {
-            "ventilationMethodKey": {
-              "minLength": 1,
-              "type": "string",
-              "format": "uuid"
-            },
-            "ventilationMethodType": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Ilmanvaihtotavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ilmanvaihto\">http://uri.suomi.fi/codelist/rytj/ilmanvaihto</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Ilmanvaihtotapa"
-        }
+        "additionalProperties": false,
+        "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
       },
-      "securitySchemes": {
-        "Bearer": {
-          "type": "apiKey",
-          "description": "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\"",
-          "name": "Authorization",
-          "in": "header"
-        },
-        "oauth2": {
-          "type": "oauth2",
-          "flows": {
-            "clientCredentials": {
-              "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
-              "scopes": {
-                "ryhti.building.write": "Rakennustietojen kirjoitusoikeus",
-                "ryhti.building.owners.all": "Oikeus rakennuksen kaikkin omistajatietoihin, ml turvakiellon alaiset.",
-                "ryhti.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia tietoja.",
-                "ryhti.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin.",
-                "ryhti.building.all": "Oikeus rakennustietoon.",
-                "ryhti.building.generalized": "Oikeus karkeutettuun rakennustietoon."
+      "GeoJsonPolygonGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "format": "double"
+                }
               }
+            },
+            "description": "Koordinaatit",
+            "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+          },
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
+          }
+        },
+        "additionalProperties": false,
+        "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+      },
+      "GetBuildingOwnerResponse": {
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifier": {
+            "type": "string"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetForemenPlannersResponse": {
+        "type": "object",
+        "properties": {
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "dateOfInitiation": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "constructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ForemenPlannersConstructionProject"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPermanentApartmentIdentifierCommand": {
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitId": {
+            "type": "string",
+            "nullable": true
+          },
+          "dvvCaseIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "permanentBuildingId": {
+            "type": "string"
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+            ],
+            "type": "string"
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "apartmentSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "numberOfRooms": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "kitchenType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "apartmentEquipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApartmentEquipment"
+            },
+            "nullable": true
+          },
+          "buildingSectionKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "apartmentKey": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "isWaterCloset": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "apartmentStorey": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPermanentBuildingIdentifierCommand": {
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "pointLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ]
+          },
+          "typeOfPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string"
+          },
+          "dvvCaseIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "permanentPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPermanentPermitIdentifierCommand": {
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "municipalityPermitId": {
+            "type": "string"
+          },
+          "permitType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/RakennusvalvontaAsianTyyppi/code/04"
+            ],
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetPermanentStructureIdentifierCommand": {
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "pointLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ]
+          },
+          "purposeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string"
+          },
+          "constructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "permanentPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GuidingStatute": {
+        "required": [
+          "guidingStatuteKey"
+        ],
+        "type": "object",
+        "properties": {
+          "guidingStatuteKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "statuteName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "statuteCollectionNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "statuteCollectionYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "chapter": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "section": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subSection": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "paragraph": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subParagraph": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Säädösviite"
+      },
+      "HealthReport": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "enum": [
+              "Unhealthy",
+              "Degraded",
+              "Healthy"
+            ],
+            "type": "string",
+            "readOnly": true
+          },
+          "totalDuration": {
+            "type": "string",
+            "format": "date-span",
+            "readOnly": true
+          },
+          "entries": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/HealthReportEntry"
+            },
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HealthReportEntry": {
+        "type": "object",
+        "properties": {
+          "duration": {
+            "type": "string",
+            "format": "date-span",
+            "readOnly": true
+          },
+          "status": {
+            "enum": [
+              "Unhealthy",
+              "Degraded",
+              "Healthy"
+            ],
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HeatingEnergySource": {
+        "required": [
+          "heatingEnergySourceKey",
+          "heatingEnergySourceType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "heatingEnergySourceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "heatingEnergySourceType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/01",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/02",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/03",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/04",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/05",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/06",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/07",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/08",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/09",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/10",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/11",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1101",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1102",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1103",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1104",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/99"
+            ],
+            "type": "string",
+            "description": "Lämmitysenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde\">http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde</a>",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lämmitysenergianlähde"
+      },
+      "HeatingMethod": {
+        "required": [
+          "heatingMethodKey",
+          "heatingMethodType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "heatingMethodKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "heatingMethodType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/01",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/02",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/03",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/04",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/05",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/06",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/07",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/99"
+            ],
+            "type": "string",
+            "description": "Lämmitystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitystapa\">http://uri.suomi.fi/codelist/rytj/lammitystapa</a>",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lämmitystapa"
+      },
+      "Inspection": {
+        "required": [
+          "inspectionCarriedOutByFirstName",
+          "inspectionCarriedOutByLastName",
+          "inspectionDate",
+          "inspectionKey",
+          "inspectionType",
+          "personsPresent",
+          "requiredByPermitRegulations"
+        ],
+        "type": "object",
+        "properties": {
+          "inspectionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "inspectionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
+            ],
+            "type": "string",
+            "description": ""
+          },
+          "inspectionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date"
+          },
+          "requiredByPermitRegulations": {
+            "type": "boolean",
+            "description": ""
+          },
+          "partiality": {
+            "type": "string",
+            "description": ""
+          },
+          "inspectionStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
+            ],
+            "type": "string",
+            "description": ""
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionBuildingReference"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionStructureReference"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectChange"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specificationOfObjectOfInspection": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "inspectionRemarks": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "inspectionCarriedOutByFirstName": {
+            "type": "string",
+            "description": ""
+          },
+          "inspectionCarriedOutByLastName": {
+            "type": "string",
+            "description": ""
+          },
+          "personsPresent": {
+            "type": "string",
+            "description": ""
+          },
+          "buildingsAttachmentDocument": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Katselmus"
+      },
+      "InspectionBuildingReference": {
+        "required": [
+          "permanentBuildingIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InspectionStructureReference": {
+        "required": [
+          "permanentStructureIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InteriorData": {
+        "type": "object",
+        "properties": {
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "basementArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Sisätilojen tiedot"
+      },
+      "LandscapeWorkPermitApplication": {
+        "required": [
+          "applicationContent",
+          "landscapeWorkPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "landscapeWorkPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Maisematyölupahakemus"
+      },
+      "LandscapeWorkPermitDecision": {
+        "required": [
+          "decisionInForceUntil",
+          "engagingParty",
+          "landscapeWorkPermitDecisionKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "landscapeWorkPermitDecisionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "description": ""
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "description": "",
+            "format": "date"
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Maisemalupapäätös"
+      },
+      "LandscapeWorkPermitIssue": {
+        "required": [
+          "buildingSite",
+          "constructionAction",
+          "landscapeWorkPermitApplication",
+          "landscapeWorkPermitDecision",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "landscapeWorkPermitDecision": {
+            "required": [
+              "landscapeWorkPermitDecisionKey",
+              "engagingParty",
+              "decisionInForceUntil",
+              "lifeCycleState"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandscapeWorkPermitDecision"
+              }
+            ],
+            "description": "Maisematyölupapäätös"
+          },
+          "landscapeWorkPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandscapeWorkPermitApplication"
+            },
+            "description": "Maisematyölupahakemus"
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionAction"
+            }
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "stormWaterTreatmentType",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Maisematyölupa-asia"
+      },
+      "LanguageString": {
+        "type": "object",
+        "properties": {
+          "fin": {
+            "type": "string",
+            "description": "suomi",
+            "nullable": true
+          },
+          "swe": {
+            "type": "string",
+            "description": "ruotsi",
+            "nullable": true
+          },
+          "smn": {
+            "type": "string",
+            "description": "inarinsaame",
+            "nullable": true
+          },
+          "sms": {
+            "type": "string",
+            "description": "koltansaame",
+            "nullable": true
+          },
+          "sme": {
+            "type": "string",
+            "description": "pohjoissaame",
+            "nullable": true
+          },
+          "eng": {
+            "type": "string",
+            "description": "englanti",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+      },
+      "MaterialData": {
+        "required": [
+          "buildingMaterialOfLoadBearingStructures",
+          "constructionMethod",
+          "facadeMaterial",
+          "wideBodiedBuilding"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionMethod": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/01",
+              "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/02"
+            ],
+            "type": "string",
+            "description": "Rakentamistapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_runkotapa\">http://uri.suomi.fi/codelist/vtj/Rake_runkotapa</a>",
+            "nullable": true
+          },
+          "buildingMaterialOfLoadBearingStructures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingMaterialOfLoadBearingStructures"
+            },
+            "description": "Kantavien rakenteiden rakennusaine"
+          },
+          "facadeMaterial": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FacadeMaterial"
+            }
+          },
+          "fireClass": {
+            "type": "string",
+            "description": "Paloluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Paloluokka\">http://uri.suomi.fi/codelist/rytj/Paloluokka</a>",
+            "nullable": true
+          },
+          "wideBodiedBuilding": {
+            "type": "boolean"
+          },
+          "reusableMaterialAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Materiaalitiedot"
+      },
+      "NetworkConnection": {
+        "required": [
+          "networkConnectionKey",
+          "networkConnectionType"
+        ],
+        "type": "object",
+        "properties": {
+          "networkConnectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "networkConnectionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/01",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/02",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/03",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/04",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/05",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/06",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/07",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/08",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/09"
+            ],
+            "type": "string",
+            "description": "Verkostoliittymän laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/verkliit\">http://uri.suomi.fi/codelist/rytj/verkliit</a>",
+            "nullable": true
+          },
+          "connected": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "connectionPoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Verkostoliittymä"
+      },
+      "Operator": {
+        "required": [
+          "isPerson"
+        ],
+        "type": "object",
+        "properties": {
+          "personalIdentityCode": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "businessId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "isPerson": {
+            "type": "boolean",
+            "description": ""
+          },
+          "firstName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "familyName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "organizationName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "operatorAddress": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactAddress"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
+            "nullable": true
+          },
+          "nationalityCode": {
+            "type": "string",
+            "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
+            "nullable": true
+          },
+          "deathDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Toimija"
+      },
+      "PermanentApartmentIdentifierResponse": {
+        "type": "object",
+        "properties": {
+          "permanentApartmentIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "response": {
+            "type": "string",
+            "nullable": true
+          },
+          "created": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermanentBuildingIdentifierResponse": {
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "response": {
+            "type": "string",
+            "nullable": true
+          },
+          "created": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermanentPermitIdentifierResponse": {
+        "type": "object",
+        "properties": {
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "response": {
+            "type": "string",
+            "nullable": true
+          },
+          "created": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermanentStructureIdentifierResponse": {
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifier": {
+            "type": "string"
+          },
+          "response": {
+            "type": "string",
+            "nullable": true
+          },
+          "created": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermitRegulation": {
+        "required": [
+          "permitRegulationKey",
+          "permitRegulationType"
+        ],
+        "type": "object",
+        "properties": {
+          "permitRegulationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitRegulationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M01",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0101",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0102",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0103",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0104",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0105",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0106",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0107",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0108",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0109",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0110",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M02",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0201",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0202",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M03",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0301",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0302",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M04"
+            ],
+            "type": "string",
+            "description": "Lupamääräys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen\">http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen</a>"
+          },
+          "textOfPermitRegulation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lupamääräys"
+      },
+      "Planner": {
+        "required": [
+          "familyName",
+          "firstName",
+          "plannerKey"
+        ],
+        "type": "object",
+        "properties": {
+          "plannerKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "plannerRole": {
+            "type": "string",
+            "description": "Suunnittelijan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli\">http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli</a>"
+          },
+          "plannerCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "responsibilityStartDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "responsibilityEndDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlannerBuildingReference"
+            },
+            "nullable": true
+          },
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlannerStructureReference"
+            },
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          },
+          "requiredCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "personalIdentityCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "familyName": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Suunnittelija"
+      },
+      "PlannerBuildingReference": {
+        "required": [
+          "permanentBuildingIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PlannerStructureReference": {
+        "required": [
+          "permanentStructureIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "Property": {
+        "required": [
+          "municipalityNumber",
+          "propertyIdentifier",
+          "relationToBaseProperty",
+          "status",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "registrationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "landArea": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "relationToBaseProperty": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kiinteistö"
+      },
+      "Purpose": {
+        "required": [
+          "isPrimary",
+          "purposeKey",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "purposeKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string",
+            "description": "Käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Käyttötarkoitus"
+      },
+      "RyhtiGeometry": {
+        "required": [
+          "geometry",
+          "srid"
+        ],
+        "type": "object",
+        "properties": {
+          "srid": {
+            "enum": [
+              "3067",
+              "3873",
+              "3874",
+              "3875",
+              "3876",
+              "3877",
+              "3878",
+              "3879",
+              "3880",
+              "3881",
+              "3882",
+              "3883",
+              "3884",
+              "3885"
+            ],
+            "type": "string",
+            "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
+          },
+          "geometry": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/GeoJsonPointGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonMultiPointGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonLineStringGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonMultiLineStringGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonPolygonGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
+              }
+            ],
+            "description": "Geometria GeoJson rakenteella: https://geojson.org/"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SpecialDesign": {
+        "required": [
+          "specialDesignKey",
+          "specialDesignType"
+        ],
+        "type": "object",
+        "properties": {
+          "specialDesignKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specialDesignType": {
+            "type": "string",
+            "description": "Erityissuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/erityissuun\">http://uri.suomi.fi/codelist/rytj/erityissuun</a>"
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Erityissuunnitelma"
+      },
+      "Structure": {
+        "required": [
+          "administrativeLocationUnit",
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "permanentStructureIdentifier",
+          "structureKey",
+          "structureMainPurpose"
+        ],
+        "type": "object",
+        "properties": {
+          "structureKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentStructureIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
+          "structureMainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string",
+            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö"
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennelma"
+      },
+      "StructureSection": {
+        "required": [
+          "lifeCycleState",
+          "partitionReason",
+          "structurePurpose",
+          "structureSectionKey"
+        ],
+        "type": "object",
+        "properties": {
+          "structureSectionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "description": "Rakennelman elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih"
+          },
+          "completionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "description": "Rakennelman osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "description": "Rakennelman osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "exteriorData": {
+            "required": [
+              "shape"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "structurePurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string",
+            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string",
+            "description": "Rakennelman osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "relatedFinishedStructureSection": {
+            "type": "string",
+            "description": "",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennelman osa"
+      },
+      "UnseparatedParcel": {
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "unseparatedParcelIdentifier": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "registrationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "relationToBaseProperty": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Määräala"
+      },
+      "UsageData": {
+        "type": "object",
+        "properties": {
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "usageStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
+            ],
+            "type": "string",
+            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "purpose": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Purpose"
+            },
+            "nullable": true
+          },
+          "usefulFloorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "intendedWorkingLife": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedUserCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuksen käyttötiedot"
+      },
+      "VentilationMethod": {
+        "required": [
+          "isPrimary",
+          "ventilationMethodKey",
+          "ventilationMethodType"
+        ],
+        "type": "object",
+        "properties": {
+          "ventilationMethodKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ventilationMethodType": {
+            "type": "string",
+            "description": "Ilmanvaihtotavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ilmanvaihto\">http://uri.suomi.fi/codelist/rytj/ilmanvaihto</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Ilmanvaihtotapa"
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "apiKey",
+        "description": "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\"",
+        "name": "Authorization",
+        "in": "header"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
+            "scopes": {
+              "ryhti.building.write": "Rakennustietojen kirjoitusoikeus",
+              "ryhti.building.owners.all": "Oikeus rakennuksen kaikkin omistajatietoihin, ml turvakiellon alaiset.",
+              "ryhti.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia tietoja.",
+              "ryhti.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin.",
+              "ryhti.building.all": "Oikeus rakennustietoon.",
+              "ryhti.building.generalized": "Oikeus karkeutettuun rakennustietoon."
             }
           }
         }
       }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [
+        "ryhti.building.write"
+      ]
     },
-    "security": [
-      {
-        "Bearer": [
-          "ryhti.building.write"
-        ]
-      },
-      {
-        "oauth2": [
-          "ryhti.building.write"
-        ]
-      }
-    ]
-  }
+    {
+      "oauth2": [
+        "ryhti.building.write"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Yleistä

# Rakennustieto

## Rakennustietojen validointi- ja tallennus-API

* Lisätty uudet yksittäiskyselyjen rajapinnat (GET):
    * /api/DemolitionPermit/{demolitionPermitId}
        * Purkamislupa-asian kaikki tiedot pysyvällä lupatunnuksella (PLT)
    * /api/LandscapeWorkPermit/{landscapeWorkPermitIssueId}
        * Maisematyölupa-asian kaikki tiedot pysyvällä lupatunnuksella (PLT)
    * /api/DeviationPermit/{permanentPermitId}
        * Poikkeamislupa-asian kaikki tiedot pysyvällä lupatunnuksella (PLT)
    * /api/Structure/{permanentStructureIdentifier
        * Rakennelman kaikki tiedot rakennelmatunnuksella (PRKT)
* Muutettu lupaan liittyvän rakennelman validointeja niin, että rakennelma on mahdollista toimittaa ilman energiatietoja (energyData)
* Muutettu rakennuksen omistajien yksittäiskyselyjä (/api/BuildingOwnersAll/ ja /api/BuildingOwners/) niin, että niiden kautta voi kysyä useamman kuin yhden rakennuksen omistajia
    * haettavien rakennusten tunnukset toimitetaan listana PRT:eitä pilkulla erotettuna query parametrina
    * tunnusten max. määrä: 100 tunnusta
* Korjattu ehdollisesti pakollisten tietojen pakollisuuksia OpenAPI-kuvauksessa
    * tavoitteena on, että attribuutti on merkitty pakolliseksi vain, jos se on pakollinen kaikissa tilanteissa
    * **HUOM! Tämä muutos on vielä kesken. Joitakin pakollisuuksia puuttuu nyt kuvauksesta.**

## Rakennustietojen validointi- ja tallennus-APIn tiedossa oleva virheet ja rajapintaan vaikuttavia tulevia muutoksia

* Attribuuttien ehdolliset pakollisuudet vielä jossain tilanteissa väärin.

## Rakennustietojen muutostietopalvelu

* Lisätty uusi muutostietopalvelun tietotuote: Poikkeamisluvat (/api/ChangeInformation/DeviationPermit)
* Suorituskykyparannuksia rakentamislupien perustietojen lataukseen (/api/InitialInformation/BuildingPermit ja /api/InitialInformation/BuildingGeneralized)
* Lisätty puuttuvia attribuutteja rakennusten ja rakentamislupien perustietojen latauksiin, sekä näiden yksittäiskyselyihin
    * hallinnolliseen sijaintiyksikköön liittyvän kiinteistön (property) tiedot
    * huoneiston hallintaperuste (housingType) ja käytössäolotilanne (occupancyOfApartment)
* Erotettu rakennuksen muutostiedoissa (diff) sen hallinnollisen sijaintiyksikön (administrativeLocationUnit) ja päätöksen hallinnollisen sijaintiyksikön muutos (decisionAdministrativeLocationUnit)

## Rakennustietojen muutostietopalvelun tiedossa olevat virheet ja tulossa olevia muutoksia

* rakennuksen poistettu varuste saattaa näkyä virheellisesti sen nykyisessä tilanteessa (objectState)
    * HUOM! varusteen poisto näkyy oikein kohteen muutoksissa (diff)

# Alueidenkäyttö

## Kaavatiedon tallennuskäyttöliittymä

- Rakennusjärjestyksen tuontiin liittyvät toiminnallisuudet julkaistaan tuotannossa.
- Lomakenäkymä kaava-asian vaiheen tallennukseen julkaistaan tuotannossa.
