### PR TITLE
2024 release 15 rajapinta kuvausten muutokset

### DIFF
--- a/OpenApi/Alueidenkäyttö/Palveluväylä/alueidenkäyttö-OpenApi.json
+++ b/OpenApi/Alueidenkäyttö/Palveluväylä/alueidenkäyttö-OpenApi.json
@@ -203,7 +203,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterCreate"
                   }
                 ]
               }
@@ -212,7 +212,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterCreate"
                   }
                 ]
               }
@@ -221,7 +221,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterCreate"
                   }
                 ]
               }
@@ -292,6 +292,70 @@
                 }
               }
             }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "BindingPlotDivisionMatter"
+        ],
+        "summary": "Rajapinta sitovan tonttijaon asian päivittämiseen.",
+        "parameters": [
+          {
+            "name": "permanentBindingPlotDivisionIdentifier",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterUpdate"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterUpdate"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterUpdate"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Kaava-asian vaihe päivitetty."
+          },
+          "400": {
+            "description": "Kutsun rakenne ei ole scheman mukainen."
+          },
+          "404": {
+            "description": "Resurssia ei löydy."
+          },
+          "422": {
+            "description": "Kutsun tietosisällössä virheitä."
           }
         }
       }
@@ -448,7 +512,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterCreate"
                   }
                 ]
               }
@@ -457,7 +521,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterCreate"
                   }
                 ]
               }
@@ -466,7 +530,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/BindingPlotDivisionMatter"
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterCreate"
                   }
                 ]
               }
@@ -659,6 +723,80 @@
                 }
               }
             }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "BindingPlotDivisionMatter"
+        ],
+        "summary": "Rajapinta jo tallennetun vaiheen päivittämiseen.",
+        "parameters": [
+          {
+            "name": "permanentBindingPlotDivisionIdentifier",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "bindingPlotDivisionMatterPhaseKey",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Kaava-asia päivitetty."
+          },
+          "400": {
+            "description": "Kutsun rakenne ei ole scheman mukainen."
+          },
+          "404": {
+            "description": "Resurssia ei löydy."
+          },
+          "422": {
+            "description": "Kutsun tietosisällössä virheitä."
           }
         }
       }
@@ -1615,7 +1753,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/LandUseRestrictionMatter"
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterCreate"
                   }
                 ]
               }
@@ -1624,7 +1762,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/LandUseRestrictionMatter"
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterCreate"
                   }
                 ]
               }
@@ -1633,7 +1771,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/LandUseRestrictionMatter"
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterCreate"
                   }
                 ]
               }
@@ -1703,6 +1841,137 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": [
+          "LandUseRestrictionMatter"
+        ],
+        "summary": "Alueidenkäytön rajoituksen asia hakeminen pysyvän yksilöivän tunnuksen perusteella.",
+        "parameters": [
+          {
+            "name": "permanentLandUseRestrictionIdentifier",
+            "in": "path",
+            "description": "Alueidenkäytön rajoituksen pysyvä tunnus",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Alueidenkäytön rajoituksen asia JSON-oliona",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandUseRestrictionMatterResponse"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandUseRestrictionMatterResponse"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandUseRestrictionMatterResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pysyvällä yksilöivällä tunnuksella ei löydy tallennettau alueidenkäytön rajoituksen asia.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Kutsun tietosisällössä virheitä.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "LandUseRestrictionMatter"
+        ],
+        "parameters": [
+          {
+            "name": "permanentLandUseRestrictionIdentifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterUpdate"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterUpdate"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterUpdate"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/LandUseRestrictionMatter/{permanentLandUseRestrictionIdentifier}/Validate": {
@@ -1730,7 +1999,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/LandUseRestrictionMatter"
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterCreate"
                   }
                 ]
               }
@@ -1739,7 +2008,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/LandUseRestrictionMatter"
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterCreate"
                   }
                 ]
               }
@@ -1748,7 +2017,7 @@
               "schema": {
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/LandUseRestrictionMatter"
+                    "$ref": "#/components/schemas/LandUseRestrictionMatterCreate"
                   }
                 ]
               }
@@ -5738,7 +6007,7 @@
         },
         "additionalProperties": false
       },
-      "BindingPlotDivisionMatter": {
+      "BindingPlotDivisionMatterCreate": {
         "required": [
           "administrativeAreaIdentifiers",
           "bindingPlotDivisionType",
@@ -5813,15 +6082,6 @@
             },
             "description": "hallinnollisen alueen tunnukset"
           },
-          "phases": {
-            "maxItems": 1,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
-            },
-            "description": "Vaiheet"
-          },
           "responsibleParty": {
             "allOf": [
               {
@@ -5846,6 +6106,15 @@
             },
             "description": "AsianLiitteet",
             "nullable": true
+          },
+          "phases": {
+            "maxItems": 1,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+            },
+            "description": "Vaiheet"
           }
         },
         "additionalProperties": false
@@ -6045,7 +6314,6 @@
           "bindingPlotDivisionType",
           "name",
           "permanentBindingPlotDivisionIdentifier",
-          "phases",
           "timeOfInitiation"
         ],
         "type": "object",
@@ -6114,15 +6382,6 @@
             },
             "description": "hallinnollisen alueen tunnukset"
           },
-          "phases": {
-            "maxItems": 1,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
-            },
-            "description": "Vaiheet"
-          },
           "responsibleParty": {
             "allOf": [
               {
@@ -6152,6 +6411,115 @@
             "type": "string",
             "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/bindingplotdivisionmatter/{identifier})",
             "readOnly": true
+          },
+          "phases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BindingPlotDivisionMatterPhase"
+            },
+            "description": "Vaiheet"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BindingPlotDivisionMatterUpdate": {
+        "required": [
+          "administrativeAreaIdentifiers",
+          "bindingPlotDivisionType",
+          "name",
+          "permanentBindingPlotDivisionIdentifier",
+          "timeOfInitiation"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "bindingPlotDivisionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji/code/02"
+            ],
+            "type": "string",
+            "description": "Sitovan tonttijaon laji. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji\">http://uri.suomi.fi/codelist/rytj/sitovanTonttijaonLaji</a>"
+          },
+          "permanentBindingPlotDivisionIdentifier": {
+            "minLength": 1,
+            "type": "string",
+            "description": "sitovan tonttijaon pysyvä tunnus"
+          },
+          "producerBindingPlotDivisionIdentifier": {
+            "type": "string",
+            "description": "kunnan antama sitovan tonttijaon tunnus",
+            "nullable": true
+          },
+          "caseIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "asianhallintatunnukset",
+            "nullable": true
+          },
+          "recordNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "diaarinumerot",
+            "nullable": true
+          },
+          "timeOfInitiation": {
+            "type": "string",
+            "description": "vireilletulopäivämäärä",
+            "format": "date"
+          },
+          "administrativeAreaIdentifiers": {
+            "maxItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "hallinnollisen alueen tunnukset"
+          },
+          "responsibleParty": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BindingPlotDivisionOperator"
+              }
+            ],
+            "description": "Vastuutaho",
+            "nullable": true
+          },
+          "relatedBindingPlotDivisionMatters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Liittyvät asiat",
+            "nullable": true
+          },
+          "matterAnnexes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BindingPlotDivisionAttachmentDocument"
+            },
+            "description": "AsianLiitteet",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7511,7 +7879,7 @@
         },
         "additionalProperties": false
       },
-      "LandUseRestrictionMatter": {
+      "LandUseRestrictionMatterCreate": {
         "required": [
           "administrativeAreaIdentifiers",
           "landUseRestrictionType",
@@ -7527,11 +7895,6 @@
             "type": "string",
             "description": "Alueidenkäytön rajoituksen pysyvä tunnus"
           },
-          "landUseRestrictionMatterUri": {
-            "type": "string",
-            "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionmatter/{identifier})",
-            "readOnly": true
-          },
           "name": {
             "allOf": [
               {
@@ -7544,15 +7907,6 @@
             "minLength": 1,
             "type": "string",
             "description": "Alueidenkäytön rajoituksen tyyppi. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji\">http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji</a>"
-          },
-          "phases": {
-            "maxItems": 1,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LandUseRestrictionMatterPhase"
-            },
-            "description": "Vaiheet"
           },
           "timeOfInitiation": {
             "type": "string",
@@ -7621,6 +7975,15 @@
             },
             "description": "Liittyvät alueidenkäytön rajoituksen asiat",
             "nullable": true
+          },
+          "phases": {
+            "maxItems": 1,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandUseRestrictionMatterPhase"
+            },
+            "description": "Vaiheet"
           }
         },
         "additionalProperties": false
@@ -7790,6 +8153,216 @@
               }
             ],
             "description": "Päätös"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandUseRestrictionMatterResponse": {
+        "required": [
+          "administrativeAreaIdentifiers",
+          "landUseRestrictionType",
+          "name",
+          "permanentLandUseRestrictionIdentifier",
+          "phases",
+          "timeOfInitiation"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentLandUseRestrictionIdentifier": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Alueidenkäytön rajoituksen pysyvä tunnus"
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          },
+          "landUseRestrictionType": {
+            "type": "string",
+            "description": "Alueidenkäytön rajoituksen tyyppi. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji\">http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji</a>"
+          },
+          "timeOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivämäärä",
+            "format": "date"
+          },
+          "administrativeAreaIdentifiers": {
+            "maxItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "hallinnollisen alueen tunnukset"
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "caseIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Asianhallintatunnukset",
+            "nullable": true
+          },
+          "recordNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Diaarinumerot",
+            "nullable": true
+          },
+          "producerLandUseRestrictionIdentifier": {
+            "type": "string",
+            "description": "Kunnan antama alueidenkäytön rajoituksen tunnus",
+            "nullable": true
+          },
+          "matterAnnexes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandUseRestrictionAttachmentDocument"
+            },
+            "description": "AsianLiitteet",
+            "nullable": true
+          },
+          "responsibleParty": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandUseRestrictionOperator"
+              }
+            ],
+            "description": "Vastuutaho",
+            "nullable": true
+          },
+          "relatedLandUseRestrictionMatters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Liittyvät alueidenkäytön rajoituksen asiat",
+            "nullable": true
+          },
+          "landUseRestrictionMatterUri": {
+            "type": "string",
+            "description": "Luokan pysyvä URI -muotoinen viittaustunniste (https://uri.rakennetunymparistontietojarjestelma.fi/landuserestrictionmatter/{identifier})",
+            "readOnly": true
+          },
+          "phases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandUseRestrictionMatterPhase"
+            },
+            "description": "Vaiheet"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandUseRestrictionMatterUpdate": {
+        "required": [
+          "administrativeAreaIdentifiers",
+          "landUseRestrictionType",
+          "name",
+          "permanentLandUseRestrictionIdentifier",
+          "timeOfInitiation"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentLandUseRestrictionIdentifier": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Alueidenkäytön rajoituksen pysyvä tunnus"
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          },
+          "landUseRestrictionType": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Alueidenkäytön rajoituksen tyyppi. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji\">http://uri.suomi.fi/codelist/rytj/alueidenkaytonRajoituksenLaji</a>"
+          },
+          "timeOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivämäärä",
+            "format": "date"
+          },
+          "administrativeAreaIdentifiers": {
+            "maxItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "hallinnollisen alueen tunnukset"
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "caseIdentifiers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Asianhallintatunnukset",
+            "nullable": true
+          },
+          "recordNumbers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Diaarinumerot",
+            "nullable": true
+          },
+          "producerLandUseRestrictionIdentifier": {
+            "type": "string",
+            "description": "Kunnan antama alueidenkäytön rajoituksen tunnus",
+            "nullable": true
+          },
+          "matterAnnexes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandUseRestrictionAttachmentDocument"
+            },
+            "description": "AsianLiitteet",
+            "nullable": true
+          },
+          "responsibleParty": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandUseRestrictionOperator"
+              }
+            ],
+            "description": "Vastuutaho",
+            "nullable": true
+          },
+          "relatedLandUseRestrictionMatters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Liittyvät alueidenkäytön rajoituksen asiat",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
@@ -1,44 +1,70 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "Ryhti API",
-      "description": "<h2>Rakennetun ympäristön muutostietorajapinta</h2>\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
-      "contact": {
-        "name": "Feedback",
-        "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
-      },
-      "license": {
-        "name": "CC BY 4.0",
-        "url": "https://creativecommons.org/licenses/by/4.0/"
-      },
-      "version": "1"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Ryhti API",
+    "description": "<h2>Rakennetun ympäristön muutostietorajapinta</h2>\r\n\r\nLisää tietoa rakennetun ympäristön tietojärjestelmästä: <a href=\"https://ryhti.syke.fi/\">https://ryhti.syke.fi/</a>\r\n<br/>",
+    "contact": {
+      "name": "Feedback",
+      "url": "https://www.syke.fi/en-US/SYKE_Info/Contact_information/Feedback_form(10043)?r=38611"
     },
-    "servers": [
-      {
-        "url": "/change-information"
-      }
-    ],
-    "paths": {
-      "/api/Authenticate": {
-        "post": {
-          "tags": [
-            "Authentication"
-          ],
-          "summary": "Hae OAuth2 -token käyttäen client credentials tunnusta ja salaisuutta.",
-          "description": "ClientId välitetään querysting parametrina ja clientSecrect http bodyssä. <b>X-Token-Expires-In</b> http headerissa palautuu tokenin voimassaoloaika sekunneissa.",
-          "parameters": [
-            {
-              "name": "clientId",
-              "in": "query",
-              "description": "OAuth clientId.",
+    "license": {
+      "name": "CC BY 4.0",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
+    },
+    "version": "1"
+  },
+  "servers": [
+    {
+      "url": "/change-information"
+    }
+  ],
+  "paths": {
+    "/api/Authenticate": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Hae OAuth2 -token käyttäen client credentials tunnusta ja salaisuutta.",
+        "description": "ClientId välitetään querysting parametrina ja clientSecrect http bodyssä. <b>X-Token-Expires-In</b> http headerissa palautuu tokenin voimassaoloaika sekunneissa.",
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "query",
+            "description": "OAuth clientId.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "OAuth clientSecret välitetään http bodyssä heittomerkkien sisällä. Esim. ```\"minunsalaisuus\"```",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "application/*+json": {
               "schema": {
                 "type": "string"
               }
             }
-          ],
-          "requestBody": {
-            "description": "OAuth clientSecret välitetään http bodyssä heittomerkkien sisällä. Esim. ```\"minunsalaisuus\"```",
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OAuth token, joka pitää välittää Authorization headerissä muissa api-kutsuissa.\r\n            ```X-Token-Expires-In``` http header kertoo sekunneissa tokeninen voimassaoloajan.\r\n            Muita api-rajapintoja kutsuttaessa lisää kutsuun Authorization header seuraavasti: ```Authorization: Bearer [token]```",
             "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              },
               "application/json": {
                 "schema": {
                   "type": "string"
@@ -48,7442 +74,7575 @@
                 "schema": {
                   "type": "string"
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
               },
-              "application/*+json": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/json": {
                 "schema": {
                   "type": "string"
                 }
               }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OAuth token, joka pitää välittää Authorization headerissä muissa api-kutsuissa.\r\n            ```X-Token-Expires-In``` http header kertoo sekunneissa tokeninen voimassaoloajan.\r\n            Muita api-rajapintoja kutsuttaessa lisää kutsuun Authorization header seuraavasti: ```Authorization: Bearer [token]```",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/Building": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae rakennuksen muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/BuildingGeneralized": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae karkeutetut rakennuksen muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/BuildingPermit": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae rakennuslupa-asian muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/BuildingPermitGeneralized": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae karkeutetut rakennuslupa-asian muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/Operator": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae toimijan muutostiedot",
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/Structure": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae rakennelman muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/DemolitionPermit": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae purkamislupa-asia muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/LandscapeWorkPermit": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae maisematyölupa muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/ChangeInformation/DeviationPermit": {
-        "post": {
-          "tags": [
-            "ChangeInformation"
-          ],
-          "summary": "Hae poikkeamislupa-asia muutostiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "description": "Viimeisin ID muutostentietojen hakemiseksi.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetChangeInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "Bad Request",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "422": {
-              "description": "Unprocessable Content",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/Building": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "summary": "Hae rakennuksen perustiedot",
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/BuildingPermit": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/BuildingGeneralized": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/BuildingPermitGeneralized": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/DemolitionPermit": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/LandscapeWorkPermit": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/InitialInformation/DeviationPermit": {
-        "post": {
-          "tags": [
-            "InitialInformation"
-          ],
-          "parameters": [
-            {
-              "name": "municipality",
-              "in": "query",
-              "schema": {
-                "type": "string"
-              }
-            }
-          ],
-          "requestBody": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              },
-              "application/*+json": {
-                "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/GetInitialInfo"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "responses": {
-            "200": {
-              "description": "OK",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/InitialInformationCollection"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "/api/Status/health": {
-        "get": {
-          "tags": [
-            "Status"
-          ],
-          "summary": "Rajapinnan toimivuuden tarkistus.",
-          "description": "Antaa tiedon rajapinnan toimivuudesta.",
-          "responses": {
-            "200": {
-              "description": "Rajapinta toimii oletetusti.",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/HealthReport"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/HealthReport"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/HealthReport"
-                  }
-                }
-              }
-            },
-            "503": {
-              "description": "Rajapinnan toiminnassa ongelmia."
             }
           }
         }
       }
     },
-    "components": {
-      "schemas": {
-        "AcceptedDeviation": {
-          "required": [
-            "acceptedDeviationKey",
-            "contentOfDeviation"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviationKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "deviationType": {
-              "type": "string",
-              "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
-            },
-            "contentOfDeviation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            }
-          },
-          "additionalProperties": false,
-          "description": "Luvan yhteydessä myönnettävä poikkeaminen"
-        },
-        "Address": {
-          "required": [
-            "addressKey"
-          ],
-          "type": "object",
-          "properties": {
-            "addressKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "addressName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "numberPartOfAddressNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "postalCode": {
-              "type": "string",
-              "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
-              "nullable": true
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "numberPartOfAddressNumber2": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber2": {
-              "type": "string",
-              "nullable": true
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Osoite"
-        },
-        "AdministrativeLocationUnit": {
-          "required": [
-            "administrativeLocationUnitKey",
-            "propertyIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "administrativeLocationUnitKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "unitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "propertyIdentifier": {
+    "/api/ChangeInformation/Building": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae rakennuksen muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
               "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
             },
-            "unseparatedParcelIdentifier": {
-              "type": "string",
-              "nullable": true
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Hallinnollinen sijaintiyksikkö"
-        },
-        "Apartment": {
-          "required": [
-            "addressNumber",
-            "apartmentKey",
-            "apartmentType",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "apartmentKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-              ],
-              "type": "string",
-              "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "apartmentEquipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ApartmentEquipment"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
               },
-              "nullable": true
-            },
-            "apartmentIdentifier": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/BuildingGeneralized": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae karkeutetut rakennuksen muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
               "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
             },
-            "apartmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-              ],
-              "type": "string",
-              "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
             },
-            "floorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "numberOfRooms": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "kitchenType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-              ],
-              "type": "string",
-              "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-              "nullable": true
-            },
-            "isWaterCloset": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "apartmentChangeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-              ],
-              "type": "string",
-              "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "apartmentStorey": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentNumber": {
-              "type": "integer",
-              "format": "int32"
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Huoneisto"
-        },
-        "ApartmentEquipment": {
-          "required": [
-            "apartmentEquipmentKey",
-            "apartmentEquipmentType",
-            "numberOfEquipment"
-          ],
-          "type": "object",
-          "properties": {
-            "apartmentEquipmentKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "apartmentEquipmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/01",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/02",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/03",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/04",
-                "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/05"
-              ],
-              "type": "string",
-              "description": "Huoneiston varusteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste\">http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste</a>",
-              "nullable": true
-            },
-            "numberOfEquipment": {
-              "type": "integer",
-              "format": "int32"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
             }
           },
-          "additionalProperties": false,
-          "description": "Huoneiston varuste"
-        },
-        "AreaToBeBuiltForSpecificActivities": {
-          "required": [
-            "areaToBeBuiltForSpecificActivitiesKey",
-            "buildingObjectOwner",
-            "buildingObjectType"
-          ],
-          "type": "object",
-          "properties": {
-            "areaToBeBuiltForSpecificActivitiesKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "specificActivitiesAreaType": {
-              "type": "string",
-              "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>",
-              "nullable": true
-            },
-            "networkConnection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/NetworkConnection"
-              },
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "temporary": {
-              "type": "boolean"
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "decisionAdministrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja",
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
+              }
             }
-          },
-          "additionalProperties": false,
-          "description": "Erityistä toimintaa varten rakennettava alue"
-        },
-        "AssemblyFacility": {
-          "required": [
-            "assemblyFacilityKey",
-            "capacityOfAssemblyFacilities"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "assemblyFacilityKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "capacityOfAssemblyFacilities": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Kokoontumistila"
-        },
-        "Building": {
-          "required": [
-            "buildingKey",
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "mainPurpose",
-            "numberOfStoreys"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentBuildingIdentifier": {
-              "type": "string",
-              "description": "Pysyvä rakennustunnus (PRT)"
-            },
-            "temporary": {
-              "type": "boolean",
-              "description": "Onko väliaikainen",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "description": "Demolition deadline",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "description": "Kerrosluku",
-              "format": "int32",
-              "nullable": true
-            },
-            "buildingSection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingSection"
-              },
-              "description": "Rakennuksen osat",
-              "nullable": true
-            },
-            "mainPurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-              ],
-              "type": "string",
-              "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja",
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "addChangeEvent": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuksen tiedot."
-        },
-        "BuildingAttachmentDocument": {
-          "required": [
-            "attachmentDocumentKey",
-            "categoryOfPublicity",
-            "documentDate",
-            "documentIdentifier",
-            "fileKey",
-            "languages",
-            "name",
-            "personalDataContent",
-            "retentionTime"
-          ],
-          "type": "object",
-          "properties": {
-            "attachmentDocumentKey": {
-              "type": "string",
-              "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
-              "format": "uuid"
-            },
-            "documentIdentifier": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            },
-            "personalDataContent": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
-            },
-            "categoryOfPublicity": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
-            },
-            "accessibility": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "retentionTime": {
-              "minLength": 1,
-              "type": "string",
-              "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
-            },
-            "confirmationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "languages": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
-            },
-            "fileKey": {
-              "type": "string",
-              "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
-              "format": "uuid"
-            },
-            "descriptors": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Descriptor"
-              },
-              "nullable": true
-            },
-            "documentDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "arrivedDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "attachmentType": {
-              "type": "string",
-              "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
-            },
-            "documentCreatorPersonalIdentityCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentCreatorOtherId": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentCreatorFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "documentCreatorFamilyName": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Liiteasiakirja"
-        },
-        "BuildingInformationModel": {
-          "required": [
-            "buildingInformationModelKey",
-            "buildingInformationModelType"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingInformationModelKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingInformationModelType": {
-              "type": "string",
-              "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
-            },
-            "document": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "referencePoint": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennustietomalli"
-        },
-        "BuildingMaterialOfLoadBearingStructures": {
-          "required": [
-            "buildingMaterialOfLoadBearingStructuresKey",
-            "buildingMaterialOfLoadBearingStructuresType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingMaterialOfLoadBearingStructuresKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingMaterialOfLoadBearingStructuresType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/00",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/01",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/02",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/03",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/04",
-                "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/99"
-              ],
-              "type": "string",
-              "description": "Kantavan rakenteen rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine\">http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine</a>"
-            },
-            "isPrimary": {
-              "type": "boolean",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Kantavien rakenteiden rakennusaine"
-        },
-        "BuildingObjectChange": {
-          "required": [
-            "buildingObjectChangeKey"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectChangeKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "volumeChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "grossFloorAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "permittedBuildingAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "totalAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "floorAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "basementAreaChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "numberOfStoreysChange": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuskohteen muutos"
-        },
-        "BuildingObjectLocationData": {
-          "required": [
-            "buildingObjectLocationDataKey"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectLocationDataKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "votingDistrictNumber": {
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/BuildingPermit": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae rakennuslupa-asian muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
               "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
             },
-            "pointLocation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
                 }
-              ]
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/BuildingPermitGeneralized": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae karkeutetut rakennuslupa-asian muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
             },
-            "geometry": {
-              "type": "array",
-              "items": {
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/Operator": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae toimijan muutostiedot",
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/Structure": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae rakennelman muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DemolitionPermit": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae purkamislupa-asia muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/LandscapeWorkPermit": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae maisematyölupa muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DeviationPermit": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae poikkeamislupa-asia muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/Building": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "summary": "Hae rakennuksen perustiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/BuildingPermit": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/BuildingGeneralized": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/BuildingPermitGeneralized": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/DemolitionPermit": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/LandscapeWorkPermit": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/DeviationPermit": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/Structure": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/Status/health": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "summary": "Rajapinnan toimivuuden tarkistus.",
+        "description": "Antaa tiedon rajapinnan toimivuudesta.",
+        "responses": {
+          "200": {
+            "description": "Rajapinta toimii oletetusti.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthReport"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthReport"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthReport"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Rajapinnan toiminnassa ongelmia."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AcceptedDeviation": {
+        "required": [
+          "acceptedDeviationKey",
+          "contentOfDeviation",
+          "deviationType"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deviationType": {
+            "type": "string",
+            "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
+          },
+          "contentOfDeviation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Luvan yhteydessä myönnettävä poikkeaminen"
+      },
+      "Address": {
+        "required": [
+          "addressKey",
+          "addressNumber",
+          "postalCode"
+        ],
+        "type": "object",
+        "properties": {
+          "addressKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "addressName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "numberPartOfAddressNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
+            "nullable": true
+          },
+          "location": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/RyhtiGeometry"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuskohteen sijaintitiedot"
-        },
-        "BuildingObjectOwner": {
-          "required": [
-            "buildingObjectOwnerKey",
-            "differentOwner",
-            "ownerOperator"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingObjectOwnerKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "ownerOperator": {
-              "required": [
-                "isPerson"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": ""
-            },
-            "differentOwner": {
-              "type": "boolean",
-              "description": ""
-            },
-            "tenureStatus": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "ownerContactOperator": {
-              "required": [
-                "isPerson"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "ownerType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/09",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/10",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/11",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/12",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/13",
-                "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/14"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen omistajan laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/OmistajanLahde"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuskohteen omistaja"
-        },
-        "BuildingPermitApplication": {
-          "required": [
-            "applicationContent",
-            "lifeCycleState",
-            "permitApplicationKey"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
-              "nullable": true
-            },
-            "applicationContent": {
-              "type": "string"
-            },
-            "dateOfReception": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
-            },
-            "permitApplicationKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitApplicationType": {
-              "type": "string",
-              "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakentamislupahakemus"
-        },
-        "BuildingPermitDecision": {
-          "required": [
-            "buildingPermitDecisionKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "buildingPermitDecisionKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitApplicationType": {
-              "type": "string",
-              "nullable": true
-            },
-            "constructionToBeStartedBy": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedBy": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeStartedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakentamislupapäätös"
-        },
-        "BuildingSection": {
-          "required": [
-            "buildingSectionKey",
-            "lifeCycleState",
-            "partitionReason",
-            "usageData"
-          ],
-          "type": "object",
-          "properties": {
-            "buildingSectionKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-              ],
-              "type": "string",
-              "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih",
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "protectionMethod": {
-              "type": "string",
-              "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
-              "nullable": true
-            },
-            "cultureHistoricalSignificance": {
-              "type": "string",
-              "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
-              "nullable": true
-            },
-            "materialData": {
-              "required": [
-                "constructionMethod",
-                "buildingMaterialOfLoadBearingStructures",
-                "facadeMaterial",
-                "wideBodiedBuilding"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/MaterialData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "energyData": {
-              "required": [
-                "energyDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EnergyData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "interiorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/InteriorData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "exteriorData": {
-              "required": [
-                "shape"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ExteriorData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "buildingServicesEngineeringData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "usageData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/UsageData"
-                }
-              ],
-              "description": ""
-            },
-            "equipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Equipment"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "entrance": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Entrance"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "assemblyFacility": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AssemblyFacility"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "elevator": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Elevator"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "apartment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Apartment"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "partitionReason": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-              ],
-              "type": "string",
-              "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
-            },
-            "partitionDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "civilDefenceShelter": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CivilDefenceShelter"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "relatedFinishedBuildingSection": {
-              "type": "string",
-              "description": "",
-              "format": "uuid",
-              "nullable": true
-            },
-            "demolitionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuksen osa"
-        },
-        "BuildingServicesEngineeringData": {
-          "type": "object",
-          "properties": {
-            "ventilationMethod": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/VentilationMethod"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "sewerageMethodType": {
-              "type": "string",
-              "description": "Jätevesien käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/jatevesienkasittely",
-              "nullable": true
-            },
-            "householdWaterType": {
-              "type": "string",
-              "description": "Talousveden laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/talousvesi",
-              "nullable": true
-            },
-            "networkConnection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/NetworkConnection"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "stormWaterTreatmentType": {
-              "type": "string",
-              "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/hulevedenkasittely",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Talotekniikkatiedot"
-        },
-        "BuildingSite": {
-          "required": [
-            "stormWaterTreatmentType",
-            "tenure"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingSiteKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "area": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "stormWaterTreatmentType": {
-              "type": "string",
-              "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
-              "nullable": true
-            },
-            "buildingSiteAddress": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "spatialPlan": {
-              "type": "string",
-              "nullable": true
-            },
-            "statusOfPlan": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/01",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/02",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/03",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/04",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/05",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/06",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/07",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/08",
-                "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/09"
-              ],
-              "type": "string",
-              "description": "Kaavatilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaava\">http://uri.suomi.fi/codelist/vtj/Rake_kaava</a>",
-              "nullable": true
-            },
-            "tenure": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/1",
-                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/2",
-                "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
-              ],
-              "type": "string",
-              "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuspaikka"
-        },
-        "CalculatoryDeliveredEnergyUsage": {
-          "required": [
-            "calculatoryDeliveredEnergyUsageKey",
-            "deliveredEnergyType",
-            "energyAmountYearly"
-          ],
-          "type": "object",
-          "properties": {
-            "calculatoryDeliveredEnergyUsageKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "deliveredEnergyType": {
-              "type": "string",
-              "description": "Ostoenergian laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ostoenergia\">http://uri.suomi.fi/codelist/rytj/ostoenergia</a>"
-            },
-            "energyAmountYearly": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Energiankulutus"
-        },
-        "CallForDeviation": {
-          "required": [
-            "callForDeviationKey",
-            "contentOfDeviation",
-            "deviationType"
-          ],
-          "type": "object",
-          "properties": {
-            "callForDeviationKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "deviationType": {
-              "type": "string",
-              "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
-            },
-            "contentOfDeviation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-            }
-          },
-          "additionalProperties": false,
-          "description": "Määräyksestä poikkeaminen"
-        },
-        "ChangeInformationAdministrativeLocationUnit": {
-          "type": "object",
-          "properties": {
-            "administrativeLocationUnitKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "unitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "propertyIdentifier": {
-              "type": "string"
-            },
-            "unseparatedParcelIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "property": {
-              "required": [
-                "municipalityNumber",
-                "propertyIdentifier",
-                "status",
-                "type",
-                "relationToBaseProperty"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Property"
-                }
-              ],
-              "description": "Kiinteistö",
-              "nullable": true
-            },
-            "parcel": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/UnseparatedParcel"
-                }
-              ],
-              "description": "Määräala",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ChangeInformationApartment": {
-          "type": "object",
-          "properties": {
-            "apartmentKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-                "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-              ],
-              "type": "string",
-              "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "apartmentEquipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ApartmentEquipment"
-              },
-              "nullable": true
-            },
-            "apartmentIdentifier": {
-              "type": "string"
-            },
-            "apartmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-              ],
-              "type": "string",
-              "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
-            },
-            "floorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "numberOfRooms": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "kitchenType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-              ],
-              "type": "string",
-              "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-              "nullable": true
-            },
-            "isWaterCloset": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "apartmentChangeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-              ],
-              "type": "string",
-              "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "addressNumber": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "apartmentStorey": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "housingType": {
-              "type": "string",
-              "nullable": true
-            },
-            "occupancyOfApartment": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentNumber": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "additionalProperties": false
-        },
-        "ChangeInformationAreaToBeBuiltForSpecificActivities": {
-          "type": "object",
-          "properties": {
-            "areaToBeBuiltForSpecificActivitiesKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "specificActivitiesAreaType": {
-              "type": "string",
-              "nullable": true
-            },
-            "networkConnection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/NetworkConnection"
-              },
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "temporary": {
-              "type": "boolean"
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string"
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuilding": {
-          "type": "object",
-          "properties": {
-            "buildingKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentBuildingIdentifier": {
-              "type": "string",
-              "description": "Pysyvä rakennustunnus (PRT)"
-            },
-            "temporary": {
-              "type": "boolean",
-              "description": "Onko väliaikainen",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "description": "Demolition deadline",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "description": "Kerrosluku",
-              "format": "int32",
-              "nullable": true
-            },
-            "buildingSection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationBuildingSection"
-              },
-              "description": "Rakennuksen osat",
-              "nullable": true
-            },
-            "mainPurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-              ],
-              "type": "string",
-              "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
-              "nullable": true
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ]
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja",
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "addChangeEvent": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "mainPurpose1994": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "numberOfNewApartments": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "numberOfDeletedApartments": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuildingChangeDiffDto": {
-          "type": "object",
-          "properties": {
-            "changeType": {
-              "type": "string"
-            },
-            "objectKey": {
-              "nullable": true
-            },
-            "objectType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentKey": {
-              "nullable": true
-            },
-            "parentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentChain": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ParentTypeKey"
               }
-            },
-            "objectState": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuilding"
-                }
-              ],
-              "nullable": true
-            },
-            "objectStatePrev": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuilding"
-                }
-              ],
-              "nullable": true
-            }
+            ],
+            "nullable": true
           },
-          "additionalProperties": false
+          "numberPartOfAddressNumber2": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber2": {
+            "type": "string",
+            "nullable": true
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
         },
-        "ChangeInformationBuildingChangeInfoCollectionDto": {
-          "type": "object",
-          "properties": {
-            "lastSeen": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PaginationToken"
-                }
-              ],
-              "nullable": true
+        "additionalProperties": false,
+        "description": "Osoite"
+      },
+      "AdministrativeLocationUnit": {
+        "required": [
+          "administrativeLocationUnitKey",
+          "propertyIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "administrativeLocationUnitKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "unitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "unseparatedParcelIdentifier": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hallinnollinen sijaintiyksikkö"
+      },
+      "Apartment": {
+        "required": [
+          "addressNumber",
+          "apartmentChangeType",
+          "apartmentIdentifier",
+          "apartmentKey",
+          "apartmentType",
+          "lifeCycleState",
+          "numberOfRooms"
+        ],
+        "type": "object",
+        "properties": {
+          "apartmentKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
+            ],
+            "type": "string",
+            "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "apartmentEquipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApartmentEquipment"
             },
-            "upToDate": {
-              "type": "boolean"
+            "nullable": true
+          },
+          "apartmentIdentifier": {
+            "type": "string"
+          },
+          "apartmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+            ],
+            "type": "string",
+            "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+          },
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "numberOfRooms": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "kitchenType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+            ],
+            "type": "string",
+            "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
+            "nullable": true
+          },
+          "isWaterCloset": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "apartmentChangeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+            ],
+            "type": "string",
+            "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "apartmentStorey": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Huoneisto"
+      },
+      "ApartmentEquipment": {
+        "required": [
+          "apartmentEquipmentKey",
+          "apartmentEquipmentType",
+          "numberOfEquipment"
+        ],
+        "type": "object",
+        "properties": {
+          "apartmentEquipmentKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "apartmentEquipmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/01",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/02",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/03",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/04",
+              "http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste/code/05"
+            ],
+            "type": "string",
+            "description": "Huoneiston varusteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste\">http://uri.suomi.fi/codelist/rytj/HuoneistoVaruste</a>",
+            "nullable": true
+          },
+          "numberOfEquipment": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Huoneiston varuste"
+      },
+      "AreaToBeBuiltForSpecificActivities": {
+        "required": [
+          "address",
+          "administrativeLocationUnit",
+          "areaToBeBuiltForSpecificActivitiesKey",
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "location",
+          "specificActivitiesAreaType",
+          "temporary"
+        ],
+        "type": "object",
+        "properties": {
+          "areaToBeBuiltForSpecificActivitiesKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specificActivitiesAreaType": {
+            "type": "string",
+            "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
             },
-            "changes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoDto"
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
               }
-            }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuildingChangeInfoDto": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "eventTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "objectKey": { },
-            "objectState": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuilding"
-                }
-              ],
-              "nullable": true
-            },
-            "diff": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationBuildingChangeDiffDto"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuildingPermitIssue": {
-          "required": [
-            "lifeCycleState",
-            "municipalityNumber"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-              "nullable": true
-            },
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "permanentPermitIdentifier": {
-              "type": "string"
-            },
-            "decision": {
-              "required": [
-                "buildingPermitDecisionKey",
-                "lifeCycleState"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingPermitDecision"
-                }
-              ],
-              "description": "Rakentamislupapäätös",
-              "nullable": true
-            },
-            "extensionDecision": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExtensionDecision"
-              },
-              "nullable": true
-            },
-            "changePermit": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangePermit"
-              },
-              "nullable": true
-            },
-            "buildingPermitApplication": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingPermitApplication"
-              },
-              "description": "Rakentamislupahakemus",
-              "nullable": true
-            },
-            "constructionAction": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationConstructionAction"
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
               }
-            },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "constructionProject": {
-              "required": [
-                "constructionProjectKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionProject"
-                }
-              ],
-              "description": "Rakentamishanke",
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "dateOfInitiation": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuildingPermitIssueChangeDiffDto": {
-          "type": "object",
-          "properties": {
-            "changeType": {
-              "type": "string"
-            },
-            "objectKey": {
-              "nullable": true
-            },
-            "objectType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentKey": {
-              "nullable": true
-            },
-            "parentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentChain": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ParentTypeKey"
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
               }
-            },
-            "objectState": {
-              "required": [
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                }
-              ],
-              "nullable": true
-            },
-            "objectStatePrev": {
-              "required": [
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                }
-              ],
-              "nullable": true
-            }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuildingPermitIssueChangeInfoCollectionDto": {
-          "type": "object",
-          "properties": {
-            "lastSeen": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PaginationToken"
-                }
-              ],
-              "nullable": true
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
             },
-            "upToDate": {
-              "type": "boolean"
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
             },
-            "changes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoDto"
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
-            }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationBuildingPermitIssueChangeInfoDto": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "eventTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "objectKey": { },
-            "objectState": {
-              "required": [
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                }
-              ],
-              "nullable": true
-            },
-            "diff": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeDiffDto"
-              },
-              "nullable": true
-            }
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          }
         },
-        "ChangeInformationBuildingSection": {
-          "type": "object",
-          "properties": {
-            "buildingSectionKey": {
-              "type": "string",
-              "format": "uuid"
+        "additionalProperties": false,
+        "description": "Erityistä toimintaa varten rakennettava alue"
+      },
+      "AssemblyFacility": {
+        "required": [
+          "assemblyFacilityKey",
+          "capacityOfAssemblyFacilities"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "assemblyFacilityKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "capacityOfAssemblyFacilities": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kokoontumistila"
+      },
+      "Building": {
+        "required": [
+          "address",
+          "administrativeLocationUnit",
+          "buildingKey",
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "buildingSection",
+          "location",
+          "mainPurpose",
+          "numberOfStoreys",
+          "permanentBuildingIdentifier",
+          "temporary"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string",
+            "description": "Pysyvä rakennustunnus (PRT)"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Onko väliaikainen",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "description": "Demolition deadline",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "description": "Kerrosluku",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingSection"
             },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-              ],
-              "type": "string",
-              "nullable": true
+            "description": "Rakennuksen osat",
+            "nullable": true
+          },
+          "mainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string",
+            "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö"
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
             },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
             },
-            "protectionMethod": {
-              "type": "string",
-              "nullable": true
-            },
-            "cultureHistoricalSignificance": {
-              "type": "string",
-              "nullable": true
-            },
-            "materialData": {
-              "required": [
-                "constructionMethod",
-                "buildingMaterialOfLoadBearingStructures",
-                "facadeMaterial",
-                "wideBodiedBuilding"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/MaterialData"
-                }
-              ],
-              "description": "Materiaalitiedot",
-              "nullable": true
-            },
-            "energyData": {
-              "required": [
-                "energyDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EnergyData"
-                }
-              ],
-              "description": "Energiatiedot",
-              "nullable": true
-            },
-            "interiorData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/InteriorData"
-                }
-              ],
-              "description": "Sisätilojen tiedot",
-              "nullable": true
-            },
-            "exteriorData": {
-              "required": [
-                "shape"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ExteriorData"
-                }
-              ],
-              "description": "Ulkokuoren tiedot",
-              "nullable": true
-            },
-            "buildingServicesEngineeringData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                }
-              ],
-              "description": "Talotekniikkatiedot",
-              "nullable": true
-            },
-            "usageData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/UsageData"
-                }
-              ],
-              "description": "Rakennuksen käyttötiedot"
-            },
-            "equipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Equipment"
-              },
-              "nullable": true
-            },
-            "entrance": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Entrance"
-              },
-              "nullable": true
-            },
-            "assemblyFacility": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AssemblyFacility"
-              },
-              "nullable": true
-            },
-            "elevator": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Elevator"
-              },
-              "nullable": true
-            },
-            "apartment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangeInformationApartment"
-              },
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "partitionReason": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-              ],
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuksen tiedot."
+      },
+      "BuildingAttachmentDocument": {
+        "required": [
+          "attachmentDocumentKey",
+          "categoryOfPublicity",
+          "documentDate",
+          "documentIdentifier",
+          "fileKey",
+          "languages",
+          "name",
+          "personalDataContent",
+          "retentionTime"
+        ],
+        "type": "object",
+        "properties": {
+          "attachmentDocumentKey": {
+            "type": "string",
+            "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
+            "format": "uuid"
+          },
+          "documentIdentifier": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          },
+          "personalDataContent": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
+          },
+          "categoryOfPublicity": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
+          },
+          "accessibility": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "retentionTime": {
+            "minLength": 1,
+            "type": "string",
+            "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
+          },
+          "confirmationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "partitionDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "civilDefenceShelter": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CivilDefenceShelter"
-              },
-              "nullable": true
-            },
-            "relatedFinishedBuildingSection": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
-            "demolitionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "nullable": true
-            }
+            "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationConstructionAction": {
-          "type": "object",
-          "properties": {
-            "constructionActionKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "constructionActionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
-              "nullable": true
-            },
-            "buildingObjectChange": {
-              "required": [
-                "buildingObjectChangeKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectChange"
-                }
-              ],
-              "description": "Rakennuskohteen muutos",
-              "nullable": true
-            },
-            "descriptionOfAction": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "areaUndergoingChanges": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-              "nullable": true
-            },
-            "renovation": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationRate": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "building": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationBuilding"
-                }
-              ],
-              "nullable": true
-            },
-            "structure": {
-              "required": [
-                "structureMainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationStructure"
-                }
-              ],
-              "nullable": true
-            },
-            "areaToBeBuiltForSpecificActivities": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
-                }
-              ],
-              "nullable": true
-            },
-            "startDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "statusOfConstructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-              "nullable": true
-            },
-            "fullyApprovedForUse": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "businessConstruction": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "changeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-              ],
-              "type": "string",
-              "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-              "nullable": true
-            },
-            "dvvPermitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "expiryDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "locatedOnUnseparatedParcel": {
-              "type": "boolean",
-              "nullable": true
-            }
+          "fileKey": {
+            "type": "string",
+            "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
+            "format": "uuid"
           },
-          "additionalProperties": false
-        },
-        "ChangeInformationStructure": {
-          "required": [
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "structureMainPurpose"
-          ],
-          "type": "object",
-          "properties": {
-            "structureKey": {
-              "type": "string",
-              "format": "uuid"
+          "descriptors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Descriptor"
             },
-            "permanentStructureIdentifier": {
-              "type": "string"
-            },
-            "temporary": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "structureSection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/StructureSection"
-              },
-              "nullable": true
-            },
-            "structureMainPurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string",
-              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ]
-            },
-            "decisionAdministrativeLocationUnit": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-                }
-              ],
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja",
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "ChangePermit": {
-          "required": [
-            "changePermitKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "changePermitKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            }
+          "documentDate": {
+            "type": "string",
+            "format": "date"
           },
-          "additionalProperties": false,
-          "description": "Muutospäätös"
-        },
-        "CivilDefenceShelter": {
-          "required": [
-            "civilDefenceShelterCapacity",
-            "civilDefenceShelterClass",
-            "civilDefenceShelterKey",
-            "civilDefenceShelterShared"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "civilDefenceShelterKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "civilDefenceShelterClass": {
-              "type": "string",
-              "description": "Väestönsuojan luokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka\">http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka</a>",
-              "nullable": true
-            },
-            "civilDefenceShelterCapacity": {
-              "type": "integer",
-              "description": "Väestönsuojan suojapaikkojen määrä",
-              "format": "int32"
-            },
-            "civilDefenceShelterShared": {
-              "type": "boolean"
-            },
-            "civilDefenceShelterAdditionalInformation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "civilDefenceShelterOtherBuildings": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CivilDefenceShelterOtherBuildings"
-              },
-              "nullable": true
-            }
+          "arrivedDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Väestönsuoja"
-        },
-        "CivilDefenceShelterOtherBuildings": {
-          "required": [
-            "civilDefenceShelterOtherBuildingsKey",
-            "civilDefenceShelterPointedCapacity",
-            "permanentBuildingIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "civilDefenceShelterOtherBuildingsKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentBuildingIdentifier": {
-              "type": "string"
-            },
-            "civilDefenceShelterPointedCapacity": {
-              "type": "integer",
-              "format": "int32"
-            }
+          "attachmentType": {
+            "type": "string",
+            "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
           },
-          "additionalProperties": false,
-          "description": "Väestönsuojan muut rakennukset"
-        },
-        "ConstructionAction": {
-          "required": [
-            "constructionActionKey",
-            "constructionActionType",
-            "statusOfConstructionAction"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionActionKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "constructionActionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
-              "nullable": true
-            },
-            "buildingObjectChange": {
-              "required": [
-                "buildingObjectChangeKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectChange"
-                }
-              ],
-              "description": "Rakennuskohteen muutos",
-              "nullable": true
-            },
-            "descriptionOfAction": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "areaUndergoingChanges": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-              "nullable": true
-            },
-            "renovation": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "renovationRate": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "building": {
-              "required": [
-                "buildingKey",
-                "numberOfStoreys",
-                "mainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Building"
-                }
-              ],
-              "description": "Rakennuksen tiedot.",
-              "nullable": true
-            },
-            "finishedBuilding": {
-              "required": [
-                "buildingKey",
-                "numberOfStoreys",
-                "mainPurpose",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Building"
-                }
-              ],
-              "description": "Rakennuksen tiedot.",
-              "nullable": true
-            },
-            "structure": {
-              "required": [
-                "structureKey",
-                "permanentStructureIdentifier",
-                "structureMainPurpose",
-                "buildingObjectType",
-                "administrativeLocationUnit",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            },
-            "finishedStructure": {
-              "required": [
-                "structureKey",
-                "permanentStructureIdentifier",
-                "structureMainPurpose",
-                "buildingObjectType",
-                "administrativeLocationUnit",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            },
-            "areaToBeBuiltForSpecificActivities": {
-              "required": [
-                "areaToBeBuiltForSpecificActivitiesKey",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-                }
-              ],
-              "description": "Erityistä toimintaa varten rakennettava alue",
-              "nullable": true
-            },
-            "startDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "completionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "statusOfConstructionAction": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-              ],
-              "type": "string",
-              "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-              "nullable": true
-            },
-            "fullyApprovedForUse": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "businessConstruction": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "changeType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-                "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-              ],
-              "type": "string",
-              "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-              "nullable": true
-            },
-            "dvvPermitIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "expiryDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "finishedAreaToBeBuiltForSpecificActivities": {
-              "required": [
-                "areaToBeBuiltForSpecificActivitiesKey",
-                "buildingObjectType",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-                }
-              ],
-              "description": "Erityistä toimintaa varten rakennettava alue",
-              "nullable": true
-            }
+          "documentCreatorPersonalIdentityCode": {
+            "type": "string",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakentamistoimenpide"
+          "documentCreatorOtherId": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCreatorFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "documentCreatorFamilyName": {
+            "type": "string",
+            "nullable": true
+          }
         },
-        "ConstructionDesign": {
-          "required": [
-            "constructionDesignKey",
-            "constructionDesignType",
-            "document"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionDesignKey": {
-              "type": "string",
-              "format": "uuid"
+        "additionalProperties": false,
+        "description": "Liiteasiakirja"
+      },
+      "BuildingInformationModel": {
+        "required": [
+          "buildingInformationModelKey",
+          "buildingInformationModelType",
+          "document",
+          "referencePoint"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingInformationModelKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModelType": {
+            "type": "string",
+            "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
             },
-            "constructionDesignType": {
-              "type": "string",
-              "description": "Rakennusssuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/raksuunlajit\">http://uri.suomi.fi/codelist/rytj/raksuunlajit</a>"
+            "nullable": true
+          },
+          "referencePoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennustietomalli"
+      },
+      "BuildingMaterialOfLoadBearingStructures": {
+        "required": [
+          "buildingMaterialOfLoadBearingStructuresKey",
+          "buildingMaterialOfLoadBearingStructuresType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingMaterialOfLoadBearingStructuresKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingMaterialOfLoadBearingStructuresType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/00",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/01",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/02",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/03",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/04",
+              "http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine/code/99"
+            ],
+            "type": "string",
+            "description": "Kantavan rakenteen rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine\">http://uri.suomi.fi/codelist/rytj/kantavanrakenteenrakennusaine</a>"
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kantavien rakenteiden rakennusaine"
+      },
+      "BuildingObjectChange": {
+        "required": [
+          "buildingObjectChangeKey"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectChangeKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "volumeChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "grossFloorAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "permittedBuildingAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "totalAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "floorAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "basementAreaChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfStoreysChange": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuskohteen muutos"
+      },
+      "BuildingObjectLocationData": {
+        "required": [
+          "buildingObjectLocationDataKey",
+          "pointLocation"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectLocationDataKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "votingDistrictNumber": {
+            "type": "string"
+          },
+          "pointLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ]
+          },
+          "geometry": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RyhtiGeometry"
             },
-            "document": {
-              "type": "array",
-              "items": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuskohteen sijaintitiedot"
+      },
+      "BuildingObjectOwner": {
+        "required": [
+          "buildingObjectOwnerKey",
+          "differentOwner",
+          "ownerOperator",
+          "ownerType"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingObjectOwnerKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "ownerOperator": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": ""
+          },
+          "differentOwner": {
+            "type": "boolean",
+            "description": ""
+          },
+          "tenureStatus": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "ownerContactOperator": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "ownerType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/09",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/10",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/11",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/12",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/13",
+              "http://uri.suomi.fi/codelist/rytj/Omistajalaji/code/14"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen omistajan laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/OmistajanLahde"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuskohteen omistaja"
+      },
+      "BuildingPermitApplication": {
+        "required": [
+          "applicationContent",
+          "dateOfReception",
+          "lifeCycleState",
+          "permitApplicationKey",
+          "permitApplicationType"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "permitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamislupahakemus"
+      },
+      "BuildingPermitDecision": {
+        "required": [
+          "buildingPermitDecisionKey",
+          "constructionToBeCompletedBy",
+          "constructionToBeStartedBy",
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "engagingParty",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
               }
-            }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennussuunnitelma"
-        },
-        "ConstructionProject": {
-          "required": [
-            "constructionProjectKey"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionProjectKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "descriptionOfConstructionProject": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "startDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "endDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "planner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Planner"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "foreman": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Foreman"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "inspection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Inspection"
-              },
-              "description": "",
-              "nullable": true
-            }
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakentamishanke"
-        },
-        "ContactAddress": {
-          "required": [
-            "addressKey"
-          ],
-          "type": "object",
-          "properties": {
-            "addressKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "addressName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "numberPartOfAddressNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber": {
-              "type": "string",
-              "nullable": true
-            },
-            "postalCode": {
-              "type": "string",
-              "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
-              "nullable": true
-            },
-            "location": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "numberPartOfAddressNumber2": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subdivisionLetterOfAddressNumber2": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentIdentifierLetterSuffix": {
-              "type": "string",
-              "nullable": true
-            },
-            "apartmentIdentifierNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "apartmentIdentifierSubdivisionLetter": {
-              "type": "string",
-              "nullable": true
-            },
-            "additionalAddressAttribute": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "c_O": {
-              "type": "string",
-              "nullable": true
-            },
-            "poBoxAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "countryCode": {
-              "type": "string",
-              "description": "Maakoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
-              "nullable": true
-            },
-            "foreignAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "foreignPostalAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "additionalForeignAddress": {
-              "type": "string",
-              "nullable": true
-            },
-            "postalAddress": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "contactAddressType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/06",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/07",
-                "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/08"
-              ],
-              "type": "string",
-              "description": "Yhteysosoitteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji\">http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji</a>"
-            },
-            "source": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/01",
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/02",
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/03",
-                "http://uri.suomi.fi/codelist/rytj/tietolahde/code/04"
-              ],
-              "type": "string",
-              "description": "Tietolähde. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tietolahde\">http://uri.suomi.fi/codelist/rytj/tietolahde</a>"
-            }
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
           },
-          "additionalProperties": false,
-          "description": "Yhteysosoite"
-        },
-        "CoolingEnergySource": {
-          "required": [
-            "coolingEnergySourceKey",
-            "coolingEnergySourceType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "coolingEnergySourceKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "coolingEnergySourceType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/01",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/02",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/03",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/04",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/05",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/06",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/07",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/08"
-              ],
-              "type": "string",
-              "description": "Jäähdytysenergian lähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytys\">http://uri.suomi.fi/codelist/rytj/jaahdytys</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Jäähdytysenergian lähde"
-        },
-        "CoolingMethod": {
-          "required": [
-            "coolingMethodKey",
-            "coolingMethodType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "coolingMethodKey": {
-              "type": "string",
-              "format": "uuid"
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
             },
-            "coolingMethodType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/01",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/02",
-                "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/03"
-              ],
-              "type": "string",
-              "description": "Jäähdytystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytystapa\">http://uri.suomi.fi/codelist/rytj/jaahdytystapa</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Jäähdytystapa"
-        },
-        "DemolitionPermitApplication": {
-          "required": [
-            "applicationContent",
-            "demolitionPermitApplicationKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
-              "nullable": true
-            },
-            "applicationContent": {
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "dateOfReception": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "buildingPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
             },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamislupapäätös"
+      },
+      "BuildingSection": {
+        "required": [
+          "buildingSectionKey",
+          "lifeCycleState",
+          "partitionReason",
+          "usageData"
+        ],
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "exteriorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "usageData": {
+            "required": [
+              "purpose"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsageData"
+              }
+            ],
+            "description": ""
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
             },
-            "demolitionPermitApplicationKey": {
-              "type": "string",
-              "format": "uuid"
+            "description": "",
+            "nullable": true
+          },
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
             },
-            "permitApplicationType": {
-              "type": "string",
-              "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
-              "nullable": true
+            "description": "",
+            "nullable": true
+          },
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Apartment"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string",
+            "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "description": "",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuksen osa"
+      },
+      "BuildingServicesEngineeringData": {
+        "type": "object",
+        "properties": {
+          "ventilationMethod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VentilationMethod"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "sewerageMethodType": {
+            "type": "string",
+            "description": "Jätevesien käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/jatevesienkasittely",
+            "nullable": true
+          },
+          "householdWaterType": {
+            "type": "string",
+            "description": "Talousveden laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/talousvesi",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "stormWaterTreatmentType": {
+            "type": "string",
+            "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/hulevedenkasittely",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Talotekniikkatiedot"
+      },
+      "BuildingSite": {
+        "required": [
+          "buildingSiteAddress",
+          "buildingSiteKey",
+          "stormWaterTreatmentType",
+          "tenure"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingSiteKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "area": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "stormWaterTreatmentType": {
+            "type": "string",
+            "description": "Huleveden käsittelyn laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hulevedenkasittely\">http://uri.suomi.fi/codelist/rytj/hulevedenkasittely</a>",
+            "nullable": true
+          },
+          "buildingSiteAddress": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "spatialPlan": {
+            "type": "string",
+            "nullable": true
+          },
+          "statusOfPlan": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/01",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/02",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/03",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/04",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/05",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/06",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/07",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/08",
+              "http://uri.suomi.fi/codelist/vtj/Rake_kaava/code/09"
+            ],
+            "type": "string",
+            "description": "Kaavatilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaava\">http://uri.suomi.fi/codelist/vtj/Rake_kaava</a>",
+            "nullable": true
+          },
+          "tenure": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/1",
+              "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/2",
+              "http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste/code/3"
+            ],
+            "type": "string",
+            "description": "Hallintaperuste. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste\">http://uri.suomi.fi/codelist/rytj/RakennuspaikanHallintaperuste</a>",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuspaikka"
+      },
+      "CalculatoryDeliveredEnergyUsage": {
+        "required": [
+          "calculatoryDeliveredEnergyUsageKey",
+          "deliveredEnergyType",
+          "energyAmountYearly"
+        ],
+        "type": "object",
+        "properties": {
+          "calculatoryDeliveredEnergyUsageKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deliveredEnergyType": {
+            "type": "string",
+            "description": "Ostoenergian laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ostoenergia\">http://uri.suomi.fi/codelist/rytj/ostoenergia</a>"
+          },
+          "energyAmountYearly": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Energiankulutus"
+      },
+      "CallForDeviation": {
+        "required": [
+          "callForDeviationKey",
+          "contentOfDeviation",
+          "deviationType"
+        ],
+        "type": "object",
+        "properties": {
+          "callForDeviationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deviationType": {
+            "type": "string",
+            "description": "Poikkeamisen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji\">http://uri.suomi.fi/codelist/rytj/PoikkeamisenLaji</a>"
+          },
+          "contentOfDeviation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+          }
+        },
+        "additionalProperties": false,
+        "description": "Määräyksestä poikkeaminen"
+      },
+      "ChangeInformationAdministrativeLocationUnit": {
+        "type": "object",
+        "properties": {
+          "administrativeLocationUnitKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "unitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "unseparatedParcelIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "property": {
+            "required": [
+              "municipalityNumber",
+              "propertyIdentifier",
+              "status",
+              "type",
+              "relationToBaseProperty"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Property"
+              }
+            ],
+            "description": "Kiinteistö",
+            "nullable": true
+          },
+          "parcel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UnseparatedParcel"
+              }
+            ],
+            "description": "Määräala",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationApartment": {
+        "type": "object",
+        "properties": {
+          "apartmentKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
+              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
+            ],
+            "type": "string",
+            "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "apartmentEquipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApartmentEquipment"
+            },
+            "nullable": true
+          },
+          "apartmentIdentifier": {
+            "type": "string"
+          },
+          "apartmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
+            ],
+            "type": "string",
+            "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
+          },
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "numberOfRooms": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "kitchenType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
+            ],
+            "type": "string",
+            "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
+            "nullable": true
+          },
+          "isWaterCloset": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "apartmentChangeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
+            ],
+            "type": "string",
+            "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "addressNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "apartmentStorey": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "housingType": {
+            "type": "string",
+            "nullable": true
+          },
+          "occupancyOfApartment": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationAreaToBeBuiltForSpecificActivities": {
+        "type": "object",
+        "properties": {
+          "areaToBeBuiltForSpecificActivitiesKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specificActivitiesAreaType": {
+            "type": "string",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
+            },
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuilding": {
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string",
+            "description": "Pysyvä rakennustunnus (PRT)"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Onko väliaikainen",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "description": "Demolition deadline",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "description": "Kerrosluku",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationBuildingSection"
+            },
+            "description": "Rakennuksen osat",
+            "nullable": true
+          },
+          "mainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string",
+            "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "mainPurpose1994": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfNewApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfDeletedApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
             }
           },
-          "additionalProperties": false,
-          "description": "PurkamislupaHakemus"
+          "objectState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          }
         },
-        "DemolitionPermitDecision": {
-          "required": [
-            "demolitionPermitDecisionKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationBuildingChangeDiffDto"
             },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingPermitIssue": {
+        "required": [
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "decision": {
+            "required": [
+              "buildingPermitDecisionKey",
+              "constructionToBeStartedBy",
+              "constructionToBeCompletedBy",
+              "engagingParty",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
             },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
             },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
+            "nullable": true
+          },
+          "buildingPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPermitApplication"
             },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "demolitionPermitDecisionKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitApplicationType": {
-              "type": "string",
-              "nullable": true
-            },
-            "constructionToBeStartedBy": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedBy": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeStartedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "constructionToBeCompletedByExtension": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
-              },
-              "nullable": true
+            "description": "Rakentamislupahakemus",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationConstructionAction"
             }
           },
-          "additionalProperties": false,
-          "description": "Rakentamislupapäätös"
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "dateOfInitiation": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          }
         },
-        "DemolitionPermitIssue": {
-          "required": [
-            "demolitionDecision",
-            "demolitionPermitApplication",
-            "lifeCycleState",
-            "municipalityNumber"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date",
-              "nullable": true
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeDiffDto"
             },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-              "nullable": true
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationBuildingSection": {
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "Materiaalitiedot",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "Energiatiedot",
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "Sisätilojen tiedot",
+            "nullable": true
+          },
+          "exteriorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "Ulkokuoren tiedot",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "Talotekniikkatiedot",
+            "nullable": true
+          },
+          "usageData": {
+            "required": [
+              "purpose"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsageData"
+              }
+            ],
+            "description": "Rakennuksen käyttötiedot"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
             },
-            "municipalityNumber": {
-              "type": "string"
+            "nullable": true
+          },
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
             },
-            "demolitionPermitApplication": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DemolitionPermitApplication"
-              },
-              "description": "Purkamislupahakemus",
-              "nullable": true
+            "nullable": true
+          },
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
             },
-            "demolitionDecision": {
-              "required": [
-                "demolitionPermitDecisionKey",
-                "lifeCycleState"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DemolitionPermitDecision"
-                }
-              ],
-              "description": "Purkamislupapäätös",
-              "nullable": true
+            "nullable": true
+          },
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
             },
-            "extensionDecision": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExtensionDecision"
-              },
-              "nullable": true
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationApartment"
             },
-            "changePermit": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ChangePermit"
-              },
-              "nullable": true
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
             },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka",
-              "nullable": true
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
             },
-            "constructionAction": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionAction"
-              },
-              "nullable": true
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
             },
-            "attachment": {
-              "type": "array",
-              "items": {
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationConstructionAction": {
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureMainPurpose",
+              "buildingObjectType",
+              "buildingObjectOwner"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "locatedOnUnseparatedParcel": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationStructure": {
+        "required": [
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "structureMainPurpose"
+        ],
+        "type": "object",
+        "properties": {
+          "structureKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentStructureIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
+          "structureMainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string",
+            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangePermit": {
+        "required": [
+          "changePermitKey",
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "constructionProject": {
-              "required": [
-                "constructionProjectKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ConstructionProject"
-                }
-              ],
-              "description": "Rakentamishanke",
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "permanentPermitIdentifier": {
-              "type": "string"
-            }
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Purkamislupa-asia"
-        },
-        "DemolitionPermitIssueChangeDiffDto": {
-          "type": "object",
-          "properties": {
-            "changeType": {
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "objectKey": {
-              "nullable": true
-            },
-            "objectType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentKey": {
-              "nullable": true
-            },
-            "parentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentChain": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ParentTypeKey"
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
-            },
-            "objectState": {
-              "required": [
-                "demolitionPermitApplication",
-                "demolitionDecision",
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DemolitionPermitIssue"
-                }
-              ],
-              "description": "Purkamislupa-asia",
-              "nullable": true
-            },
-            "objectStatePrev": {
-              "required": [
-                "demolitionPermitApplication",
-                "demolitionDecision",
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DemolitionPermitIssue"
-                }
-              ],
-              "description": "Purkamislupa-asia",
-              "nullable": true
-            }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false
+          "changePermitKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          }
         },
-        "DemolitionPermitIssueChangeInfoCollectionDto": {
-          "type": "object",
-          "properties": {
-            "lastSeen": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PaginationToken"
-                }
-              ],
-              "nullable": true
-            },
-            "upToDate": {
-              "type": "boolean"
-            },
-            "changes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoDto"
+        "additionalProperties": false,
+        "description": "Muutospäätös"
+      },
+      "CivilDefenceShelter": {
+        "required": [
+          "civilDefenceShelterCapacity",
+          "civilDefenceShelterClass",
+          "civilDefenceShelterKey",
+          "civilDefenceShelterShared"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
-            }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false
-        },
-        "DemolitionPermitIssueChangeInfoDto": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "eventTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "objectKey": { },
-            "objectState": {
-              "required": [
-                "demolitionPermitApplication",
-                "demolitionDecision",
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DemolitionPermitIssue"
-                }
-              ],
-              "description": "Purkamislupa-asia",
-              "nullable": true
-            },
-            "diff": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DemolitionPermitIssueChangeDiffDto"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Descriptor": {
-          "type": "object",
-          "properties": {
-            "descriptorIdentifier": {
-              "type": "string",
-              "nullable": true
-            },
-            "vocabulary": {
-              "type": "string",
-              "nullable": true
-            },
-            "descriptor": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "DeviationObject": {
-          "required": [
-            "address",
-            "buildingObjectOwner",
-            "deviationObjectKey"
-          ],
-          "type": "object",
-          "properties": {
-            "deviationObjectKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "totalArea": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot"
-            },
-            "administrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja"
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Poikkeamisen kohde"
-        },
-        "DeviationPermitApplication": {
-          "required": [
-            "applicationContent",
-            "constructionDesign",
-            "deviationPermitApplicationKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
-              "nullable": true
-            },
-            "applicationContent": {
-              "type": "string"
-            },
-            "dateOfReception": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "callForDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CallForDeviation"
-              },
-              "nullable": true
-            },
-            "deviationPermitApplicationKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
               }
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              }
-            }
+            ],
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Poikkeamislupahakemus"
-        },
-        "DeviationPermitDecision": {
-          "required": [
-            "decisionInForceUntil",
-            "deviationPermitDecisionKey",
-            "engagingParty",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
-            },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "deviationPermitDecisionKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "expiryDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "engagingParty": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/EngagingParty"
-              },
-              "description": ""
-            },
-            "decisionInForceUntil": {
-              "type": "string",
-              "description": "",
-              "format": "date"
-            }
+          "civilDefenceShelterKey": {
+            "type": "string",
+            "format": "uuid"
           },
-          "additionalProperties": false,
-          "description": "Poikkeamislupapäätös"
-        },
-        "DeviationPermitIssue": {
-          "required": [
-            "deviationPermitApplication",
-            "deviationPermitDecision",
-            "lifeCycleState",
-            "municipalityNumber",
-            "permanentPermitIdentifier"
-          ],
-          "type": "object",
-          "properties": {
-            "dateOfInitiation": {
-              "type": "string",
-              "description": "Vireilletulopäivä",
-              "format": "date",
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
-              "nullable": true
-            },
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "permanentPermitIdentifier": {
-              "type": "string"
-            },
-            "recordNumber": {
-              "type": "string"
-            },
-            "deviationPermitDecision": {
-              "required": [
-                "deviationPermitDecisionKey",
-                "engagingParty",
-                "decisionInForceUntil",
-                "lifeCycleState"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitDecision"
-                }
-              ],
-              "description": "Poikkeamislupapäätös"
-            },
-            "deviationPermitApplication": {
-              "required": [
-                "deviationPermitApplicationKey",
-                "constructionDesign",
-                "lifeCycleState",
-                "applicationContent"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitApplication"
-                }
-              ],
-              "description": "Poikkeamislupahakemus"
-            },
-            "deviationObject": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DeviationObject"
+          "civilDefenceShelterClass": {
+            "type": "string",
+            "description": "Väestönsuojan luokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka\">http://uri.suomi.fi/codelist/rytj/VaestonsuojaLuokka</a>",
+            "nullable": true
+          },
+          "civilDefenceShelterCapacity": {
+            "type": "integer",
+            "description": "Väestönsuojan suojapaikkojen määrä",
+            "format": "int32"
+          },
+          "civilDefenceShelterShared": {
+            "type": "boolean"
+          },
+          "civilDefenceShelterAdditionalInformation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelterOtherBuildings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelterOtherBuildings"
             },
-            "buildingSite": {
-              "required": [
-                "stormWaterTreatmentType",
-                "tenure"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingSite"
-                }
-              ],
-              "description": "Rakennuspaikka"
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Väestönsuoja"
+      },
+      "CivilDefenceShelterOtherBuildings": {
+        "required": [
+          "civilDefenceShelterOtherBuildingsKey",
+          "civilDefenceShelterPointedCapacity",
+          "permanentBuildingIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "civilDefenceShelterOtherBuildingsKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string"
+          },
+          "civilDefenceShelterPointedCapacity": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Väestönsuojan muut rakennukset"
+      },
+      "ConstructionAction": {
+        "required": [
+          "constructionActionKey",
+          "constructionActionType",
+          "statusOfConstructionAction"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "required": [
+              "buildingKey",
+              "permanentBuildingIdentifier",
+              "temporary",
+              "numberOfStoreys",
+              "buildingSection",
+              "mainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Building"
+              }
+            ],
+            "description": "Rakennuksen tiedot.",
+            "nullable": true
+          },
+          "finishedBuilding": {
+            "required": [
+              "buildingKey",
+              "permanentBuildingIdentifier",
+              "temporary",
+              "numberOfStoreys",
+              "buildingSection",
+              "mainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Building"
+              }
+            ],
+            "description": "Rakennuksen tiedot.",
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "finishedStructure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "required": [
+              "areaToBeBuiltForSpecificActivitiesKey",
+              "specificActivitiesAreaType",
+              "temporary",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "description": "Erityistä toimintaa varten rakennettava alue",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "finishedAreaToBeBuiltForSpecificActivities": {
+            "required": [
+              "areaToBeBuiltForSpecificActivitiesKey",
+              "specificActivitiesAreaType",
+              "temporary",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "description": "Erityistä toimintaa varten rakennettava alue",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamistoimenpide"
+      },
+      "ConstructionDesign": {
+        "required": [
+          "constructionDesignKey",
+          "constructionDesignType",
+          "document"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionDesignKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionDesignType": {
+            "type": "string",
+            "description": "Rakennusssuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/raksuunlajit\">http://uri.suomi.fi/codelist/rytj/raksuunlajit</a>"
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennussuunnitelma"
+      },
+      "ConstructionProject": {
+        "required": [
+          "constructionProjectKey"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionProjectKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "descriptionOfConstructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "planner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Planner"
             },
-            "attachment": {
-              "type": "array",
-              "items": {
+            "description": "",
+            "nullable": true
+          },
+          "foreman": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Foreman"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "inspection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Inspection"
+            },
+            "description": "",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamishanke"
+      },
+      "ContactAddress": {
+        "required": [
+          "addressKey",
+          "contactAddressType",
+          "postalCode",
+          "source"
+        ],
+        "type": "object",
+        "properties": {
+          "addressKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "addressName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "numberPartOfAddressNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postinumero. Käytetään koodiston code arvoa <a href=\"https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607\">https://uri.suomi.fi/codelist/statbr/postitoimipaik_1_20160607</a>",
+            "nullable": true
+          },
+          "location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "numberPartOfAddressNumber2": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subdivisionLetterOfAddressNumber2": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentIdentifierLetterSuffix": {
+            "type": "string",
+            "nullable": true
+          },
+          "apartmentIdentifierNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "apartmentIdentifierSubdivisionLetter": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalAddressAttribute": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "c_O": {
+            "type": "string",
+            "nullable": true
+          },
+          "poBoxAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "Maakoodi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/valtio_1_20120101\">http://uri.suomi.fi/codelist/jhs/valtio_1_20120101</a>",
+            "nullable": true
+          },
+          "foreignAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "foreignPostalAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "additionalForeignAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "postalAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "contactAddressType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji/code/08"
+            ],
+            "type": "string",
+            "description": "Yhteysosoitteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji\">http://uri.suomi.fi/codelist/rytj/yhteysosoitteenLaji</a>"
+          },
+          "source": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/01",
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/02",
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/03",
+              "http://uri.suomi.fi/codelist/rytj/tietolahde/code/04"
+            ],
+            "type": "string",
+            "description": "Tietolähde. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tietolahde\">http://uri.suomi.fi/codelist/rytj/tietolahde</a>"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Yhteysosoite"
+      },
+      "CoolingEnergySource": {
+        "required": [
+          "coolingEnergySourceKey",
+          "coolingEnergySourceType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "coolingEnergySourceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "coolingEnergySourceType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/01",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/02",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/03",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/04",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/05",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/06",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/07",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytys/code/08"
+            ],
+            "type": "string",
+            "description": "Jäähdytysenergian lähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytys\">http://uri.suomi.fi/codelist/rytj/jaahdytys</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Jäähdytysenergian lähde"
+      },
+      "CoolingMethod": {
+        "required": [
+          "coolingMethodKey",
+          "coolingMethodType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "coolingMethodKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "coolingMethodType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/01",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/02",
+              "http://uri.suomi.fi/codelist/rytj/jaahdytystapa/code/03"
+            ],
+            "type": "string",
+            "description": "Jäähdytystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/jaahdytystapa\">http://uri.suomi.fi/codelist/rytj/jaahdytystapa</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Jäähdytystapa"
+      },
+      "DemolitionPermitApplication": {
+        "required": [
+          "applicationContent",
+          "dateOfReception",
+          "demolitionPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "demolitionPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "PurkamislupaHakemus"
+      },
+      "DemolitionPermitDecision": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "demolitionPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "nullable": true
-            },
-            "updateType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-              ],
-              "type": "string",
-              "nullable": true
-            },
-            "updateDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Poikkeamislupa-asia"
-        },
-        "DeviationPermitIssueChangeDiffDto": {
-          "type": "object",
-          "properties": {
-            "changeType": {
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "objectKey": {
-              "nullable": true
-            },
-            "objectType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentKey": {
-              "nullable": true
-            },
-            "parentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentChain": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ParentTypeKey"
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
               }
-            },
-            "objectState": {
-              "required": [
-                "permanentPermitIdentifier",
-                "deviationPermitDecision",
-                "deviationPermitApplication",
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitIssue"
-                }
-              ],
-              "description": "Poikkeamislupa-asia",
-              "nullable": true
-            },
-            "objectStatePrev": {
-              "required": [
-                "permanentPermitIdentifier",
-                "deviationPermitDecision",
-                "deviationPermitApplication",
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitIssue"
-                }
-              ],
-              "description": "Poikkeamislupa-asia",
-              "nullable": true
-            }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false
+          "demolitionPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "type": "string",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "nullable": true
+          }
         },
-        "DeviationPermitIssueChangeInfoCollectionDto": {
-          "type": "object",
-          "properties": {
-            "lastSeen": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PaginationToken"
-                }
-              ],
-              "nullable": true
+        "additionalProperties": false,
+        "description": "Rakentamislupapäätös"
+      },
+      "DemolitionPermitIssue": {
+        "required": [
+          "dateOfInitiation",
+          "demolitionDecision",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
             },
-            "upToDate": {
-              "type": "boolean"
-            },
-            "changes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoDto"
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecision"
               }
+            ],
+            "description": "Purkamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionAction"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Purkamislupa-asia"
+      },
+      "DemolitionPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
             }
           },
-          "additionalProperties": false
+          "objectState": {
+            "required": [
+              "demolitionPermitApplication",
+              "demolitionDecision",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitIssue"
+              }
+            ],
+            "description": "Purkamislupa-asia",
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "demolitionPermitApplication",
+              "demolitionDecision",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitIssue"
+              }
+            ],
+            "description": "Purkamislupa-asia",
+            "nullable": true
+          }
         },
-        "DeviationPermitIssueChangeInfoDto": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid"
+        "additionalProperties": false
+      },
+      "DemolitionPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "DemolitionPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "demolitionPermitApplication",
+              "demolitionDecision",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitIssue"
+              }
+            ],
+            "description": "Purkamislupa-asia",
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitIssueChangeDiffDto"
             },
-            "eventTime": {
-              "type": "string",
-              "format": "date-time"
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Descriptor": {
+        "type": "object",
+        "properties": {
+          "descriptorIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "vocabulary": {
+            "type": "string",
+            "nullable": true
+          },
+          "descriptor": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeviationObject": {
+        "required": [
+          "address",
+          "administrativeLocationUnit",
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "deviationObjectKey"
+        ],
+        "type": "object",
+        "properties": {
+          "deviationObjectKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "totalArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot"
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö"
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
             },
-            "objectKey": { },
-            "objectState": {
-              "required": [
-                "permanentPermitIdentifier",
-                "deviationPermitDecision",
-                "deviationPermitApplication",
-                "lifeCycleState",
-                "municipalityNumber"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/DeviationPermitIssue"
-                }
-              ],
-              "description": "Poikkeamislupa-asia",
-              "nullable": true
-            },
-            "diff": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/DeviationPermitIssueChangeDiffDto"
-              },
-              "nullable": true
+            "description": "Rakennuskohteen omistaja"
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
             }
           },
-          "additionalProperties": false
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
         },
-        "ElectricalEnergySource": {
-          "required": [
-            "electricalEnergySourceKey",
-            "electricalEnergySourceType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "electricalEnergySourceKey": {
-              "type": "string",
-              "format": "uuid"
+        "additionalProperties": false,
+        "description": "Poikkeamisen kohde"
+      },
+      "DeviationPermitApplication": {
+        "required": [
+          "applicationContent",
+          "constructionDesign",
+          "dateOfReception",
+          "deviationPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
             },
-            "electricalEnergySourceType": {
-              "type": "string",
-              "description": "Sähköenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde\">http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
+            "nullable": true
+          },
+          "deviationPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
             }
           },
-          "additionalProperties": false,
-          "description": "Sähköenergian lähde"
-        },
-        "Elevator": {
-          "required": [
-            "elevatorKey",
-            "elevatorType",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "elevatorKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "elevatorType": {
-              "type": "string",
-              "description": "Hissin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hissi\">http://uri.suomi.fi/codelist/rytj/hissi</a>"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
-              ],
-              "type": "string",
-              "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "insideLength": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "insideWidth": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "doorOpeningWidth": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "doorOpeningHeight": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "passengerCapacity": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "loadCapacity": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
             }
-          },
-          "additionalProperties": false,
-          "description": "Hissi"
+          }
         },
-        "EnergyData": {
-          "required": [
-            "energyDataKey"
-          ],
-          "type": "object",
-          "properties": {
-            "energyDataKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
+        "additionalProperties": false,
+        "description": "Poikkeamislupahakemus"
+      },
+      "DeviationPermitDecision": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "deviationPermitDecisionKey",
+          "engagingParty",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
             },
-            "energyRating": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/08"
-              ],
-              "type": "string",
-              "description": "Energialuokka. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Energialuokka",
-              "nullable": true
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
             },
-            "computationalEnergyEfficiencyComparand": {
-              "type": "number",
-              "description": "",
-              "format": "double",
-              "nullable": true
-            },
-            "heatingMethod": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/HeatingMethod"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "heatingEnergySource": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/HeatingEnergySource"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "coolingMethod": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CoolingMethod"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "coolingEnergySource": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/CoolingEnergySource"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "electricalEnergySource": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ElectricalEnergySource"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "netHeatedArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "heatedVolume": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "calculatoryDeliveredEnergyUsage": {
-              "required": [
-                "calculatoryDeliveredEnergyUsageKey",
-                "deliveredEnergyType",
-                "energyAmountYearly"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/CalculatoryDeliveredEnergyUsage"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "energyRatingSubindex": {
-              "type": "string",
-              "description": "Energiatehokkuusluokan alaindeksi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi",
-              "nullable": true
-            }
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Energiatiedot"
-        },
-        "EngagingParty": {
-          "required": [
-            "engagingPartyKey",
-            "isPerson"
-          ],
-          "type": "object",
-          "properties": {
-            "engagingPartyKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "personalIdentityCode": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "businessId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "isPerson": {
-              "type": "boolean",
-              "description": ""
-            },
-            "firstName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "familyName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "organizationName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "applicantContactOperator": {
-              "required": [
-                "isPerson"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "languageCode": {
-              "type": "string",
-              "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
-              "nullable": true
-            },
-            "nationalityCode": {
-              "type": "string",
-              "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
-              "nullable": true
-            },
-            "deathDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            }
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Hankkeeseen ryhtyvä"
-        },
-        "Entrance": {
-          "required": [
-            "entranceKey",
-            "entranceType",
-            "isPrimary",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "entranceKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            },
-            "entranceType": {
-              "type": "string",
-              "description": "Sisäänkäynnin tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sisaankaynti\">http://uri.suomi.fi/codelist/rytj/sisaankaynti</a>"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
-                "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
-              ],
-              "type": "string",
-              "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
-              "nullable": true
-            },
-            "addressOfEntrance": {
-              "type": "string",
-              "nullable": true
-            },
-            "isAccessible": {
-              "type": "boolean",
-              "description": "Kerrosluku"
-            }
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
           },
-          "additionalProperties": false,
-          "description": "Sisäänkäynti"
-        },
-        "Equipment": {
-          "required": [
-            "equipmentKey",
-            "equipmentType"
-          ],
-          "type": "object",
-          "properties": {
-            "equipmentKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "equipmentType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/01",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/02",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/03",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/04",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/05",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/06",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/07",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/08",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/09",
-                "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/10"
-              ],
-              "type": "string",
-              "description": "Rakennuksen varuste. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rakennusvaruste"
-            },
-            "equipmentCount": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            }
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Varuste"
-        },
-        "ExtensionDecision": {
-          "required": [
-            "extensionDecisionKey",
-            "lifeCycleState"
-          ],
-          "type": "object",
-          "properties": {
-            "acceptedDeviation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/AcceptedDeviation"
-              },
-              "nullable": true
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
             },
-            "permitRegulation": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PermitRegulation"
-              },
-              "nullable": true
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
-                "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
-              ],
-              "type": "string",
-              "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
-            },
-            "decisionDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "dateOfValidityOfDecision": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "decisionDocument": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingAttachmentDocument"
-                }
-              ],
-              "description": "Liiteasiakirja",
-              "nullable": true
-            },
-            "decisionArticle": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "publicNoticeDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "decisionText": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "guidingStatute": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/GuidingStatute"
-              },
-              "nullable": true
-            },
-            "relatedPermit": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "nullable": true
-            },
-            "decisionMakerType": {
-              "type": "string",
-              "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
-              "nullable": true
-            },
-            "decisionMakerFirstName": {
-              "type": "string",
-              "nullable": true
-            },
-            "decisionMakerName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "extensionDecisionKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Jatkoaikapäätös"
-        },
-        "ExteriorData": {
-          "required": [
-            "shape"
-          ],
-          "type": "object",
-          "properties": {
-            "numberOfStoreys": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "height": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "flightObstacle": {
-              "type": "boolean",
-              "description": "",
-              "nullable": true
-            },
-            "shape": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "description": ""
-            },
-            "relationToGroundLevel": {
-              "type": "string",
-              "description": "Suhde maan pintaan. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Suhde_pintaan",
-              "nullable": true
-            },
-            "volume": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "grossFloorArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "permittedBuildingArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            },
-            "totalArea": {
-              "type": "integer",
-              "description": "",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Ulkokuoren tiedot"
-        },
-        "FacadeMaterial": {
-          "required": [
-            "facadeMaterialKey",
-            "facadeMaterialType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "facadeMaterialKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "facadeMaterialType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/00",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/01",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/02",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/03",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/04",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/05",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/06",
-                "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/99"
-              ],
-              "type": "string",
-              "description": "Julkisivun rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine\">http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Julkisivumateriaali"
-        },
-        "Foreman": {
-          "required": [
-            "familyName",
-            "firstName",
-            "foremanKey"
-          ],
-          "type": "object",
-          "properties": {
-            "foremanKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "foremanRole": {
-              "type": "string",
-              "description": "Työnjohtajan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli\">http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli</a>"
-            },
-            "foremanCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "responsibilityStartDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "responsibilityEndDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ForemanBuildingReference"
-              },
-              "nullable": true
-            },
-            "structureReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ForemanStructureReference"
-              },
-              "nullable": true
-            },
-            "specificAreaReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            },
-            "requiredCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "personalIdentityCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "nullable": true
-            },
-            "firstName": {
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
             },
-            "familyName": {
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "deviationPermitDecisionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "expiryDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "description": ""
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "description": "",
+            "format": "date"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupapäätös"
+      },
+      "DeviationPermitIssue": {
+        "required": [
+          "buildingSite",
+          "dateOfInitiation",
+          "deviationObject",
+          "deviationPermitApplication",
+          "deviationPermitDecision",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "recordNumber": {
+            "type": "string"
+          },
+          "deviationPermitDecision": {
+            "required": [
+              "deviationPermitDecisionKey",
+              "engagingParty",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitDecision"
+              }
+            ],
+            "description": "Poikkeamislupapäätös"
+          },
+          "deviationPermitApplication": {
+            "required": [
+              "deviationPermitApplicationKey",
+              "constructionDesign",
+              "lifeCycleState",
+              "applicationContent",
+              "dateOfReception"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitApplication"
+              }
+            ],
+            "description": "Poikkeamislupahakemus"
+          },
+          "deviationObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationObject"
+            }
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupa-asia"
+      },
+      "DeviationPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "deviationPermitDecision",
+              "deviationPermitApplication",
+              "deviationObject",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitIssue"
+              }
+            ],
+            "description": "Poikkeamislupa-asia",
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "permanentPermitIdentifier",
+              "deviationPermitDecision",
+              "deviationPermitApplication",
+              "deviationObject",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitIssue"
+              }
+            ],
+            "description": "Poikkeamislupa-asia",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeviationPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "DeviationPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "deviationPermitDecision",
+              "deviationPermitApplication",
+              "deviationObject",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitIssue"
+              }
+            ],
+            "description": "Poikkeamislupa-asia",
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationPermitIssueChangeDiffDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ElectricalEnergySource": {
+        "required": [
+          "electricalEnergySourceKey",
+          "electricalEnergySourceType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "electricalEnergySourceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "electricalEnergySourceType": {
+            "type": "string",
+            "description": "Sähköenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde\">http://uri.suomi.fi/codelist/rytj/sahkoenergianlahde</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Sähköenergian lähde"
+      },
+      "Elevator": {
+        "required": [
+          "elevatorKey",
+          "elevatorType",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "elevatorKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "elevatorType": {
+            "type": "string",
+            "description": "Hissin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/hissi\">http://uri.suomi.fi/codelist/rytj/hissi</a>"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
+            ],
+            "type": "string",
+            "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "insideLength": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "insideWidth": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "doorOpeningWidth": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "doorOpeningHeight": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "passengerCapacity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "loadCapacity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hissi"
+      },
+      "EnergyData": {
+        "required": [
+          "energyDataKey"
+        ],
+        "type": "object",
+        "properties": {
+          "energyDataKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "energyRating": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Energialuokka/code/08"
+            ],
+            "type": "string",
+            "description": "Energialuokka. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Energialuokka",
+            "nullable": true
+          },
+          "computationalEnergyEfficiencyComparand": {
+            "type": "number",
+            "description": "",
+            "format": "double",
+            "nullable": true
+          },
+          "heatingMethod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HeatingMethod"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "heatingEnergySource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HeatingEnergySource"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "coolingMethod": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoolingMethod"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "coolingEnergySource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CoolingEnergySource"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "electricalEnergySource": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElectricalEnergySource"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "netHeatedArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "heatedVolume": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "calculatoryDeliveredEnergyUsage": {
+            "required": [
+              "calculatoryDeliveredEnergyUsageKey",
+              "deliveredEnergyType",
+              "energyAmountYearly"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CalculatoryDeliveredEnergyUsage"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "energyRatingSubindex": {
+            "type": "string",
+            "description": "Energiatehokkuusluokan alaindeksi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/energialuokkaAlaindeksi",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Energiatiedot"
+      },
+      "EngagingParty": {
+        "required": [
+          "engagingPartyKey",
+          "isPerson"
+        ],
+        "type": "object",
+        "properties": {
+          "engagingPartyKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "personalIdentityCode": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "businessId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "isPerson": {
+            "type": "boolean",
+            "description": ""
+          },
+          "firstName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "familyName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "organizationName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "applicantContactOperator": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
+            "nullable": true
+          },
+          "nationalityCode": {
+            "type": "string",
+            "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
+            "nullable": true
+          },
+          "deathDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Hankkeeseen ryhtyvä"
+      },
+      "Entrance": {
+        "required": [
+          "entranceKey",
+          "entranceType",
+          "isAccessible",
+          "isPrimary",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "entranceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "entranceType": {
+            "type": "string",
+            "description": "Sisäänkäynnin tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/sisaankaynti\">http://uri.suomi.fi/codelist/rytj/sisaankaynti</a>"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/5",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/6",
+              "http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe/code/7"
+            ],
+            "type": "string",
+            "description": "Rakennuksen toiminnallisen osan elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/rakennuksen-toim-osan-elinkaaren-vaihe</a>",
+            "nullable": true
+          },
+          "addressOfEntrance": {
+            "type": "string",
+            "nullable": true
+          },
+          "isAccessible": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Sisäänkäynti"
+      },
+      "Equipment": {
+        "required": [
+          "equipmentKey",
+          "equipmentType"
+        ],
+        "type": "object",
+        "properties": {
+          "equipmentKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "equipmentType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/01",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/02",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/03",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/04",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/05",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/06",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/07",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/08",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/09",
+              "http://uri.suomi.fi/codelist/rytj/RakennusVaruste/code/10"
+            ],
+            "type": "string",
+            "description": "Rakennuksen varuste. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rakennusvaruste"
+          },
+          "equipmentCount": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Varuste"
+      },
+      "ExtensionDecision": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "extensionDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
               "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Työnjohtaja"
-        },
-        "ForemanBuildingReference": {
-          "required": [
-            "permanentBuildingIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifierReference": {
-              "type": "string"
             },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennusviite"
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "extensionDecisionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          }
         },
-        "ForemanStructureReference": {
-          "required": [
-            "permanentStructureIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifierReference": {
-              "type": "string"
+        "additionalProperties": false,
+        "description": "Jatkoaikapäätös"
+      },
+      "ExteriorData": {
+        "type": "object",
+        "properties": {
+          "numberOfStoreys": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "height": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "flightObstacle": {
+            "type": "boolean",
+            "description": "",
+            "nullable": true
+          },
+          "shape": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "description": ""
+          },
+          "relationToGroundLevel": {
+            "type": "string",
+            "description": "Suhde maan pintaan. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/Suhde_pintaan",
+            "nullable": true
+          },
+          "volume": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "grossFloorArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "permittedBuildingArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          },
+          "totalArea": {
+            "type": "integer",
+            "description": "",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Ulkokuoren tiedot"
+      },
+      "FacadeMaterial": {
+        "required": [
+          "facadeMaterialKey",
+          "facadeMaterialType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "facadeMaterialKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "facadeMaterialType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/00",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/01",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/02",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/03",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/04",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/05",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/06",
+              "http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine/code/99"
+            ],
+            "type": "string",
+            "description": "Julkisivun rakennusaine. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine\">http://uri.suomi.fi/codelist/rytj/julkisivunrakennusaine</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Julkisivumateriaali"
+      },
+      "Foreman": {
+        "required": [
+          "familyName",
+          "firstName",
+          "foremanCompetence",
+          "foremanKey",
+          "foremanRole",
+          "requiredCompetence",
+          "responsibilityStartDate"
+        ],
+        "type": "object",
+        "properties": {
+          "foremanKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "foremanRole": {
+            "type": "string",
+            "description": "Työnjohtajan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli\">http://uri.suomi.fi/codelist/rytj/tyonjohtajanrooli</a>"
+          },
+          "foremanCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "responsibilityStartDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "responsibilityEndDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ForemanBuildingReference"
             },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "Rakennelmaviite"
-        },
-        "GeoJsonGeometry": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ForemanStructureReference"
+            },
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
               "type": "string",
-              "description": "Tuetut geometriatyypit"
-            }
-          },
-          "additionalProperties": false,
-          "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
-        },
-        "GeoJsonLineStringGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+              "format": "uuid"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
-            }
+            "nullable": true
           },
-          "additionalProperties": false,
-          "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+          "requiredCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "personalIdentityCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "familyName": {
+            "type": "string"
+          }
         },
-        "GeoJsonMultiLineStringGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "number",
-                    "format": "double"
-                  }
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
+        "additionalProperties": false,
+        "description": "Työnjohtaja"
+      },
+      "ForemanBuildingReference": {
+        "required": [
+          "permanentBuildingIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
-            }
-          },
-          "additionalProperties": false,
-          "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+            "nullable": true
+          }
         },
-        "GeoJsonMultiPointGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "number",
-                  "format": "double"
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+        "additionalProperties": false,
+        "description": "Rakennusviite"
+      },
+      "ForemanStructureReference": {
+        "required": [
+          "permanentStructureIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
-            }
-          },
-          "additionalProperties": false,
-          "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+            "nullable": true
+          }
         },
-        "GeoJsonMultiPolygonGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "type": "number",
-                      "format": "double"
-                    }
-                  }
-                }
-              },
-              "description": "Koordinaatit",
-              "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
-            },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
-            }
-          },
-          "additionalProperties": false,
-          "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+        "additionalProperties": false,
+        "description": "Rakennelmaviite"
+      },
+      "GeoJsonGeometry": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Tuetut geometriatyypit"
+          }
         },
-        "GeoJsonPointGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
+        "additionalProperties": false,
+        "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
+      },
+      "GeoJsonLineStringGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
               "type": "array",
               "items": {
                 "type": "number",
                 "format": "double"
-              },
-              "description": "Koordinaatit",
-              "example": "[100.0, 0.0]"
+              }
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
-            }
+            "description": "Koordinaatit",
+            "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
           },
-          "additionalProperties": false,
-          "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+          }
         },
-        "GeoJsonPolygonGeometry": {
-          "required": [
-            "coordinates",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/GeoJsonGeometry"
-            }
-          ],
-          "properties": {
-            "coordinates": {
+        "additionalProperties": false,
+        "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+      },
+      "GeoJsonMultiLineStringGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            },
+            "description": "Koordinaatit",
+            "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
+          },
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+          }
+        },
+        "additionalProperties": false,
+        "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+      },
+      "GeoJsonMultiPointGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "description": "Koordinaatit",
+            "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
+          },
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
+          }
+        },
+        "additionalProperties": false,
+        "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+      },
+      "GeoJsonMultiPolygonGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
               "type": "array",
               "items": {
                 "type": "array",
@@ -7494,2048 +7653,2158 @@
                     "format": "double"
                   }
                 }
-              },
-              "description": "Koordinaatit",
-              "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+              }
             },
-            "type": {
-              "enum": [
-                "Point",
-                "MultiPoint",
-                "LineString",
-                "MultiLineString",
-                "Polygon",
-                "MultiPolygon"
-              ],
-              "type": "string",
-              "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
-            }
+            "description": "Koordinaatit",
+            "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
           },
-          "additionalProperties": false,
-          "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
+          }
         },
-        "GetChangeInfo": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
+        "additionalProperties": false,
+        "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+      },
+      "GeoJsonPointGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
             },
-            "objectKey": {
-              "type": "string",
-              "nullable": true
-            }
+            "description": "Koordinaatit",
+            "example": "[100.0, 0.0]"
           },
-          "additionalProperties": false
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
+          }
         },
-        "GetInitialInfo": {
-          "type": "object",
-          "properties": {
-            "lastObjectKey": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "GuidingStatute": {
-          "required": [
-            "guidingStatuteKey"
-          ],
-          "type": "object",
-          "properties": {
-            "guidingStatuteKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "statuteName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "statuteCollectionNumber": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "statuteCollectionYear": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "chapter": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "section": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subSection": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "paragraph": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "subParagraph": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Säädösviite"
-        },
-        "HealthReport": {
-          "type": "object",
-          "properties": {
-            "status": {
-              "enum": [
-                "Unhealthy",
-                "Degraded",
-                "Healthy"
-              ],
-              "type": "string",
-              "readOnly": true
-            },
-            "totalDuration": {
-              "type": "string",
-              "format": "date-span",
-              "readOnly": true
-            },
-            "entries": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/HealthReportEntry"
-              },
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "HealthReportEntry": {
-          "type": "object",
-          "properties": {
-            "duration": {
-              "type": "string",
-              "format": "date-span",
-              "readOnly": true
-            },
-            "status": {
-              "enum": [
-                "Unhealthy",
-                "Degraded",
-                "Healthy"
-              ],
-              "type": "string",
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "HeatingEnergySource": {
-          "required": [
-            "heatingEnergySourceKey",
-            "heatingEnergySourceType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "heatingEnergySourceKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "heatingEnergySourceType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/01",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/02",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/03",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/04",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/05",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/06",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/07",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/08",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/09",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/10",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/11",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1101",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1102",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1103",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1104",
-                "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/99"
-              ],
-              "type": "string",
-              "description": "Lämmitysenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde\">http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde</a>",
-              "nullable": true
-            },
-            "isPrimary": {
-              "type": "boolean",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lämmitysenergianlähde"
-        },
-        "HeatingMethod": {
-          "required": [
-            "heatingMethodKey",
-            "heatingMethodType",
-            "isPrimary"
-          ],
-          "type": "object",
-          "properties": {
-            "heatingMethodKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "heatingMethodType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/01",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/02",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/03",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/04",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/05",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/06",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/07",
-                "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/99"
-              ],
-              "type": "string",
-              "description": "Lämmitystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitystapa\">http://uri.suomi.fi/codelist/rytj/lammitystapa</a>",
-              "nullable": true
-            },
-            "isPrimary": {
-              "type": "boolean",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lämmitystapa"
-        },
-        "InitialInformationCollection": {
-          "type": "object",
-          "properties": {
-            "next": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/InitialInformationNextInfo"
-                }
-              ],
-              "nullable": true
-            },
-            "eventId": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
+        "additionalProperties": false,
+        "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+      },
+      "GeoJsonPolygonGeometry": {
+        "required": [
+          "coordinates",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GeoJsonGeometry"
+          }
+        ],
+        "properties": {
+          "coordinates": {
+            "type": "array",
             "items": {
               "type": "array",
-              "items": { }
-            }
-          },
-          "additionalProperties": false
-        },
-        "InitialInformationNextInfo": {
-          "type": "object",
-          "properties": {
-            "lastObjectKey": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Inspection": {
-          "required": [
-            "inspectionCarriedOutByFirstName",
-            "inspectionCarriedOutByLastName",
-            "inspectionDate",
-            "inspectionKey",
-            "inspectionType",
-            "personsPresent",
-            "requiredByPermitRegulations"
-          ],
-          "type": "object",
-          "properties": {
-            "inspectionKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "inspectionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
-                "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
-              ],
-              "type": "string",
-              "description": ""
-            },
-            "inspectionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date"
-            },
-            "requiredByPermitRegulations": {
-              "type": "boolean",
-              "description": ""
-            },
-            "partiality": {
-              "type": "string",
-              "description": ""
-            },
-            "inspectionStatus": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
-                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
-                "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
-              ],
-              "type": "string",
-              "description": ""
-            },
-            "buildingReference": {
-              "type": "array",
               "items": {
-                "$ref": "#/components/schemas/InspectionBuildingReference"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "structureReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/InspectionStructureReference"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specificAreaReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "buildingObjectChange": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectChange"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specificationOfObjectOfInspection": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "inspectionRemarks": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "inspectionCarriedOutByFirstName": {
-              "type": "string",
-              "description": ""
-            },
-            "inspectionCarriedOutByLastName": {
-              "type": "string",
-              "description": ""
-            },
-            "personsPresent": {
-              "type": "string",
-              "description": ""
-            },
-            "buildingsAttachmentDocument": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Katselmus"
-        },
-        "InspectionBuildingReference": {
-          "required": [
-            "permanentBuildingIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifierReference": {
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "InspectionStructureReference": {
-          "required": [
-            "permanentStructureIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifierReference": {
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "InteriorData": {
-          "type": "object",
-          "properties": {
-            "floorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "basementArea": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Sisätilojen tiedot"
-        },
-        "LanguageString": {
-          "type": "object",
-          "properties": {
-            "fin": {
-              "type": "string",
-              "description": "suomi",
-              "nullable": true
-            },
-            "swe": {
-              "type": "string",
-              "description": "ruotsi",
-              "nullable": true
-            },
-            "smn": {
-              "type": "string",
-              "description": "inarinsaame",
-              "nullable": true
-            },
-            "sms": {
-              "type": "string",
-              "description": "koltansaame",
-              "nullable": true
-            },
-            "sme": {
-              "type": "string",
-              "description": "pohjoissaame",
-              "nullable": true
-            },
-            "eng": {
-              "type": "string",
-              "description": "englanti",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-        },
-        "MaterialData": {
-          "required": [
-            "buildingMaterialOfLoadBearingStructures",
-            "constructionMethod",
-            "facadeMaterial",
-            "wideBodiedBuilding"
-          ],
-          "type": "object",
-          "properties": {
-            "constructionMethod": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/01",
-                "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/02"
-              ],
-              "type": "string",
-              "description": "Rakentamistapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_runkotapa\">http://uri.suomi.fi/codelist/vtj/Rake_runkotapa</a>",
-              "nullable": true
-            },
-            "buildingMaterialOfLoadBearingStructures": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingMaterialOfLoadBearingStructures"
-              },
-              "description": "Kantavien rakenteiden rakennusaine"
-            },
-            "facadeMaterial": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/FacadeMaterial"
-              }
-            },
-            "fireClass": {
-              "type": "string",
-              "description": "Paloluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Paloluokka\">http://uri.suomi.fi/codelist/rytj/Paloluokka</a>",
-              "nullable": true
-            },
-            "wideBodiedBuilding": {
-              "type": "boolean"
-            },
-            "reusableMaterialAmount": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Materiaalitiedot"
-        },
-        "NetworkConnection": {
-          "required": [
-            "networkConnectionKey",
-            "networkConnectionType"
-          ],
-          "type": "object",
-          "properties": {
-            "networkConnectionKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "networkConnectionType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/01",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/02",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/03",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/04",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/05",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/06",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/07",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/08",
-                "http://uri.suomi.fi/codelist/rytj/verkliit/code/09"
-              ],
-              "type": "string",
-              "description": "Verkostoliittymän laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/verkliit\">http://uri.suomi.fi/codelist/rytj/verkliit</a>",
-              "nullable": true
-            },
-            "connected": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "connectionPoint": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Verkostoliittymä"
-        },
-        "Operator": {
-          "required": [
-            "isPerson"
-          ],
-          "type": "object",
-          "properties": {
-            "personalIdentityCode": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "businessId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "isPerson": {
-              "type": "boolean",
-              "description": ""
-            },
-            "firstName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "familyName": {
-              "type": "string",
-              "description": "",
-              "nullable": true
-            },
-            "organizationName": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "operatorAddress": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ContactAddress"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "languageCode": {
-              "type": "string",
-              "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
-              "nullable": true
-            },
-            "nationalityCode": {
-              "type": "string",
-              "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
-              "nullable": true
-            },
-            "deathDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Toimija"
-        },
-        "OperatorChangeDiffDto": {
-          "type": "object",
-          "properties": {
-            "changeType": {
-              "type": "string"
-            },
-            "objectKey": {
-              "nullable": true
-            },
-            "objectType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentKey": {
-              "nullable": true
-            },
-            "parentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentChain": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ParentTypeKey"
-              }
-            },
-            "objectState": {
-              "required": [
-                "isPerson"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "Toimija",
-              "nullable": true
-            },
-            "objectStatePrev": {
-              "required": [
-                "isPerson"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "Toimija",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "OperatorChangeInfoCollectionDto": {
-          "type": "object",
-          "properties": {
-            "lastSeen": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PaginationToken"
-                }
-              ],
-              "nullable": true
-            },
-            "upToDate": {
-              "type": "boolean"
-            },
-            "changes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OperatorChangeInfoDto"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        "OperatorChangeInfoDto": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "eventTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "objectKey": { },
-            "objectState": {
-              "required": [
-                "isPerson"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Operator"
-                }
-              ],
-              "description": "Toimija",
-              "nullable": true
-            },
-            "diff": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/OperatorChangeDiffDto"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "PaginationToken": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid",
-              "nullable": true
-            },
-            "objectKey": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ParentTypeKey": {
-          "type": "object",
-          "properties": {
-            "parentType": {
-              "type": "string"
-            },
-            "parentKey": { }
-          },
-          "additionalProperties": false
-        },
-        "PermitRegulation": {
-          "required": [
-            "permitRegulationKey",
-            "permitRegulationType"
-          ],
-          "type": "object",
-          "properties": {
-            "permitRegulationKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permitRegulationType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M01",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0101",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0102",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0103",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0104",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0105",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0106",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0107",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0108",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0109",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0110",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M02",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0201",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0202",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M03",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0301",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0302",
-                "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M04"
-              ],
-              "type": "string",
-              "description": "Lupamääräys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen\">http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen</a>"
-            },
-            "textOfPermitRegulation": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Lupamääräys"
-        },
-        "Planner": {
-          "required": [
-            "familyName",
-            "firstName",
-            "plannerKey"
-          ],
-          "type": "object",
-          "properties": {
-            "plannerKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "plannerRole": {
-              "type": "string",
-              "description": "Suunnittelijan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli\">http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli</a>"
-            },
-            "plannerCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "responsibilityStartDate": {
-              "type": "string",
-              "format": "date"
-            },
-            "responsibilityEndDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "buildingReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PlannerBuildingReference"
-              },
-              "nullable": true
-            },
-            "structureReference": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/PlannerStructureReference"
-              },
-              "nullable": true
-            },
-            "specificAreaReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            },
-            "requiredCompetence": {
-              "type": "string",
-              "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
-            },
-            "personalIdentityCode": {
-              "type": "string",
-              "nullable": true
-            },
-            "otherId": {
-              "type": "string",
-              "nullable": true
-            },
-            "firstName": {
-              "type": "string"
-            },
-            "familyName": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Suunnittelija"
-        },
-        "PlannerBuildingReference": {
-          "required": [
-            "permanentBuildingIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentBuildingIdentifierReference": {
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "PlannerStructureReference": {
-          "required": [
-            "permanentStructureIdentifierReference"
-          ],
-          "type": "object",
-          "properties": {
-            "permanentStructureIdentifierReference": {
-              "type": "string"
-            },
-            "buildingSectionReference": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "uuid"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "ProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "additionalProperties": { }
-        },
-        "Property": {
-          "required": [
-            "municipalityNumber",
-            "propertyIdentifier",
-            "relationToBaseProperty",
-            "status",
-            "type"
-          ],
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "propertyIdentifier": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "string"
-            },
-            "registrationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "endDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "landArea": {
-              "type": "integer",
-              "format": "int64"
-            },
-            "geometry": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/RyhtiGeometry"
-                }
-              ],
-              "nullable": true
-            },
-            "type": {
-              "type": "string"
-            },
-            "relationToBaseProperty": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Kiinteistö"
-        },
-        "Purpose": {
-          "required": [
-            "isPrimary",
-            "purposeKey",
-            "type"
-          ],
-          "type": "object",
-          "properties": {
-            "purposeKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "type": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-                "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-              ],
-              "type": "string",
-              "description": "Käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
-            },
-            "isPrimary": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Käyttötarkoitus"
-        },
-        "RyhtiGeometry": {
-          "required": [
-            "geometry",
-            "srid"
-          ],
-          "type": "object",
-          "properties": {
-            "srid": {
-              "enum": [
-                "3067",
-                "3873",
-                "3874",
-                "3875",
-                "3876",
-                "3877",
-                "3878",
-                "3879",
-                "3880",
-                "3881",
-                "3882",
-                "3883",
-                "3884",
-                "3885"
-              ],
-              "type": "string",
-              "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
-            },
-            "geometry": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/GeoJsonPointGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonMultiPointGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonLineStringGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonMultiLineStringGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonPolygonGeometry"
-                },
-                {
-                  "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
-                }
-              ],
-              "description": "Geometria GeoJson rakenteella: https://geojson.org/"
-            }
-          },
-          "additionalProperties": false
-        },
-        "SpecialDesign": {
-          "required": [
-            "specialDesignKey",
-            "specialDesignType"
-          ],
-          "type": "object",
-          "properties": {
-            "specialDesignKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "specialDesignType": {
-              "type": "string",
-              "description": "Erityissuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/erityissuun\">http://uri.suomi.fi/codelist/rytj/erityissuun</a>"
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "document": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            }
-          },
-          "additionalProperties": false,
-          "description": "Erityissuunnitelma"
-        },
-        "Structure": {
-          "required": [
-            "administrativeLocationUnit",
-            "buildingObjectOwner",
-            "buildingObjectType",
-            "permanentStructureIdentifier",
-            "structureKey",
-            "structureMainPurpose"
-          ],
-          "type": "object",
-          "properties": {
-            "structureKey": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "permanentStructureIdentifier": {
-              "type": "string"
-            },
-            "temporary": {
-              "type": "boolean",
-              "nullable": true
-            },
-            "demolitionDeadline": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "numberOfStoreys": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "structureSection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/StructureSection"
-              },
-              "nullable": true
-            },
-            "structureMainPurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string",
-              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-            },
-            "buildingObjectType": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-              ],
-              "type": "string",
-              "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-            },
-            "location": {
-              "required": [
-                "buildingObjectLocationDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingObjectLocationData"
-                }
-              ],
-              "description": "Rakennuskohteen sijaintitiedot",
-              "nullable": true
-            },
-            "administrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö"
-            },
-            "decisionAdministrativeLocationUnit": {
-              "required": [
-                "administrativeLocationUnitKey",
-                "propertyIdentifier"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/AdministrativeLocationUnit"
-                }
-              ],
-              "description": "Hallinnollinen sijaintiyksikkö",
-              "nullable": true
-            },
-            "buildingObjectOwner": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingObjectOwner"
-              },
-              "description": "Rakennuskohteen omistaja",
-              "nullable": true
-            },
-            "address": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Address"
-              },
-              "nullable": true
-            },
-            "name": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "description": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennelma"
-        },
-        "StructureChangeDiffDto": {
-          "type": "object",
-          "properties": {
-            "changeType": {
-              "type": "string"
-            },
-            "objectKey": {
-              "nullable": true
-            },
-            "objectType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentKey": {
-              "nullable": true
-            },
-            "parentType": {
-              "type": "string",
-              "nullable": true
-            },
-            "parentChain": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ParentTypeKey"
-              }
-            },
-            "objectState": {
-              "required": [
-                "structureKey",
-                "permanentStructureIdentifier",
-                "structureMainPurpose",
-                "buildingObjectType",
-                "administrativeLocationUnit",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            },
-            "objectStatePrev": {
-              "required": [
-                "structureKey",
-                "permanentStructureIdentifier",
-                "structureMainPurpose",
-                "buildingObjectType",
-                "administrativeLocationUnit",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "StructureChangeInfoCollectionDto": {
-          "type": "object",
-          "properties": {
-            "lastSeen": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PaginationToken"
-                }
-              ],
-              "nullable": true
-            },
-            "upToDate": {
-              "type": "boolean"
-            },
-            "changes": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/StructureChangeInfoDto"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        "StructureChangeInfoDto": {
-          "type": "object",
-          "properties": {
-            "eventId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "eventTime": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "objectKey": { },
-            "objectState": {
-              "required": [
-                "structureKey",
-                "permanentStructureIdentifier",
-                "structureMainPurpose",
-                "buildingObjectType",
-                "administrativeLocationUnit",
-                "buildingObjectOwner"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/Structure"
-                }
-              ],
-              "description": "Rakennelma",
-              "nullable": true
-            },
-            "diff": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/StructureChangeDiffDto"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "StructureSection": {
-          "required": [
-            "lifeCycleState",
-            "partitionReason",
-            "structurePurpose",
-            "structureSectionKey"
-          ],
-          "type": "object",
-          "properties": {
-            "structureSectionKey": {
-              "type": "string",
-              "description": "",
-              "format": "uuid"
-            },
-            "lifeCycleState": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-                "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-              ],
-              "type": "string",
-              "description": "Rakennelman elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih"
-            },
-            "completionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "protectionMethod": {
-              "type": "string",
-              "description": "Rakennelman osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
-              "nullable": true
-            },
-            "cultureHistoricalSignificance": {
-              "type": "string",
-              "description": "Rakennelman osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
-              "nullable": true
-            },
-            "materialData": {
-              "required": [
-                "constructionMethod",
-                "buildingMaterialOfLoadBearingStructures",
-                "facadeMaterial",
-                "wideBodiedBuilding"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/MaterialData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "energyData": {
-              "required": [
-                "energyDataKey"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/EnergyData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "exteriorData": {
-              "required": [
-                "shape"
-              ],
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/ExteriorData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "buildingServicesEngineeringData": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-                }
-              ],
-              "description": "",
-              "nullable": true
-            },
-            "structurePurpose": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-                "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-              ],
-              "type": "string",
-              "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus"
-            },
-            "equipment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Equipment"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "constructionDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ConstructionDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "buildingInformationModel": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingInformationModel"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "specialDesign": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SpecialDesign"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "attachment": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              },
-              "description": "",
-              "nullable": true
-            },
-            "partitionReason": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-                "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-              ],
-              "type": "string",
-              "description": "Rakennelman osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
-            },
-            "partitionDescription": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/LanguageString"
-                }
-              ],
-              "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-              "nullable": true
-            },
-            "relatedFinishedStructureSection": {
-              "type": "string",
-              "description": "",
-              "format": "uuid",
-              "nullable": true
-            },
-            "demolitionDate": {
-              "type": "string",
-              "description": "",
-              "format": "date",
-              "nullable": true
-            },
-            "reasonForDemolition": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-                "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-              ],
-              "type": "string",
-              "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennelman osa"
-        },
-        "UnseparatedParcel": {
-          "type": "object",
-          "properties": {
-            "municipalityNumber": {
-              "type": "string"
-            },
-            "unseparatedParcelIdentifier": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "registrationDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "endDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "type": {
-              "type": "string"
-            },
-            "relationToBaseProperty": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Määräala"
-        },
-        "UsageData": {
-          "type": "object",
-          "properties": {
-            "commissioningDate": {
-              "type": "string",
-              "format": "date",
-              "nullable": true
-            },
-            "usageStatus": {
-              "enum": [
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
-                "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
-              ],
-              "type": "string",
-              "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-              "nullable": true
-            },
-            "purpose": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Purpose"
-              },
-              "nullable": true
-            },
-            "usefulFloorArea": {
-              "type": "number",
-              "format": "double",
-              "nullable": true
-            },
-            "intendedWorkingLife": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "plannedUserCount": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false,
-          "description": "Rakennuksen käyttötiedot"
-        },
-        "ValidationProblemDetails": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true
-            },
-            "title": {
-              "type": "string",
-              "nullable": true
-            },
-            "status": {
-              "type": "integer",
-              "format": "int32",
-              "nullable": true
-            },
-            "detail": {
-              "type": "string",
-              "nullable": true
-            },
-            "instance": {
-              "type": "string",
-              "nullable": true
-            },
-            "errors": {
-              "type": "object",
-              "additionalProperties": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "number",
+                  "format": "double"
                 }
               }
-            }
+            },
+            "description": "Koordinaatit",
+            "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
           },
-          "additionalProperties": { }
+          "type": {
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon"
+            ],
+            "type": "string",
+            "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
+          }
         },
-        "VentilationMethod": {
-          "required": [
-            "isPrimary",
-            "ventilationMethodKey",
-            "ventilationMethodType"
-          ],
-          "type": "object",
-          "properties": {
-            "ventilationMethodKey": {
+        "additionalProperties": false,
+        "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+      },
+      "GetChangeInfo": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "objectKey": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GetInitialInfo": {
+        "type": "object",
+        "properties": {
+          "lastObjectKey": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GuidingStatute": {
+        "required": [
+          "guidingStatuteKey"
+        ],
+        "type": "object",
+        "properties": {
+          "guidingStatuteKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "statuteName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "statuteCollectionNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "statuteCollectionYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "chapter": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "section": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subSection": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "paragraph": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subParagraph": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Säädösviite"
+      },
+      "HealthReport": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "enum": [
+              "Unhealthy",
+              "Degraded",
+              "Healthy"
+            ],
+            "type": "string",
+            "readOnly": true
+          },
+          "totalDuration": {
+            "type": "string",
+            "format": "date-span",
+            "readOnly": true
+          },
+          "entries": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/HealthReportEntry"
+            },
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HealthReportEntry": {
+        "type": "object",
+        "properties": {
+          "duration": {
+            "type": "string",
+            "format": "date-span",
+            "readOnly": true
+          },
+          "status": {
+            "enum": [
+              "Unhealthy",
+              "Degraded",
+              "Healthy"
+            ],
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HeatingEnergySource": {
+        "required": [
+          "heatingEnergySourceKey",
+          "heatingEnergySourceType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "heatingEnergySourceKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "heatingEnergySourceType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/01",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/02",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/03",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/04",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/05",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/06",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/07",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/08",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/09",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/10",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/11",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1101",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1102",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1103",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/1104",
+              "http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde/code/99"
+            ],
+            "type": "string",
+            "description": "Lämmitysenergianlähteen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde\">http://uri.suomi.fi/codelist/rytj/lammitysenergianlahde</a>",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lämmitysenergianlähde"
+      },
+      "HeatingMethod": {
+        "required": [
+          "heatingMethodKey",
+          "heatingMethodType",
+          "isPrimary"
+        ],
+        "type": "object",
+        "properties": {
+          "heatingMethodKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "heatingMethodType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/01",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/02",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/03",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/04",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/05",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/06",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/07",
+              "http://uri.suomi.fi/codelist/rytj/lammitystapa/code/99"
+            ],
+            "type": "string",
+            "description": "Lämmitystavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/lammitystapa\">http://uri.suomi.fi/codelist/rytj/lammitystapa</a>",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lämmitystapa"
+      },
+      "InitialInformationCollection": {
+        "type": "object",
+        "properties": {
+          "next": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InitialInformationNextInfo"
+              }
+            ],
+            "nullable": true
+          },
+          "eventId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": { }
+          }
+        },
+        "additionalProperties": false
+      },
+      "InitialInformationNextInfo": {
+        "type": "object",
+        "properties": {
+          "lastObjectKey": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Inspection": {
+        "required": [
+          "inspectionCarriedOutByFirstName",
+          "inspectionCarriedOutByLastName",
+          "inspectionDate",
+          "inspectionKey",
+          "inspectionStatus",
+          "inspectionType",
+          "partiality",
+          "personsPresent",
+          "requiredByPermitRegulations"
+        ],
+        "type": "object",
+        "properties": {
+          "inspectionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "inspectionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
+            ],
+            "type": "string",
+            "description": "Katselmuksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Katselmuslaji\">http://uri.suomi.fi/codelist/rytj/Katselmuslaji</a>"
+          },
+          "inspectionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date"
+          },
+          "requiredByPermitRegulations": {
+            "type": "boolean",
+            "description": ""
+          },
+          "partiality": {
+            "type": "string",
+            "description": ""
+          },
+          "inspectionStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
+            ],
+            "type": "string",
+            "description": "Katselmuksen tilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne\">http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne</a>"
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionBuildingReference"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionStructureReference"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
               "type": "string",
               "format": "uuid"
             },
-            "ventilationMethodType": {
-              "type": "string",
-              "description": "Ilmanvaihtotavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ilmanvaihto\">http://uri.suomi.fi/codelist/rytj/ilmanvaihto</a>"
+            "description": "",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectChange"
             },
-            "isPrimary": {
-              "type": "boolean"
+            "description": "",
+            "nullable": true
+          },
+          "specificationOfObjectOfInspection": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "inspectionRemarks": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "inspectionCarriedOutByFirstName": {
+            "type": "string",
+            "description": ""
+          },
+          "inspectionCarriedOutByLastName": {
+            "type": "string",
+            "description": ""
+          },
+          "personsPresent": {
+            "type": "string",
+            "description": ""
+          },
+          "buildingsAttachmentDocument": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Katselmus"
+      },
+      "InspectionBuildingReference": {
+        "required": [
+          "permanentBuildingIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InspectionStructureReference": {
+        "required": [
+          "permanentStructureIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "InteriorData": {
+        "type": "object",
+        "properties": {
+          "floorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "atticArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "basementArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Sisätilojen tiedot"
+      },
+      "LanguageString": {
+        "type": "object",
+        "properties": {
+          "fin": {
+            "type": "string",
+            "description": "suomi",
+            "nullable": true
+          },
+          "swe": {
+            "type": "string",
+            "description": "ruotsi",
+            "nullable": true
+          },
+          "smn": {
+            "type": "string",
+            "description": "inarinsaame",
+            "nullable": true
+          },
+          "sms": {
+            "type": "string",
+            "description": "koltansaame",
+            "nullable": true
+          },
+          "sme": {
+            "type": "string",
+            "description": "pohjoissaame",
+            "nullable": true
+          },
+          "eng": {
+            "type": "string",
+            "description": "englanti",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
+      },
+      "MaterialData": {
+        "required": [
+          "buildingMaterialOfLoadBearingStructures",
+          "constructionMethod",
+          "facadeMaterial",
+          "wideBodiedBuilding"
+        ],
+        "type": "object",
+        "properties": {
+          "constructionMethod": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/01",
+              "http://uri.suomi.fi/codelist/vtj/Rake_runkotapa/code/02"
+            ],
+            "type": "string",
+            "description": "Rakentamistapa. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_runkotapa\">http://uri.suomi.fi/codelist/vtj/Rake_runkotapa</a>",
+            "nullable": true
+          },
+          "buildingMaterialOfLoadBearingStructures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingMaterialOfLoadBearingStructures"
+            },
+            "description": "Kantavien rakenteiden rakennusaine"
+          },
+          "facadeMaterial": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FacadeMaterial"
             }
           },
-          "additionalProperties": false,
-          "description": "Ilmanvaihtotapa"
-        }
-      },
-      "securitySchemes": {
-        "Bearer": {
-          "type": "apiKey",
-          "description": "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\"",
-          "name": "Authorization",
-          "in": "header"
+          "fireClass": {
+            "type": "string",
+            "description": "Paloluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Paloluokka\">http://uri.suomi.fi/codelist/rytj/Paloluokka</a>",
+            "nullable": true
+          },
+          "wideBodiedBuilding": {
+            "type": "boolean"
+          },
+          "reusableMaterialAmount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
         },
-        "oauth2": {
-          "type": "oauth2",
-          "flows": {
-            "clientCredentials": {
-              "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
-              "scopes": {
-                "ryhti.changeinformation.read": "Muutostietojen lukuoikeus.",
-                "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
-                "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus",
-                "ryhti.changeinformation.building.owners.all": "Omistajatietojen lukuoikeus, ml turvakiellon alaiset henkilöt.",
-                "ryhti.changeinformation.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia henkilöitä.",
-                "ryhti.changeinformation.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin."
+        "additionalProperties": false,
+        "description": "Materiaalitiedot"
+      },
+      "NetworkConnection": {
+        "required": [
+          "networkConnectionKey",
+          "networkConnectionType"
+        ],
+        "type": "object",
+        "properties": {
+          "networkConnectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "networkConnectionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/01",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/02",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/03",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/04",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/05",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/06",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/07",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/08",
+              "http://uri.suomi.fi/codelist/rytj/verkliit/code/09"
+            ],
+            "type": "string",
+            "description": "Verkostoliittymän laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/verkliit\">http://uri.suomi.fi/codelist/rytj/verkliit</a>",
+            "nullable": true
+          },
+          "connected": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "connectionPoint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
               }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Verkostoliittymä"
+      },
+      "Operator": {
+        "required": [
+          "isPerson"
+        ],
+        "type": "object",
+        "properties": {
+          "personalIdentityCode": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "businessId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "isPerson": {
+            "type": "boolean",
+            "description": ""
+          },
+          "firstName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "familyName": {
+            "type": "string",
+            "description": "",
+            "nullable": true
+          },
+          "organizationName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "operatorAddress": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContactAddress"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "languageCode": {
+            "type": "string",
+            "description": "IETF kielikoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/interoperabilityplatform/languagecodes",
+            "nullable": true
+          },
+          "nationalityCode": {
+            "type": "string",
+            "description": "Valtiokoodi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/jhs/valtio_1_20120101",
+            "nullable": true
+          },
+          "deathDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Toimija"
+      },
+      "OperatorChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "Toimija",
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "Toimija",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "OperatorChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OperatorChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "OperatorChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "isPerson"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Operator"
+              }
+            ],
+            "description": "Toimija",
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OperatorChangeDiffDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PaginationToken": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "objectKey": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParentTypeKey": {
+        "type": "object",
+        "properties": {
+          "parentType": {
+            "type": "string"
+          },
+          "parentKey": { }
+        },
+        "additionalProperties": false
+      },
+      "PermitRegulation": {
+        "required": [
+          "permitRegulationKey",
+          "permitRegulationType"
+        ],
+        "type": "object",
+        "properties": {
+          "permitRegulationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitRegulationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M01",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0101",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0102",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0103",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0104",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0105",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0106",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0107",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0108",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0109",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0110",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M02",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0201",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0202",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M03",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0301",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M0302",
+              "http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen/code/M04"
+            ],
+            "type": "string",
+            "description": "Lupamääräys. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen\">http://uri.suomi.fi/codelist/rytj/Lupamaarayshierarkinen</a>"
+          },
+          "textOfPermitRegulation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Lupamääräys"
+      },
+      "Planner": {
+        "required": [
+          "familyName",
+          "firstName",
+          "plannerCompetence",
+          "plannerKey",
+          "plannerRole",
+          "requiredCompetence",
+          "responsibilityStartDate"
+        ],
+        "type": "object",
+        "properties": {
+          "plannerKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "plannerRole": {
+            "type": "string",
+            "description": "Suunnittelijan rooli. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli\">http://uri.suomi.fi/codelist/rytj/suunnittelijanrooli</a>"
+          },
+          "plannerCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "responsibilityStartDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "responsibilityEndDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlannerBuildingReference"
+            },
+            "nullable": true
+          },
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlannerStructureReference"
+            },
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          },
+          "requiredCompetence": {
+            "type": "string",
+            "description": "Vaativuus- ja pätevyysluokka. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/vaativuusluokat\">http://uri.suomi.fi/codelist/rytj/vaativuusluokat</a>"
+          },
+          "personalIdentityCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "otherId": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "familyName": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Suunnittelija"
+      },
+      "PlannerBuildingReference": {
+        "required": [
+          "permanentBuildingIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentBuildingIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PlannerStructureReference": {
+        "required": [
+          "permanentStructureIdentifierReference"
+        ],
+        "type": "object",
+        "properties": {
+          "permanentStructureIdentifierReference": {
+            "type": "string"
+          },
+          "buildingSectionReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "Property": {
+        "required": [
+          "municipalityNumber",
+          "propertyIdentifier",
+          "relationToBaseProperty",
+          "status",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "propertyIdentifier": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "registrationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "landArea": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "geometry": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry"
+              }
+            ],
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "relationToBaseProperty": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kiinteistö"
+      },
+      "Purpose": {
+        "required": [
+          "isPrimary",
+          "purposeKey",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "purposeKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
+              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
+            ],
+            "type": "string",
+            "description": "Käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Käyttötarkoitus"
+      },
+      "RyhtiGeometry": {
+        "required": [
+          "geometry",
+          "srid"
+        ],
+        "type": "object",
+        "properties": {
+          "srid": {
+            "enum": [
+              "3067",
+              "3873",
+              "3874",
+              "3875",
+              "3876",
+              "3877",
+              "3878",
+              "3879",
+              "3880",
+              "3881",
+              "3882",
+              "3883",
+              "3884",
+              "3885"
+            ],
+            "type": "string",
+            "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
+          },
+          "geometry": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/GeoJsonPointGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonMultiPointGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonLineStringGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonMultiLineStringGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonPolygonGeometry"
+              },
+              {
+                "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
+              }
+            ],
+            "description": "Geometria GeoJson rakenteella: https://geojson.org/"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SpecialDesign": {
+        "required": [
+          "document",
+          "specialDesignKey",
+          "specialDesignType"
+        ],
+        "type": "object",
+        "properties": {
+          "specialDesignKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specialDesignType": {
+            "type": "string",
+            "description": "Erityissuunnitelman laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/erityissuun\">http://uri.suomi.fi/codelist/rytj/erityissuun</a>"
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Erityissuunnitelma"
+      },
+      "Structure": {
+        "required": [
+          "address",
+          "administrativeLocationUnit",
+          "buildingObjectOwner",
+          "buildingObjectType",
+          "location",
+          "permanentStructureIdentifier",
+          "structureKey",
+          "structureMainPurpose",
+          "structureSection",
+          "temporary"
+        ],
+        "type": "object",
+        "properties": {
+          "structureKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentStructureIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
+          "structureMainPurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string",
+            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö"
+          },
+          "decisionAdministrativeLocationUnit": {
+            "required": [
+              "administrativeLocationUnitKey",
+              "propertyIdentifier"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdministrativeLocationUnit"
+              }
+            ],
+            "description": "Hallinnollinen sijaintiyksikkö",
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "description": "Rakennuskohteen omistaja",
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennelma"
+      },
+      "StructureChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StructureChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "StructureChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureChangeDiffDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "StructureSection": {
+        "required": [
+          "lifeCycleState",
+          "partitionReason",
+          "structurePurpose",
+          "structureSectionKey"
+        ],
+        "type": "object",
+        "properties": {
+          "structureSectionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "description": "Rakennelman elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih"
+          },
+          "completionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "description": "Rakennelman osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "description": "Rakennelman osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "exteriorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "structurePurpose": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
+              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
+            ],
+            "type": "string",
+            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus"
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "description": "",
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string",
+            "description": "Rakennelman osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "relatedFinishedStructureSection": {
+            "type": "string",
+            "description": "",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "description": "",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennelman osa"
+      },
+      "UnseparatedParcel": {
+        "type": "object",
+        "properties": {
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "unseparatedParcelIdentifier": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "registrationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "type": {
+            "type": "string"
+          },
+          "relationToBaseProperty": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Määräala"
+      },
+      "UsageData": {
+        "required": [
+          "purpose"
+        ],
+        "type": "object",
+        "properties": {
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "usageStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
+            ],
+            "type": "string",
+            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "purpose": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Purpose"
+            },
+            "nullable": true
+          },
+          "usefulFloorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "intendedWorkingLife": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedUserCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakennuksen käyttötiedot"
+      },
+      "ValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "additionalProperties": { }
+      },
+      "VentilationMethod": {
+        "required": [
+          "isPrimary",
+          "ventilationMethodKey",
+          "ventilationMethodType"
+        ],
+        "type": "object",
+        "properties": {
+          "ventilationMethodKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ventilationMethodType": {
+            "type": "string",
+            "description": "Ilmanvaihtotavan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ilmanvaihto\">http://uri.suomi.fi/codelist/rytj/ilmanvaihto</a>"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Ilmanvaihtotapa"
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "apiKey",
+        "description": "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\"",
+        "name": "Authorization",
+        "in": "header"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://identitytest.ymparisto.fi/connect/token",
+            "scopes": {
+              "ryhti.changeinformation.read": "Muutostietojen lukuoikeus.",
+              "ryhti.changeinformation.building.all": "Kaikkien muutostietojen lukuoikeus",
+              "ryhti.changeinformation.building.generalized": "Karkeutettujen muutostietojen lukuoikeus",
+              "ryhti.changeinformation.building.owners.all": "Omistajatietojen lukuoikeus, ml turvakiellon alaiset henkilöt.",
+              "ryhti.changeinformation.building.owners.limited": "Oikeus omistajatietoihin, ilman turvakiellon alaisia henkilöitä.",
+              "ryhti.changeinformation.building.foremen": "Oikeudet työnjohtajien ja suunnittelijoiden tietoihin."
             }
           }
         }
       }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
     },
-    "security": [
-      {
-        "Bearer": [ ]
-      },
-      {
-        "oauth2": [ ]
-      }
-    ]
-  }
+    {
+      "oauth2": [ ]
+    }
+  ]
+}

--- a/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
@@ -216,6 +216,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "personalDataContent",
+            "in": "query",
+            "description": "Lisätään henkilötietoja sisältävät liitteet (query parametri).",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -717,6 +725,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -734,6 +745,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -751,6 +765,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -837,6 +854,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -854,6 +874,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -871,6 +894,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1074,6 +1100,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1091,6 +1120,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1108,6 +1140,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1202,6 +1237,14 @@
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "personalDataContent",
+            "in": "query",
+            "description": "Lisätään henkilötietoja sisältävät liitteet (query parametri).",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -1303,6 +1346,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1319,6 +1363,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1335,6 +1380,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1421,6 +1467,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1437,6 +1484,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1453,6 +1501,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1619,6 +1668,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1635,6 +1685,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1651,6 +1702,7 @@
                 "required": [
                   "demolitionPermitApplication",
                   "demolitionDecision",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1726,6 +1778,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1743,6 +1798,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1760,6 +1818,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1846,6 +1907,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1863,6 +1927,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -1880,6 +1947,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2083,6 +2153,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2100,6 +2173,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2117,6 +2193,9 @@
                   "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
+                  "deviationObject",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2292,6 +2371,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2309,6 +2391,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2326,6 +2411,9 @@
                   "permanentPermitIdentifier",
                   "decision",
                   "buildingPermitApplication",
+                  "constructionAction",
+                  "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2523,6 +2611,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2542,6 +2631,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2561,6 +2651,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2650,6 +2741,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2669,6 +2761,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2688,6 +2781,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2874,6 +2968,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2893,6 +2988,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -2912,6 +3008,7 @@
                   "landscapeWorkPermitApplication",
                   "constructionAction",
                   "buildingSite",
+                  "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
                 ],
@@ -3626,7 +3723,8 @@
       "AcceptedDeviation": {
         "required": [
           "acceptedDeviationKey",
-          "contentOfDeviation"
+          "contentOfDeviation",
+          "deviationType"
         ],
         "type": "object",
         "properties": {
@@ -3652,7 +3750,9 @@
       },
       "Address": {
         "required": [
-          "addressKey"
+          "addressKey",
+          "addressNumber",
+          "postalCode"
         ],
         "type": "object",
         "properties": {
@@ -3737,9 +3837,12 @@
       "Apartment": {
         "required": [
           "addressNumber",
+          "apartmentChangeType",
+          "apartmentIdentifier",
           "apartmentKey",
           "apartmentType",
-          "lifeCycleState"
+          "lifeCycleState",
+          "numberOfRooms"
         ],
         "type": "object",
         "properties": {
@@ -3880,9 +3983,14 @@
       },
       "AreaToBeBuiltForSpecificActivities": {
         "required": [
+          "address",
+          "administrativeLocationUnit",
           "areaToBeBuiltForSpecificActivitiesKey",
           "buildingObjectOwner",
-          "buildingObjectType"
+          "buildingObjectType",
+          "location",
+          "specificActivitiesAreaType",
+          "temporary"
         ],
         "type": "object",
         "properties": {
@@ -3925,7 +4033,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -4073,11 +4182,17 @@
       },
       "Building": {
         "required": [
+          "address",
+          "administrativeLocationUnit",
           "buildingKey",
           "buildingObjectOwner",
           "buildingObjectType",
+          "buildingSection",
+          "location",
           "mainPurpose",
-          "numberOfStoreys"
+          "numberOfStoreys",
+          "permanentBuildingIdentifier",
+          "temporary"
         ],
         "type": "object",
         "properties": {
@@ -4283,7 +4398,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -4475,7 +4591,9 @@
       "BuildingInformationModel": {
         "required": [
           "buildingInformationModelKey",
-          "buildingInformationModelType"
+          "buildingInformationModelType",
+          "document",
+          "referencePoint"
         ],
         "type": "object",
         "properties": {
@@ -4613,7 +4731,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -4640,7 +4760,8 @@
       },
       "BuildingObjectLocationData": {
         "required": [
-          "buildingObjectLocationDataKey"
+          "buildingObjectLocationDataKey",
+          "pointLocation"
         ],
         "type": "object",
         "properties": {
@@ -4673,7 +4794,8 @@
         "required": [
           "buildingObjectOwnerKey",
           "differentOwner",
-          "ownerOperator"
+          "ownerOperator",
+          "ownerType"
         ],
         "type": "object",
         "properties": {
@@ -4745,8 +4867,10 @@
       "BuildingPermitApplication": {
         "required": [
           "applicationContent",
+          "dateOfReception",
           "lifeCycleState",
-          "permitApplicationKey"
+          "permitApplicationKey",
+          "permitApplicationType"
         ],
         "type": "object",
         "properties": {
@@ -4791,7 +4915,19 @@
       "BuildingPermitDecision": {
         "required": [
           "buildingPermitDecisionKey",
-          "lifeCycleState"
+          "constructionToBeCompletedBy",
+          "constructionToBeStartedBy",
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "engagingParty",
+          "lifeCycleState",
+          "publicNoticeDate"
         ],
         "type": "object",
         "properties": {
@@ -4905,6 +5041,7 @@
           },
           "permitApplicationType": {
             "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
             "nullable": true
           },
           "constructionToBeStartedBy": {
@@ -4941,6 +5078,9 @@
       "BuildingPermitIssue": {
         "required": [
           "buildingPermitApplication",
+          "buildingSite",
+          "constructionAction",
+          "dateOfInitiation",
           "decision",
           "lifeCycleState",
           "municipalityNumber",
@@ -4974,7 +5114,19 @@
           "decision": {
             "required": [
               "buildingPermitDecisionKey",
-              "lifeCycleState"
+              "constructionToBeStartedBy",
+              "constructionToBeCompletedBy",
+              "engagingParty",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
             ],
             "allOf": [
               {
@@ -5014,7 +5166,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -5153,9 +5307,6 @@
             "nullable": true
           },
           "exteriorData": {
-            "required": [
-              "shape"
-            ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/ExteriorData"
@@ -5174,6 +5325,9 @@
             "nullable": true
           },
           "usageData": {
+            "required": [
+              "purpose"
+            ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/UsageData"
@@ -5347,6 +5501,8 @@
       },
       "BuildingSite": {
         "required": [
+          "buildingSiteAddress",
+          "buildingSiteKey",
           "stormWaterTreatmentType",
           "tenure"
         ],
@@ -5685,7 +5841,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -5979,7 +6136,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -6091,7 +6249,19 @@
           "decision": {
             "required": [
               "buildingPermitDecisionKey",
-              "lifeCycleState"
+              "constructionToBeStartedBy",
+              "constructionToBeCompletedBy",
+              "engagingParty",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
             ],
             "allOf": [
               {
@@ -6131,7 +6301,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -6263,9 +6435,6 @@
             "nullable": true
           },
           "exteriorData": {
-            "required": [
-              "shape"
-            ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/ExteriorData"
@@ -6284,6 +6453,9 @@
             "nullable": true
           },
           "usageData": {
+            "required": [
+              "purpose"
+            ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/UsageData"
@@ -6684,7 +6856,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -6748,7 +6921,16 @@
       "ChangePermit": {
         "required": [
           "changePermitKey",
-          "lifeCycleState"
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "lifeCycleState",
+          "publicNoticeDate"
         ],
         "type": "object",
         "properties": {
@@ -7038,10 +7220,16 @@
           "building": {
             "required": [
               "buildingKey",
+              "permanentBuildingIdentifier",
+              "temporary",
               "numberOfStoreys",
+              "buildingSection",
               "mainPurpose",
               "buildingObjectType",
-              "buildingObjectOwner"
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
             ],
             "allOf": [
               {
@@ -7054,10 +7242,16 @@
           "finishedBuilding": {
             "required": [
               "buildingKey",
+              "permanentBuildingIdentifier",
+              "temporary",
               "numberOfStoreys",
+              "buildingSection",
               "mainPurpose",
               "buildingObjectType",
-              "buildingObjectOwner"
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
             ],
             "allOf": [
               {
@@ -7071,10 +7265,14 @@
             "required": [
               "structureKey",
               "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
               "structureMainPurpose",
               "buildingObjectType",
+              "location",
               "administrativeLocationUnit",
-              "buildingObjectOwner"
+              "buildingObjectOwner",
+              "address"
             ],
             "allOf": [
               {
@@ -7088,10 +7286,14 @@
             "required": [
               "structureKey",
               "permanentStructureIdentifier",
+              "temporary",
+              "structureSection",
               "structureMainPurpose",
               "buildingObjectType",
+              "location",
               "administrativeLocationUnit",
-              "buildingObjectOwner"
+              "buildingObjectOwner",
+              "address"
             ],
             "allOf": [
               {
@@ -7104,8 +7306,13 @@
           "areaToBeBuiltForSpecificActivities": {
             "required": [
               "areaToBeBuiltForSpecificActivitiesKey",
+              "specificActivitiesAreaType",
+              "temporary",
               "buildingObjectType",
-              "buildingObjectOwner"
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
             ],
             "allOf": [
               {
@@ -7172,8 +7379,13 @@
           "finishedAreaToBeBuiltForSpecificActivities": {
             "required": [
               "areaToBeBuiltForSpecificActivitiesKey",
+              "specificActivitiesAreaType",
+              "temporary",
               "buildingObjectType",
-              "buildingObjectOwner"
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
             ],
             "allOf": [
               {
@@ -7275,7 +7487,10 @@
       },
       "ContactAddress": {
         "required": [
-          "addressKey"
+          "addressKey",
+          "contactAddressType",
+          "postalCode",
+          "source"
         ],
         "type": "object",
         "properties": {
@@ -7548,6 +7763,7 @@
       "DemolitionPermitApplication": {
         "required": [
           "applicationContent",
+          "dateOfReception",
           "demolitionPermitApplicationKey",
           "lifeCycleState"
         ],
@@ -7593,8 +7809,17 @@
       },
       "DemolitionPermitDecision": {
         "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
           "demolitionPermitDecisionKey",
-          "lifeCycleState"
+          "lifeCycleState",
+          "publicNoticeDate"
         ],
         "type": "object",
         "properties": {
@@ -7743,6 +7968,7 @@
       },
       "DemolitionPermitIssue": {
         "required": [
+          "dateOfInitiation",
           "demolitionDecision",
           "demolitionPermitApplication",
           "lifeCycleState",
@@ -7781,7 +8007,16 @@
           "demolitionDecision": {
             "required": [
               "demolitionPermitDecisionKey",
-              "lifeCycleState"
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
             ],
             "allOf": [
               {
@@ -7807,7 +8042,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -7894,7 +8131,9 @@
       "DeviationObject": {
         "required": [
           "address",
+          "administrativeLocationUnit",
           "buildingObjectOwner",
+          "buildingObjectType",
           "deviationObjectKey"
         ],
         "type": "object",
@@ -7918,7 +8157,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -7991,6 +8231,7 @@
         "required": [
           "applicationContent",
           "constructionDesign",
+          "dateOfReception",
           "deviationPermitApplicationKey",
           "lifeCycleState"
         ],
@@ -8043,10 +8284,19 @@
       },
       "DeviationPermitDecision": {
         "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
           "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
           "deviationPermitDecisionKey",
           "engagingParty",
-          "lifeCycleState"
+          "lifeCycleState",
+          "publicNoticeDate"
         ],
         "type": "object",
         "properties": {
@@ -8183,6 +8433,9 @@
       },
       "DeviationPermitIssue": {
         "required": [
+          "buildingSite",
+          "dateOfInitiation",
+          "deviationObject",
           "deviationPermitApplication",
           "deviationPermitDecision",
           "lifeCycleState",
@@ -8222,7 +8475,16 @@
               "deviationPermitDecisionKey",
               "engagingParty",
               "decisionInForceUntil",
-              "lifeCycleState"
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
             ],
             "allOf": [
               {
@@ -8236,7 +8498,8 @@
               "deviationPermitApplicationKey",
               "constructionDesign",
               "lifeCycleState",
-              "applicationContent"
+              "applicationContent",
+              "dateOfReception"
             ],
             "allOf": [
               {
@@ -8253,7 +8516,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -8609,6 +8874,7 @@
         "required": [
           "entranceKey",
           "entranceType",
+          "isAccessible",
           "isPrimary",
           "lifeCycleState"
         ],
@@ -8670,8 +8936,7 @@
             "nullable": true
           },
           "isAccessible": {
-            "type": "boolean",
-            "description": "Kerrosluku"
+            "type": "boolean"
           }
         },
         "additionalProperties": false,
@@ -8717,8 +8982,17 @@
       },
       "ExtensionDecision": {
         "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
           "extensionDecisionKey",
-          "lifeCycleState"
+          "lifeCycleState",
+          "publicNoticeDate"
         ],
         "type": "object",
         "properties": {
@@ -8836,9 +9110,6 @@
         "description": "Jatkoaikapäätös"
       },
       "ExteriorData": {
-        "required": [
-          "shape"
-        ],
         "type": "object",
         "properties": {
           "numberOfStoreys": {
@@ -8936,7 +9207,11 @@
         "required": [
           "familyName",
           "firstName",
-          "foremanKey"
+          "foremanCompetence",
+          "foremanKey",
+          "foremanRole",
+          "requiredCompetence",
+          "responsibilityStartDate"
         ],
         "type": "object",
         "properties": {
@@ -9111,7 +9386,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -9197,6 +9473,7 @@
       },
       "GeneralizedBuildingPermitIssue": {
         "required": [
+          "dateOfInitiation",
           "lifeCycleState",
           "municipalityNumber"
         ],
@@ -9228,7 +9505,19 @@
           "decision": {
             "required": [
               "buildingPermitDecisionKey",
-              "lifeCycleState"
+              "constructionToBeStartedBy",
+              "constructionToBeCompletedBy",
+              "engagingParty",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
             ],
             "allOf": [
               {
@@ -9268,7 +9557,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -9395,9 +9686,6 @@
             "nullable": true
           },
           "exteriorData": {
-            "required": [
-              "shape"
-            ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/ExteriorData"
@@ -10751,7 +11039,9 @@
           "inspectionCarriedOutByLastName",
           "inspectionDate",
           "inspectionKey",
+          "inspectionStatus",
           "inspectionType",
+          "partiality",
           "personsPresent",
           "requiredByPermitRegulations"
         ],
@@ -10776,7 +11066,7 @@
               "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
             ],
             "type": "string",
-            "description": ""
+            "description": "Katselmuksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Katselmuslaji\">http://uri.suomi.fi/codelist/rytj/Katselmuslaji</a>"
           },
           "inspectionDate": {
             "type": "string",
@@ -10798,7 +11088,7 @@
               "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
             ],
             "type": "string",
-            "description": ""
+            "description": "Katselmuksen tilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne\">http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne</a>"
           },
           "buildingReference": {
             "type": "array",
@@ -10923,6 +11213,11 @@
             "format": "double",
             "nullable": true
           },
+          "atticArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "basementArea": {
             "type": "integer",
             "format": "int32",
@@ -10935,6 +11230,7 @@
       "LandscapeWorkPermitApplication": {
         "required": [
           "applicationContent",
+          "dateOfReception",
           "landscapeWorkPermitApplicationKey",
           "lifeCycleState"
         ],
@@ -10988,10 +11284,19 @@
       },
       "LandscapeWorkPermitDecision": {
         "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
           "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
           "engagingParty",
           "landscapeWorkPermitDecisionKey",
-          "lifeCycleState"
+          "lifeCycleState",
+          "publicNoticeDate"
         ],
         "type": "object",
         "properties": {
@@ -11148,6 +11453,7 @@
         "required": [
           "buildingSite",
           "constructionAction",
+          "dateOfInitiation",
           "landscapeWorkPermitApplication",
           "landscapeWorkPermitDecision",
           "lifeCycleState",
@@ -11184,7 +11490,16 @@
               "landscapeWorkPermitDecisionKey",
               "engagingParty",
               "decisionInForceUntil",
-              "lifeCycleState"
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "decisionDocument",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
             ],
             "allOf": [
               {
@@ -11222,7 +11537,9 @@
           },
           "buildingSite": {
             "required": [
+              "buildingSiteKey",
               "stormWaterTreatmentType",
+              "buildingSiteAddress",
               "tenure"
             ],
             "allOf": [
@@ -11594,7 +11911,11 @@
         "required": [
           "familyName",
           "firstName",
-          "plannerKey"
+          "plannerCompetence",
+          "plannerKey",
+          "plannerRole",
+          "requiredCompetence",
+          "responsibilityStartDate"
         ],
         "type": "object",
         "properties": {
@@ -12017,6 +12338,7 @@
       },
       "SpecialDesign": {
         "required": [
+          "document",
           "specialDesignKey",
           "specialDesignType"
         ],
@@ -12051,12 +12373,16 @@
       },
       "Structure": {
         "required": [
+          "address",
           "administrativeLocationUnit",
           "buildingObjectOwner",
           "buildingObjectType",
+          "location",
           "permanentStructureIdentifier",
           "structureKey",
-          "structureMainPurpose"
+          "structureMainPurpose",
+          "structureSection",
+          "temporary"
         ],
         "type": "object",
         "properties": {
@@ -12174,7 +12500,8 @@
           },
           "location": {
             "required": [
-              "buildingObjectLocationDataKey"
+              "buildingObjectLocationDataKey",
+              "pointLocation"
             ],
             "allOf": [
               {
@@ -12319,9 +12646,6 @@
             "nullable": true
           },
           "exteriorData": {
-            "required": [
-              "shape"
-            ],
             "allOf": [
               {
                 "$ref": "#/components/schemas/ExteriorData"
@@ -12534,6 +12858,9 @@
         "description": "Määräala"
       },
       "UsageData": {
+        "required": [
+          "purpose"
+        ],
         "type": "object",
         "properties": {
           "commissioningDate": {


### PR DESCRIPTION
OpenApi kuvausten muutokset, jotka testattavissa testi-ympärisössä 18.12.2024 alkaen. Tuotantoon vuoden 2025 alussa.

# Yleistä

# Rakennustieto

## Rakennustietojen validointi- ja tallennus-API

* Korjattu ehdollisesti pakollisten tietojen pakollisuuksia OpenAPI-kuvauksessa
    * attribuutti on merkitty pakolliseksi vain, jos se on pakollinen kaikissa tilanteissa ja käyttötapauksissa.
* Korjattu rakennuksen osan huonestoalan (floorArea) validointi
    * tyhjä arvo (NULL) on sallittu, jos rakennuksen osaan ei liity huoneistoja
* Liästty OpenAPI-kuvaukseen päätökseen liittyvänLupatyypin (permitApplicationType) koodistoviittaus
* Lisätty rakennuksen osalle sisätilojen tietoihin uusi attribuutti ullakkoAla (atticArea)
    * ei pakollinen missään tilanteessa

## Rakennustietojen muutostietopalvelu

* Lisätty rakennuksen osalle sisätilojen tietoihin uusi attribuutti ullakkoAla (atticArea)

## Rakennustietojen muutostietopalvelun tiedossa olevat virheet ja tulossa olevia muutoksia

* rakennuksen poistettu varuste ja/tai sijainti saattaa näkyä virheellisesti sen nykyisessä tilanteessa (objectState)
    * HUOM! sijainnin ja/tai varusteen poisto näkyy oikein kohteen muutoksissa (diff)

# Alueidenkäyttö

## Sitova tonttijako
* Sitovan tonttijaon asian ja vaiheen päivitys (PUT) -rajapinta lisätty

## Alueidenkäytön rajoitus
* Alueidenkäytön rajoituksen asian ja vaiheen päivitys (PUT) -rajapinta lisätty
* Alueidenkäytön rajoituksen asian lataus  (GET) -rajapinta lisätty
