### PR TITLE
Ensimmäinen draft version 2025-rel-19 rajapintamuutoksista.

### DIFF
--- a/OpenApi/Alueidenkäyttö/Palveluväylä/alueidenkäyttö-OpenApi.json
+++ b/OpenApi/Alueidenkäyttö/Palveluväylä/alueidenkäyttö-OpenApi.json
@@ -2977,22 +2977,22 @@
               }
             }
           },
-          "404": {
-            "description": "Resurssia ei löydy.",
+          "422": {
+            "description": "Kutsun tietosisällössä virheitä.",
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
                 }
               }
             }
@@ -8980,17 +8980,11 @@
       "PartiallyCancelledPlanObjectInfo": {
         "required": [
           "cancelledPlanUri",
-          "partiallyCancelledPlanObjectInfoKey",
           "partiallyCancelledPlanObjectUri",
           "validityGeometry"
         ],
         "type": "object",
         "properties": {
-          "partiallyCancelledPlanObjectInfoKey": {
-            "type": "string",
-            "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
-            "format": "uuid"
-          },
           "cancelledPlanUri": {
             "minLength": 1,
             "type": "string",
@@ -9550,22 +9544,6 @@
             },
             "description": "Päätöksentekijä",
             "nullable": true
-          },
-          "planCancellationInfos": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PlanCancellationInfo"
-            },
-            "description": "Kumoamistieto",
-            "nullable": true
-          },
-          "partiallyCancelledPlanObjectInfos": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PartiallyCancelledPlanObjectInfo"
-            },
-            "description": "Osittain kumottavat kaavakohteet",
-            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -9666,15 +9644,15 @@
           "planType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/11",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/12",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/21",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/22",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/23",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/24",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/25",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/31",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/32",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/33",
@@ -10016,15 +9994,15 @@
           "planType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/11",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/12",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/21",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/22",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/23",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/24",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/25",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/31",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/32",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/33",
@@ -10182,15 +10160,15 @@
           "planType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/11",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/12",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/21",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/22",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/23",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/24",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/25",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/31",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/32",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/33",

--- a/OpenApi/Alueidenkäyttö/Palveluväylä/alueidenkäyttö-OpenApi.json
+++ b/OpenApi/Alueidenkäyttö/Palveluväylä/alueidenkäyttö-OpenApi.json
@@ -2977,22 +2977,22 @@
               }
             }
           },
-          "422": {
-            "description": "Kutsun tietosisällössä virheitä.",
+          "404": {
+            "description": "Resurssia ei löydy.",
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -8980,11 +8980,17 @@
       "PartiallyCancelledPlanObjectInfo": {
         "required": [
           "cancelledPlanUri",
+          "partiallyCancelledPlanObjectInfoKey",
           "partiallyCancelledPlanObjectUri",
           "validityGeometry"
         ],
         "type": "object",
         "properties": {
+          "partiallyCancelledPlanObjectInfoKey": {
+            "type": "string",
+            "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
+            "format": "uuid"
+          },
           "cancelledPlanUri": {
             "minLength": 1,
             "type": "string",
@@ -9544,6 +9550,22 @@
             },
             "description": "Päätöksentekijä",
             "nullable": true
+          },
+          "planCancellationInfos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlanCancellationInfo"
+            },
+            "description": "Kumoamistieto",
+            "nullable": true
+          },
+          "partiallyCancelledPlanObjectInfos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartiallyCancelledPlanObjectInfo"
+            },
+            "description": "Osittain kumottavat kaavakohteet",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -9644,15 +9666,15 @@
           "planType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/11",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/12",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/21",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/22",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/23",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/24",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/25",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/31",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/32",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/33",
@@ -9994,15 +10016,15 @@
           "planType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/11",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/12",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/21",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/22",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/23",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/24",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/25",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/31",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/32",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/33",
@@ -10160,15 +10182,15 @@
           "planType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/11",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/12",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/2",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/21",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/22",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/23",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/24",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/25",
-              "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/3",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/31",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/32",
               "http://uri.suomi.fi/codelist/rytj/RY_Kaavalaji/code/33",

--- a/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
@@ -121,6 +121,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -130,6 +133,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -139,6 +145,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -233,6 +242,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -242,6 +254,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -251,6 +266,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -266,17 +284,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingChangeInfoCollectionDto"
                 }
               }
             }
@@ -345,6 +363,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -354,6 +375,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -363,6 +387,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -378,17 +405,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingNoPersonDataChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingNoPersonDataChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingNoPersonDataChangeInfoCollectionDto"
                 }
               }
             }
@@ -457,6 +484,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -466,6 +496,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -475,6 +508,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -569,6 +605,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -578,6 +617,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -587,6 +629,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -602,17 +647,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueChangeInfoCollectionDto"
                 }
               }
             }
@@ -681,6 +726,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -690,6 +738,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -699,6 +750,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -714,17 +768,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonDataChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonDataChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonDataChangeInfoCollectionDto"
                 }
               }
             }
@@ -783,6 +837,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -792,6 +849,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -801,6 +861,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -895,6 +958,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -904,6 +970,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -913,6 +982,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -928,17 +1000,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationStructureChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationStructureChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/StructureChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationStructureChangeInfoCollectionDto"
                 }
               }
             }
@@ -1007,6 +1079,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1016,6 +1091,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1025,6 +1103,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1119,6 +1200,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1128,6 +1212,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1137,6 +1224,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1152,17 +1242,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto"
                 }
               }
             }
@@ -1231,6 +1321,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1240,6 +1333,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1249,6 +1345,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1264,17 +1363,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto"
                 }
               }
             }
@@ -1343,6 +1442,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1352,6 +1454,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1361,6 +1466,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1376,17 +1484,17 @@
             "content": {
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoCollectionDto"
                 }
               },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoCollectionDto"
                 }
               },
               "text/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoCollectionDto"
+                  "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoCollectionDto"
                 }
               }
             }
@@ -1455,6 +1563,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1464,6 +1575,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1473,6 +1587,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1567,6 +1684,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1576,6 +1696,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1585,6 +1708,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1679,6 +1805,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1688,6 +1817,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1697,6 +1829,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1791,6 +1926,9 @@
           "content": {
             "application/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1800,6 +1938,9 @@
             },
             "text/json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1809,6 +1950,9 @@
             },
             "application/*+json": {
               "schema": {
+                "required": [
+                  "eventId"
+                ],
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GetChangeInfo"
@@ -1835,6 +1979,853 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DemolitionPermitGeneralized": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae karkeutetut purkamislupa-asia muutostiedot",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DemolitionPermitNoPersons": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae karkeutetut purkamislupa-asian muutostiedot ilman henkilötietoja",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DemolitionPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae purkamislupa-asioiden muutostiedot ilman turvakiellollisten henkilötietoja",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DeviationPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae poikkeamislupa-asioiden muutostiedot ilman turvakiellollisten henkilötietoja",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/DeviationPermitNoPersons": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae karkeutetut poikkeamislupa-asian muutostiedot ilman henkilötietoja",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/LandscapeWorkPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae maisemalupa-asioiden muutostiedot ilman turvakiellollisten henkilötietoja",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/LandscapeWorkPermitNoPersons": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae karkeutetut maisemalupa-asian muutostiedot ilman henkilötietoja",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "required": [
+                  "eventId"
+                ],
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonDataChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonDataChangeInfoCollectionDto"
                 }
               }
             }
@@ -2366,6 +3357,144 @@
         }
       }
     },
+    "/api/InitialInformation/DemolitionPermitGeneralized": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/DemolitionPermitNoPersons": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/InitialInformation/LandscapeWorkPermit": {
       "post": {
         "tags": [
@@ -2435,7 +3564,145 @@
         }
       }
     },
+    "/api/InitialInformation/LandscapeWorkPermitNoPersons": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/InitialInformation/DeviationPermit": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/DeviationPermitNoPersons": {
       "post": {
         "tags": [
           "InitialInformation"
@@ -2849,6 +4116,213 @@
         }
       }
     },
+    "/api/InitialInformation/DemolitionPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/DeviationPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/InitialInformation/LandscapeWorkPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "InitialInformation"
+        ],
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetInitialInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InitialInformationCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/Status/health": {
       "get": {
         "tags": [
@@ -2974,147 +4448,6 @@
         "additionalProperties": false,
         "description": "Osoite"
       },
-      "AdministrativeLocationUnit": {
-        "required": [
-          "administrativeLocationUnitKey",
-          "propertyIdentifier"
-        ],
-        "type": "object",
-        "properties": {
-          "administrativeLocationUnitKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "unitIdentifier": {
-            "type": "string",
-            "nullable": true
-          },
-          "propertyIdentifier": {
-            "type": "string"
-          },
-          "unseparatedParcelIdentifier": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Hallinnollinen sijaintiyksikkö"
-      },
-      "Apartment": {
-        "required": [
-          "addressNumber",
-          "apartmentChangeType",
-          "apartmentIdentifier",
-          "apartmentKey",
-          "apartmentType",
-          "lifeCycleState",
-          "numberOfRooms"
-        ],
-        "type": "object",
-        "properties": {
-          "apartmentKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "lifeCycleState": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/1",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/2",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/3",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/4",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/5",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/6",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/7",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/8",
-              "http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe/code/9"
-            ],
-            "type": "string",
-            "description": "Huoneiston elinkaaren vaihe. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe\">http://uri.suomi.fi/codelist/rytj/huon-elinkaaren-vaihe</a>",
-            "nullable": true
-          },
-          "apartmentEquipment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ApartmentEquipment"
-            },
-            "nullable": true
-          },
-          "apartmentIdentifier": {
-            "type": "string"
-          },
-          "apartmentType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/01",
-              "http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi/code/02"
-            ],
-            "type": "string",
-            "description": "Huoneistotyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi\">http://uri.suomi.fi/codelist/rytj/Huoneistotyyppi</a>"
-          },
-          "floorArea": {
-            "type": "number",
-            "format": "double",
-            "nullable": true
-          },
-          "numberOfRooms": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "kitchenType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/01",
-              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/02",
-              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/03",
-              "http://uri.suomi.fi/codelist/rytj/Keittiotyyppi/code/04"
-            ],
-            "type": "string",
-            "description": "Keittiötyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Keittiotyyppi\">http://uri.suomi.fi/codelist/rytj/Keittiotyyppi</a>",
-            "nullable": true
-          },
-          "isWaterCloset": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "apartmentChangeType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/01",
-              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/02",
-              "http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji/code/03"
-            ],
-            "type": "string",
-            "description": "Huoneiston muutoksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji\">http://uri.suomi.fi/codelist/rytj/huoneistonmuutoksenlaji</a>",
-            "nullable": true
-          },
-          "commissioningDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "addressNumber": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "apartmentStorey": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "apartmentIdentifierLetterSuffix": {
-            "type": "string",
-            "nullable": true
-          },
-          "apartmentSubdivisionLetter": {
-            "type": "string",
-            "nullable": true
-          },
-          "apartmentNumber": {
-            "type": "integer",
-            "format": "int32"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Huoneisto"
-      },
       "ApartmentEquipment": {
         "required": [
           "apartmentEquipmentKey",
@@ -3146,160 +4479,6 @@
         },
         "additionalProperties": false,
         "description": "Huoneiston varuste"
-      },
-      "AreaToBeBuiltForSpecificActivities": {
-        "required": [
-          "address",
-          "administrativeLocationUnit",
-          "areaToBeBuiltForSpecificActivitiesKey",
-          "buildingObjectOwner",
-          "buildingObjectType",
-          "location",
-          "specificActivitiesAreaType",
-          "temporary"
-        ],
-        "type": "object",
-        "properties": {
-          "areaToBeBuiltForSpecificActivitiesKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "specificActivitiesAreaType": {
-            "type": "string",
-            "description": "Erityistä toimintaa varten rakennettavan alueen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi\">http://uri.suomi.fi/codelist/rakrek/erityistatoimintaavartenrakennettavanalueentyyppi</a>",
-            "nullable": true
-          },
-          "networkConnection": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/NetworkConnection"
-            },
-            "nullable": true
-          },
-          "completionDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "temporary": {
-            "type": "boolean"
-          },
-          "demolitionDeadline": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "buildingObjectType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-            ],
-            "type": "string",
-            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-          },
-          "location": {
-            "required": [
-              "buildingObjectLocationDataKey",
-              "pointLocation"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingObjectLocationData"
-              }
-            ],
-            "description": "Rakennuskohteen sijaintitiedot",
-            "nullable": true
-          },
-          "administrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö",
-            "nullable": true
-          },
-          "decisionAdministrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö",
-            "nullable": true
-          },
-          "buildingObjectOwner": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingObjectOwner"
-            },
-            "description": "Rakennuskohteen omistaja",
-            "nullable": true
-          },
-          "address": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Address"
-            },
-            "nullable": true
-          },
-          "name": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "description": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "constructionDesign": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConstructionDesign"
-            },
-            "nullable": true
-          },
-          "buildingInformationModel": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingInformationModel"
-            },
-            "nullable": true
-          },
-          "specialDesign": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SpecialDesign"
-            },
-            "nullable": true
-          },
-          "attachment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Erityistä toimintaa varten rakennettava alue"
       },
       "AssemblyFacility": {
         "required": [
@@ -3345,306 +4524,6 @@
         },
         "additionalProperties": false,
         "description": "Kokoontumistila"
-      },
-      "Building": {
-        "required": [
-          "address",
-          "administrativeLocationUnit",
-          "buildingKey",
-          "buildingObjectOwner",
-          "buildingObjectType",
-          "buildingSection",
-          "location",
-          "mainPurpose",
-          "numberOfStoreys",
-          "permanentBuildingIdentifier",
-          "temporary"
-        ],
-        "type": "object",
-        "properties": {
-          "buildingKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "permanentBuildingIdentifier": {
-            "type": "string",
-            "description": "Pysyvä rakennustunnus (PRT)"
-          },
-          "temporary": {
-            "type": "boolean",
-            "description": "Onko väliaikainen",
-            "nullable": true
-          },
-          "demolitionDeadline": {
-            "type": "string",
-            "description": "Demolition deadline",
-            "format": "date",
-            "nullable": true
-          },
-          "numberOfStoreys": {
-            "type": "integer",
-            "description": "Kerrosluku",
-            "format": "int32",
-            "nullable": true
-          },
-          "buildingSection": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingSection"
-            },
-            "description": "Rakennuksen osat",
-            "nullable": true
-          },
-          "mainPurpose": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/01",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/011",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0110",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0111",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0112",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/012",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0120",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0121",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/013",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0130",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/014",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0140",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/02",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/021",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0210",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0211",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/03",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/031",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0310",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0311",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0319",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/032",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0320",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0321",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0322",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0329",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/033",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0330",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/04",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/040",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0400",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/05",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/051",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0510",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0511",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0512",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0513",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0514",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/052",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0520",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0521",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/059",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0590",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/06",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/061",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0610",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0611",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0612",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0613",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0614",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0615",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0619",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/062",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0620",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0621",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/063",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0630",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/07",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/071",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0710",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0711",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0712",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0713",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0714",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/072",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0720",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/073",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0730",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0731",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0739",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/074",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0740",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0741",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0742",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0743",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0744",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0749",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/079",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0790",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/08",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/081",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0810",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/082",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0820",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/083",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0830",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/084",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0840",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0841",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/089",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0890",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0891",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/09",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/091",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0910",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0911",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0912",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0919",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/092",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0920",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/093",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0930",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/0939",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/10",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/101",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1010",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1011",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/109",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1090",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1091",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/11",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/111",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1110",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/112",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1120",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/113",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1130",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/12",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/121",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1210",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1211",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1212",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1213",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1214",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1215",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/13",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/131",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1310",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1311",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1319",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/14",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/141",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1410",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1411",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1412",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1413",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1414",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1415",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1416",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1419",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/149",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1490",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1491",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1492",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1493",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1499",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/19",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/191",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1910",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1911",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1912",
-              "http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712/code/1919"
-            ],
-            "type": "string",
-            "description": "Pääasiallinen käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712\">http://uri.suomi.fi/codelist/jhs/rakennus_1_20180712</a>",
-            "nullable": true
-          },
-          "buildingObjectType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-            ],
-            "type": "string",
-            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-          },
-          "location": {
-            "required": [
-              "buildingObjectLocationDataKey",
-              "pointLocation"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingObjectLocationData"
-              }
-            ],
-            "description": "Rakennuskohteen sijaintitiedot",
-            "nullable": true
-          },
-          "administrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö"
-          },
-          "decisionAdministrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö",
-            "nullable": true
-          },
-          "buildingObjectOwner": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingObjectOwner"
-            },
-            "description": "Rakennuskohteen omistaja",
-            "nullable": true
-          },
-          "address": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Address"
-            },
-            "nullable": true
-          },
-          "name": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "description": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "addChangeEvent": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "renovationDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Rakennuksen tiedot."
       },
       "BuildingAttachmentDocument": {
         "required": [
@@ -3839,7 +4718,8 @@
             "nullable": true
           },
           "attachmentType": {
-            "type": "string"
+            "type": "string",
+            "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
           }
         },
         "additionalProperties": false
@@ -3861,25 +4741,30 @@
             "type": "string",
             "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
           },
-          "document": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "nullable": true
-          },
           "referencePoint": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/RyhtiGeometry"
               }
             ]
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false,
         "description": "Rakennustietomalli"
       },
       "BuildingInformationModelNoPersonData": {
+        "required": [
+          "buildingInformationModelKey",
+          "buildingInformationModelType",
+          "referencePoint"
+        ],
         "type": "object",
         "properties": {
           "buildingInformationModelKey": {
@@ -3890,19 +4775,19 @@
             "type": "string",
             "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
           },
-          "document": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
-            },
-            "nullable": true
-          },
           "referencePoint": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/RyhtiGeometry"
               }
             ]
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -4223,6 +5108,60 @@
             "format": "date",
             "nullable": true
           },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
           "decisionDocument": {
             "allOf": [
               {
@@ -4230,6 +5169,107 @@
               }
             ],
             "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "buildingPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/01",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/02",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/03",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/04"
+            ],
+            "type": "string",
+            "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Rakentamislupapäätös"
+      },
+      "BuildingPermitDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
             "nullable": true
           },
           "decisionArticle": {
@@ -4286,6 +5326,14 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
           "buildingPermitDecisionKey": {
             "type": "string",
             "format": "uuid"
@@ -4320,254 +5368,9 @@
             "type": "string",
             "format": "date",
             "nullable": true
-          },
-          "engagingParty": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EngagingParty"
-            },
-            "nullable": true
           }
         },
-        "additionalProperties": false,
-        "description": "Rakentamislupapäätös"
-      },
-      "BuildingSection": {
-        "required": [
-          "buildingSectionKey",
-          "lifeCycleState",
-          "partitionReason",
-          "usageData"
-        ],
-        "type": "object",
-        "properties": {
-          "buildingSectionKey": {
-            "type": "string",
-            "description": "",
-            "format": "uuid"
-          },
-          "lifeCycleState": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
-              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
-            ],
-            "type": "string",
-            "description": "Rakennuksen osan elinkaaren vaihe. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/rakelinvaih",
-            "nullable": true
-          },
-          "completionDate": {
-            "type": "string",
-            "description": "",
-            "format": "date",
-            "nullable": true
-          },
-          "protectionMethod": {
-            "type": "string",
-            "description": "Rakennuksen osan suojatapa. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/suojtapa",
-            "nullable": true
-          },
-          "cultureHistoricalSignificance": {
-            "type": "string",
-            "description": "Rakennuksen osan kulttuurihistoriallinen merkittävyys. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rakrek/kulthistmer",
-            "nullable": true
-          },
-          "materialData": {
-            "required": [
-              "constructionMethod",
-              "buildingMaterialOfLoadBearingStructures",
-              "facadeMaterial",
-              "wideBodiedBuilding"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MaterialData"
-              }
-            ],
-            "description": "",
-            "nullable": true
-          },
-          "energyData": {
-            "required": [
-              "energyDataKey"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/EnergyData"
-              }
-            ],
-            "description": "",
-            "nullable": true
-          },
-          "interiorData": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/InteriorData"
-              }
-            ],
-            "description": "",
-            "nullable": true
-          },
-          "exteriorData": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ExteriorData"
-              }
-            ],
-            "description": "",
-            "nullable": true
-          },
-          "buildingServicesEngineeringData": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
-              }
-            ],
-            "description": "",
-            "nullable": true
-          },
-          "usageData": {
-            "required": [
-              "purpose"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/UsageData"
-              }
-            ],
-            "description": ""
-          },
-          "equipment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Equipment"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "entrance": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Entrance"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "assemblyFacility": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AssemblyFacility"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "elevator": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Elevator"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "apartment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Apartment"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "constructionDesign": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConstructionDesign"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "buildingInformationModel": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingInformationModel"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "specialDesign": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SpecialDesign"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "attachment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "partitionReason": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
-              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
-            ],
-            "type": "string",
-            "description": "Rakennuksen osan osittelun laji. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji"
-          },
-          "partitionDescription": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "civilDefenceShelter": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CivilDefenceShelter"
-            },
-            "description": "",
-            "nullable": true
-          },
-          "relatedFinishedBuildingSection": {
-            "type": "string",
-            "description": "",
-            "format": "uuid",
-            "nullable": true
-          },
-          "demolitionDate": {
-            "type": "string",
-            "description": "",
-            "format": "date",
-            "nullable": true
-          },
-          "reasonForDemolition": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-            ],
-            "type": "string",
-            "description": "Purkamisen syy. Käytetään koodistoa http://uri.suomi.fi/codelist/rytj/PurkamisenSyy",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Rakennuksen osa"
+        "additionalProperties": false
       },
       "BuildingServicesEngineeringData": {
         "type": "object",
@@ -5039,6 +5842,129 @@
         },
         "additionalProperties": false
       },
+      "ChangeInformationAreaToBeBuiltForSpecificActivitiesNoPersonData": {
+        "type": "object",
+        "properties": {
+          "areaToBeBuiltForSpecificActivitiesKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "specificActivitiesAreaType": {
+            "type": "string",
+            "nullable": true
+          },
+          "networkConnection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkConnection"
+            },
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "temporary": {
+            "type": "boolean"
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesignNoPersonData"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModelNoPersonData"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesignNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ChangeInformationBuilding": {
         "type": "object",
         "properties": {
@@ -5429,11 +6355,18 @@
       },
       "ChangeInformationBuildingPermitIssue": {
         "required": [
+          "dateOfInitiation",
           "lifeCycleState",
           "municipalityNumber"
         ],
         "type": "object",
         "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
           "lifeCycleState": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
@@ -5457,11 +6390,11 @@
               "constructionToBeStartedBy",
               "constructionToBeCompletedBy",
               "engagingParty",
+              "decisionDocument",
               "lifeCycleState",
               "decisionDate",
               "dateOfDecision",
               "dateOfValidityOfDecision",
-              "decisionDocument",
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
@@ -5559,11 +6492,6 @@
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
-          },
-          "dateOfInitiation": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
           }
         },
         "additionalProperties": false
@@ -5596,6 +6524,7 @@
           },
           "objectState": {
             "required": [
+              "dateOfInitiation",
               "lifeCycleState",
               "municipalityNumber"
             ],
@@ -5608,6 +6537,7 @@
           },
           "objectStatePrev": {
             "required": [
+              "dateOfInitiation",
               "lifeCycleState",
               "municipalityNumber"
             ],
@@ -5658,6 +6588,7 @@
           "objectKey": { },
           "objectState": {
             "required": [
+              "dateOfInitiation",
               "lifeCycleState",
               "municipalityNumber"
             ],
@@ -5889,6 +6820,11 @@
         "additionalProperties": false
       },
       "ChangeInformationConstructionAction": {
+        "required": [
+          "constructionActionKey",
+          "constructionActionType",
+          "statusOfConstructionAction"
+        ],
         "type": "object",
         "properties": {
           "constructionActionKey": {
@@ -5958,34 +6894,6 @@
             "format": "int32",
             "nullable": true
           },
-          "building": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationBuilding"
-              }
-            ],
-            "nullable": true
-          },
-          "structure": {
-            "required": [
-              "structureMainPurpose",
-              "buildingObjectType"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationStructure"
-              }
-            ],
-            "nullable": true
-          },
-          "areaToBeBuiltForSpecificActivities": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
-              }
-            ],
-            "nullable": true
-          },
           "startDate": {
             "type": "string",
             "format": "date",
@@ -6040,6 +6948,38 @@
             "format": "date",
             "nullable": true
           },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "nullable": true
+          },
           "locatedOnUnseparatedParcel": {
             "type": "boolean",
             "nullable": true
@@ -6047,10 +6987,860 @@
         },
         "additionalProperties": false
       },
+      "ChangeInformationDemolitionPermitIssue": {
+        "required": [
+          "dateOfInitiation",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
+            },
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "decisionDocument",
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationConstructionAction"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDemolitionPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "demolitionPermitApplication",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "demolitionPermitApplication",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssue"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDemolitionPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDemolitionPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "demolitionPermitApplication",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssueChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDeviationObject": {
+        "required": [
+          "address",
+          "buildingObjectType",
+          "deviationObjectKey"
+        ],
+        "type": "object",
+        "properties": {
+          "deviationObjectKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "totalArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot"
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDeviationPermitIssue": {
+        "required": [
+          "buildingSite",
+          "dateOfInitiation",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "recordNumber": {
+            "type": "string"
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "deviationPermitDecision": {
+            "required": [
+              "decisionDocument",
+              "engagingParty",
+              "deviationPermitDecisionKey",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitDecision"
+              }
+            ],
+            "description": "Poikkeamislupapäätös",
+            "nullable": true
+          },
+          "deviationPermitApplication": {
+            "required": [
+              "constructionDesign",
+              "deviationPermitApplicationKey",
+              "lifeCycleState",
+              "applicationContent",
+              "dateOfReception"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitApplication"
+              }
+            ],
+            "description": "Poikkeamislupahakemus",
+            "nullable": true
+          },
+          "deviationObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationDeviationObject"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDeviationPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssue"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDeviationPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationDeviationPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationDeviationPermitIssueChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationLandscapeWorkPermitIssue": {
+        "required": [
+          "buildingSite",
+          "dateOfInitiation",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "landscapeWorkPermitDecision": {
+            "required": [
+              "decisionDocument",
+              "engagingParty",
+              "landscapeWorkPermitDecisionKey",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandscapeWorkPermitDecision"
+              }
+            ],
+            "description": "Maisemalupapäätös",
+            "nullable": true
+          },
+          "landscapeWorkPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandscapeWorkPermitApplication"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationConstructionAction"
+            }
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationLandscapeWorkPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssue"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationLandscapeWorkPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationLandscapeWorkPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationLandscapeWorkPermitIssueChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "ChangeInformationStructure": {
         "required": [
+          "address",
           "buildingObjectType",
-          "structureMainPurpose"
+          "permanentStructureIdentifier",
+          "structureKey",
+          "structureMainPurpose",
+          "temporary"
         ],
         "type": "object",
         "properties": {
@@ -6172,21 +7962,6 @@
             "description": "Rakennuskohteen sijaintitiedot",
             "nullable": true
           },
-          "administrativeLocationUnit": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-              }
-            ]
-          },
-          "decisionAdministrativeLocationUnit": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-              }
-            ],
-            "nullable": true
-          },
           "address": {
             "type": "array",
             "items": {
@@ -6212,6 +7987,28 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
           "buildingObjectOwner": {
             "type": "array",
             "items": {
@@ -6219,13 +8016,127 @@
             },
             "description": "Rakennuskohteen omistaja",
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationStructureChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
           },
-          "structureSection": {
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/StructureSection"
-            },
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
             "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationStructureChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationStructureChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ChangeInformationStructureChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationStructureChangeDiffDto"
+            }
           }
         },
         "additionalProperties": false
@@ -6287,6 +8198,60 @@
             "format": "date",
             "nullable": true
           },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
           "decisionDocument": {
             "allOf": [
               {
@@ -6294,6 +8259,70 @@
               }
             ],
             "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "changePermitKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Muutospäätös"
+      },
+      "ChangePermitNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
             "nullable": true
           },
           "decisionArticle": {
@@ -6350,14 +8379,20 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
           "changePermitKey": {
             "type": "string",
-            "description": "",
             "format": "uuid"
           }
         },
-        "additionalProperties": false,
-        "description": "Muutospäätös"
+        "additionalProperties": false
       },
       "CivilDefenceShelter": {
         "required": [
@@ -6454,268 +8489,10 @@
         "additionalProperties": false,
         "description": "Väestönsuojan muut rakennukset"
       },
-      "ConstructionAction": {
-        "required": [
-          "constructionActionKey",
-          "constructionActionType",
-          "statusOfConstructionAction"
-        ],
-        "type": "object",
-        "properties": {
-          "constructionActionKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "constructionActionType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
-              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
-            ],
-            "type": "string",
-            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
-            "nullable": true
-          },
-          "buildingObjectChange": {
-            "required": [
-              "buildingObjectChangeKey"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingObjectChange"
-              }
-            ],
-            "description": "Rakennuskohteen muutos",
-            "nullable": true
-          },
-          "descriptionOfAction": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "areaUndergoingChanges": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "reasonForDemolition": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
-              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
-            ],
-            "type": "string",
-            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
-            "nullable": true
-          },
-          "renovation": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "renovationRate": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "building": {
-            "required": [
-              "buildingKey",
-              "permanentBuildingIdentifier",
-              "temporary",
-              "numberOfStoreys",
-              "buildingSection",
-              "mainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Building"
-              }
-            ],
-            "description": "Rakennuksen tiedot.",
-            "nullable": true
-          },
-          "finishedBuilding": {
-            "required": [
-              "buildingKey",
-              "permanentBuildingIdentifier",
-              "temporary",
-              "numberOfStoreys",
-              "buildingSection",
-              "mainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Building"
-              }
-            ],
-            "description": "Rakennuksen tiedot.",
-            "nullable": true
-          },
-          "structure": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          },
-          "finishedStructure": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          },
-          "areaToBeBuiltForSpecificActivities": {
-            "required": [
-              "areaToBeBuiltForSpecificActivitiesKey",
-              "specificActivitiesAreaType",
-              "temporary",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-              }
-            ],
-            "description": "Erityistä toimintaa varten rakennettava alue",
-            "nullable": true
-          },
-          "startDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "completionDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "commissioningDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "statusOfConstructionAction": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
-            ],
-            "type": "string",
-            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
-            "nullable": true
-          },
-          "fullyApprovedForUse": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "businessConstruction": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "changeType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
-              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
-              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
-            ],
-            "type": "string",
-            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
-            "nullable": true
-          },
-          "dvvPermitIdentifier": {
-            "type": "string",
-            "nullable": true
-          },
-          "expiryDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "finishedAreaToBeBuiltForSpecificActivities": {
-            "required": [
-              "areaToBeBuiltForSpecificActivitiesKey",
-              "specificActivitiesAreaType",
-              "temporary",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-              }
-            ],
-            "description": "Erityistä toimintaa varten rakennettava alue",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Rakentamistoimenpide"
-      },
       "ConstructionDesign": {
         "required": [
           "constructionDesignKey",
-          "constructionDesignType",
-          "document"
+          "constructionDesignType"
         ],
         "type": "object",
         "properties": {
@@ -6738,6 +8515,10 @@
         "description": "Rakennussuunnitelma"
       },
       "ConstructionDesignNoPersonData": {
+        "required": [
+          "constructionDesignKey",
+          "constructionDesignType"
+        ],
         "type": "object",
         "properties": {
           "constructionDesignKey": {
@@ -6816,6 +8597,42 @@
         },
         "additionalProperties": false,
         "description": "Rakentamishanke"
+      },
+      "ConstructionProjectNoPersonData": {
+        "type": "object",
+        "properties": {
+          "constructionProjectKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "descriptionOfConstructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "inspection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionNoPersonData"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "ContactAddress": {
         "required": [
@@ -7140,15 +8957,6 @@
             "format": "date",
             "nullable": true
           },
-          "decisionDocument": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            ],
-            "description": "Liiteasiakirja",
-            "nullable": true
-          },
           "decisionArticle": {
             "allOf": [
               {
@@ -7243,12 +9051,177 @@
               "$ref": "#/components/schemas/EngagingParty"
             },
             "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           }
         },
         "additionalProperties": false,
         "description": "Rakentamislupapäätös"
       },
-      "DemolitionPermitIssue": {
+      "DemolitionPermitDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "demolitionPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/01",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/02",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/03",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/04"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DemolitionPermitIssueNoPersonData": {
         "required": [
           "dateOfInitiation",
           "demolitionDecision",
@@ -7278,48 +9251,15 @@
           "municipalityNumber": {
             "type": "string"
           },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
           "demolitionPermitApplication": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/DemolitionPermitApplication"
             },
             "description": "Purkamislupahakemus",
-            "nullable": true
-          },
-          "demolitionDecision": {
-            "required": [
-              "demolitionPermitDecisionKey",
-              "lifeCycleState",
-              "decisionDate",
-              "dateOfDecision",
-              "dateOfValidityOfDecision",
-              "decisionDocument",
-              "publicNoticeDate",
-              "decisionText",
-              "decisionMakerType",
-              "decisionMakerFirstName",
-              "decisionMakerName"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DemolitionPermitDecision"
-              }
-            ],
-            "description": "Purkamislupapäätös",
-            "nullable": true
-          },
-          "extensionDecision": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExtensionDecision"
-            },
-            "nullable": true
-          },
-          "changePermit": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ChangePermit"
-            },
             "nullable": true
           },
           "buildingSite": {
@@ -7337,32 +9277,6 @@
             "description": "Rakennuspaikka",
             "nullable": true
           },
-          "constructionAction": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ConstructionAction"
-            },
-            "nullable": true
-          },
-          "attachment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "nullable": true
-          },
-          "constructionProject": {
-            "required": [
-              "constructionProjectKey"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ConstructionProject"
-              }
-            ],
-            "description": "Rakentamishanke",
-            "nullable": true
-          },
           "updateType": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
@@ -7373,7 +9287,6 @@
               "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
             ],
             "type": "string",
-            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
             "nullable": true
           },
           "updateDescription": {
@@ -7385,14 +9298,68 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
-          "permanentPermitIdentifier": {
-            "type": "string"
+          "demolitionDecision": {
+            "required": [
+              "decisionDocument",
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecisionNoPersonData"
+              }
+            ],
+            "description": "Purkamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecisionNoPersonData"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermitNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionActionNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProjectNoPersonData"
+              }
+            ],
+            "nullable": true
           }
         },
-        "additionalProperties": false,
-        "description": "Purkamislupa-asia"
+        "additionalProperties": false
       },
-      "DemolitionPermitIssueChangeDiffDto": {
+      "DemolitionPermitIssueNoPersonDataChangeDiffDto": {
         "type": "object",
         "properties": {
           "changeType": {
@@ -7420,40 +9387,38 @@
           },
           "objectState": {
             "required": [
-              "demolitionPermitApplication",
               "demolitionDecision",
+              "demolitionPermitApplication",
               "dateOfInitiation",
               "lifeCycleState",
               "municipalityNumber"
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DemolitionPermitIssue"
+                "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonData"
               }
             ],
-            "description": "Purkamislupa-asia",
             "nullable": true
           },
           "objectStatePrev": {
             "required": [
-              "demolitionPermitApplication",
               "demolitionDecision",
+              "demolitionPermitApplication",
               "dateOfInitiation",
               "lifeCycleState",
               "municipalityNumber"
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DemolitionPermitIssue"
+                "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonData"
               }
             ],
-            "description": "Purkamislupa-asia",
             "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "DemolitionPermitIssueChangeInfoCollectionDto": {
+      "DemolitionPermitIssueNoPersonDataChangeInfoCollectionDto": {
         "type": "object",
         "properties": {
           "lastSeen": {
@@ -7470,13 +9435,13 @@
           "changes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DemolitionPermitIssueChangeInfoDto"
+              "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonDataChangeInfoDto"
             }
           }
         },
         "additionalProperties": false
       },
-      "DemolitionPermitIssueChangeInfoDto": {
+      "DemolitionPermitIssueNoPersonDataChangeInfoDto": {
         "type": "object",
         "properties": {
           "eventId": {
@@ -7490,24 +9455,23 @@
           "objectKey": { },
           "objectState": {
             "required": [
-              "demolitionPermitApplication",
               "demolitionDecision",
+              "demolitionPermitApplication",
               "dateOfInitiation",
               "lifeCycleState",
               "municipalityNumber"
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DemolitionPermitIssue"
+                "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonData"
               }
             ],
-            "description": "Purkamislupa-asia",
             "nullable": true
           },
           "diff": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DemolitionPermitIssueChangeDiffDto"
+              "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonDataChangeDiffDto"
             }
           }
         },
@@ -7531,11 +9495,9 @@
         },
         "additionalProperties": false
       },
-      "DeviationObject": {
+      "DeviationObjectNoPersonData": {
         "required": [
           "address",
-          "administrativeLocationUnit",
-          "buildingObjectOwner",
           "buildingObjectType",
           "deviationObjectKey"
         ],
@@ -7570,38 +9532,6 @@
             ],
             "description": "Rakennuskohteen sijaintitiedot"
           },
-          "administrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö"
-          },
-          "decisionAdministrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö",
-            "nullable": true
-          },
-          "buildingObjectOwner": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingObjectOwner"
-            },
-            "description": "Rakennuskohteen omistaja"
-          },
           "address": {
             "type": "array",
             "items": {
@@ -7625,10 +9555,25 @@
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false,
-        "description": "Poikkeamisen kohde"
+        "description": "Poikkeamisen kohde ilman henkilötietoja"
       },
       "DeviationPermitApplication": {
         "required": [
@@ -7684,6 +9629,61 @@
         },
         "additionalProperties": false,
         "description": "Poikkeamislupahakemus"
+      },
+      "DeviationPermitApplicationNoPersonData": {
+        "required": [
+          "applicationContent",
+          "constructionDesign",
+          "dateOfReception",
+          "deviationPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "deviationPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModelNoPersonData"
+            }
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesignNoPersonData"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupahakemus ilman henkilötietoja"
       },
       "DeviationPermitDecision": {
         "required": [
@@ -7744,13 +9744,149 @@
             "format": "date",
             "nullable": true
           },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "deviationPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "format": "date"
+          },
           "decisionDocument": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
               }
             ],
-            "description": "Liiteasiakirja",
+            "description": "",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "description": ""
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupapäätös"
+      },
+      "DeviationPermitDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "deviationPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
             "nullable": true
           },
           "decisionArticle": {
@@ -7809,38 +9945,32 @@
           },
           "deviationPermitDecisionKey": {
             "type": "string",
-            "description": "",
             "format": "uuid"
           },
           "expiryDate": {
             "type": "string",
-            "description": "",
             "format": "date",
             "nullable": true
           },
-          "engagingParty": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EngagingParty"
-            },
-            "description": ""
-          },
           "decisionInForceUntil": {
             "type": "string",
-            "description": "",
             "format": "date"
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
           }
         },
-        "additionalProperties": false,
-        "description": "Poikkeamislupapäätös"
+        "additionalProperties": false
       },
-      "DeviationPermitIssue": {
+      "DeviationPermitIssueNoPersonData": {
         "required": [
           "buildingSite",
           "dateOfInitiation",
-          "deviationObject",
-          "deviationPermitApplication",
-          "deviationPermitDecision",
           "lifeCycleState",
           "municipalityNumber",
           "permanentPermitIdentifier"
@@ -7873,50 +10003,6 @@
           "recordNumber": {
             "type": "string"
           },
-          "deviationPermitDecision": {
-            "required": [
-              "deviationPermitDecisionKey",
-              "engagingParty",
-              "decisionInForceUntil",
-              "lifeCycleState",
-              "decisionDate",
-              "dateOfDecision",
-              "dateOfValidityOfDecision",
-              "decisionDocument",
-              "publicNoticeDate",
-              "decisionText",
-              "decisionMakerType",
-              "decisionMakerFirstName",
-              "decisionMakerName"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DeviationPermitDecision"
-              }
-            ],
-            "description": "Poikkeamislupapäätös"
-          },
-          "deviationPermitApplication": {
-            "required": [
-              "deviationPermitApplicationKey",
-              "constructionDesign",
-              "lifeCycleState",
-              "applicationContent",
-              "dateOfReception"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DeviationPermitApplication"
-              }
-            ],
-            "description": "Poikkeamislupahakemus"
-          },
-          "deviationObject": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DeviationObject"
-            }
-          },
           "buildingSite": {
             "required": [
               "buildingSiteKey",
@@ -7930,13 +10016,6 @@
               }
             ],
             "description": "Rakennuspaikka"
-          },
-          "attachment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "nullable": true
           },
           "updateType": {
             "enum": [
@@ -7958,12 +10037,63 @@
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
+          },
+          "deviationPermitDecision": {
+            "required": [
+              "decisionDocument",
+              "deviationPermitDecisionKey",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitDecisionNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "deviationPermitApplication": {
+            "required": [
+              "constructionDesign",
+              "deviationPermitApplicationKey",
+              "lifeCycleState",
+              "applicationContent",
+              "dateOfReception"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitApplicationNoPersonData"
+              }
+            ],
+            "description": "Poikkeamislupahakemus ilman henkilötietoja",
+            "nullable": true
+          },
+          "deviationObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationObjectNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
           }
         },
-        "additionalProperties": false,
-        "description": "Poikkeamislupa-asia"
+        "additionalProperties": false
       },
-      "DeviationPermitIssueChangeDiffDto": {
+      "DeviationPermitIssueNoPersonDataChangeDiffDto": {
         "type": "object",
         "properties": {
           "changeType": {
@@ -7992,9 +10122,6 @@
           "objectState": {
             "required": [
               "permanentPermitIdentifier",
-              "deviationPermitDecision",
-              "deviationPermitApplication",
-              "deviationObject",
               "buildingSite",
               "dateOfInitiation",
               "lifeCycleState",
@@ -8002,18 +10129,14 @@
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DeviationPermitIssue"
+                "$ref": "#/components/schemas/DeviationPermitIssueNoPersonData"
               }
             ],
-            "description": "Poikkeamislupa-asia",
             "nullable": true
           },
           "objectStatePrev": {
             "required": [
               "permanentPermitIdentifier",
-              "deviationPermitDecision",
-              "deviationPermitApplication",
-              "deviationObject",
               "buildingSite",
               "dateOfInitiation",
               "lifeCycleState",
@@ -8021,16 +10144,15 @@
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DeviationPermitIssue"
+                "$ref": "#/components/schemas/DeviationPermitIssueNoPersonData"
               }
             ],
-            "description": "Poikkeamislupa-asia",
             "nullable": true
           }
         },
         "additionalProperties": false
       },
-      "DeviationPermitIssueChangeInfoCollectionDto": {
+      "DeviationPermitIssueNoPersonDataChangeInfoCollectionDto": {
         "type": "object",
         "properties": {
           "lastSeen": {
@@ -8047,13 +10169,13 @@
           "changes": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DeviationPermitIssueChangeInfoDto"
+              "$ref": "#/components/schemas/DeviationPermitIssueNoPersonDataChangeInfoDto"
             }
           }
         },
         "additionalProperties": false
       },
-      "DeviationPermitIssueChangeInfoDto": {
+      "DeviationPermitIssueNoPersonDataChangeInfoDto": {
         "type": "object",
         "properties": {
           "eventId": {
@@ -8068,9 +10190,6 @@
           "objectState": {
             "required": [
               "permanentPermitIdentifier",
-              "deviationPermitDecision",
-              "deviationPermitApplication",
-              "deviationObject",
               "buildingSite",
               "dateOfInitiation",
               "lifeCycleState",
@@ -8078,16 +10197,15 @@
             ],
             "allOf": [
               {
-                "$ref": "#/components/schemas/DeviationPermitIssue"
+                "$ref": "#/components/schemas/DeviationPermitIssueNoPersonData"
               }
             ],
-            "description": "Poikkeamislupa-asia",
             "nullable": true
           },
           "diff": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/DeviationPermitIssueChangeDiffDto"
+              "$ref": "#/components/schemas/DeviationPermitIssueNoPersonDataChangeDiffDto"
             }
           }
         },
@@ -8668,6 +10786,60 @@
             "format": "date",
             "nullable": true
           },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
           "decisionDocument": {
             "allOf": [
               {
@@ -8675,6 +10847,70 @@
               }
             ],
             "description": "Liiteasiakirja",
+            "nullable": true
+          },
+          "extensionDecisionKey": {
+            "type": "string",
+            "description": "",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Jatkoaikapäätös"
+      },
+      "ExtensionDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
             "nullable": true
           },
           "decisionArticle": {
@@ -8731,14 +10967,20 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
           "extensionDecisionKey": {
             "type": "string",
-            "description": "",
             "format": "uuid"
           }
         },
-        "additionalProperties": false,
-        "description": "Jatkoaikapäätös"
+        "additionalProperties": false
       },
       "ExteriorData": {
         "type": "object",
@@ -8767,6 +11009,14 @@
               }
             ],
             "description": "",
+            "nullable": true
+          },
+          "shape3d": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry3d"
+              }
+            ],
             "nullable": true
           },
           "relationToGroundLevel": {
@@ -8953,6 +11203,2029 @@
         },
         "additionalProperties": false,
         "description": "Rakennelmaviite"
+      },
+      "GeneralizedBuilding": {
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingSection"
+            },
+            "nullable": true
+          },
+          "mainPurpose": {
+            "type": "string",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "buildingObjectOwner": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectOwner"
+            },
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "mainPurpose1994": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfNewApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfDeletedApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingNoPersonData": {
+        "type": "object",
+        "properties": {
+          "buildingKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permanentBuildingIdentifier": {
+            "type": "string"
+          },
+          "temporary": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "demolitionDeadline": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "numberOfStoreys": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "buildingSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingSectionNoPersonData"
+            },
+            "nullable": true
+          },
+          "mainPurpose": {
+            "type": "string",
+            "nullable": true
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string"
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot",
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "addChangeEvent": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "mainPurpose1994": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfNewApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "numberOfDeletedApartments": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingNoPersonDataChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingNoPersonDataChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingNoPersonDataChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingNoPersonDataChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingNoPersonDataChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssue": {
+        "required": [
+          "dateOfInitiation",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "decision": {
+            "required": [
+              "buildingPermitDecisionKey",
+              "constructionToBeStartedBy",
+              "constructionToBeCompletedBy",
+              "engagingParty",
+              "decisionDocument",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "buildingPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPermitApplication"
+            },
+            "description": "Rakentamislupahakemus",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionAction"
+            }
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueNoPersonData": {
+        "required": [
+          "dateOfInitiation",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "decision": {
+            "required": [
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingPermitDecisionNoPersonData"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecisionNoPersonData"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermitNoPersonData"
+            },
+            "nullable": true
+          },
+          "buildingPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPermitApplication"
+            },
+            "description": "Rakentamislupahakemus",
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionActionNoPersonData"
+            }
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProjectNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "description": "Rakentamislupa-asian päivityksen tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueNoPersonDataChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueNoPersonDataChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonDataChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingPermitIssueNoPersonDataChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedBuildingPermitIssueNoPersonDataChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingSection": {
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "Materiaalitiedot",
+            "nullable": true
+          },
+          "energyData": {
+            "required": [
+              "energyDataKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyData"
+              }
+            ],
+            "description": "Energiatiedot",
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "Sisätilojen tiedot",
+            "nullable": true
+          },
+          "exteriorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "Ulkokuoren tiedot",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "Talotekniikkatiedot",
+            "nullable": true
+          },
+          "usageData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedUsageData"
+              }
+            ]
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
+            },
+            "nullable": true
+          },
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
+            },
+            "nullable": true
+          },
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
+            },
+            "nullable": true
+          },
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
+            },
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationApartment"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesign"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedBuildingSectionNoPersonData": {
+        "type": "object",
+        "properties": {
+          "buildingSectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/01",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/02",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/03",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/04",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/05",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/06",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/07",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/08",
+              "http://uri.suomi.fi/codelist/rakrek/rakelinvaih/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "protectionMethod": {
+            "type": "string",
+            "nullable": true
+          },
+          "cultureHistoricalSignificance": {
+            "type": "string",
+            "nullable": true
+          },
+          "materialData": {
+            "required": [
+              "constructionMethod",
+              "buildingMaterialOfLoadBearingStructures",
+              "facadeMaterial",
+              "wideBodiedBuilding"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MaterialData"
+              }
+            ],
+            "description": "Materiaalitiedot",
+            "nullable": true
+          },
+          "energyData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EnergyDataNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "interiorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InteriorData"
+              }
+            ],
+            "description": "Sisätilojen tiedot",
+            "nullable": true
+          },
+          "exteriorData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExteriorData"
+              }
+            ],
+            "description": "Ulkokuoren tiedot",
+            "nullable": true
+          },
+          "buildingServicesEngineeringData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingServicesEngineeringData"
+              }
+            ],
+            "description": "Talotekniikkatiedot",
+            "nullable": true
+          },
+          "usageData": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedUsageData"
+              }
+            ]
+          },
+          "equipment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Equipment"
+            },
+            "nullable": true
+          },
+          "entrance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entrance"
+            },
+            "nullable": true
+          },
+          "assemblyFacility": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AssemblyFacility"
+            },
+            "nullable": true
+          },
+          "elevator": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Elevator"
+            },
+            "nullable": true
+          },
+          "apartment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationApartment"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesignNoPersonData"
+            },
+            "nullable": true
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModelNoPersonData"
+            },
+            "nullable": true
+          },
+          "specialDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SpecialDesignNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          },
+          "partitionReason": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rak-osittelun-laji/code/3"
+            ],
+            "type": "string"
+          },
+          "partitionDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "civilDefenceShelter": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CivilDefenceShelter"
+            },
+            "nullable": true
+          },
+          "relatedFinishedBuildingSection": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedConstructionAction": {
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "finishedBuilding": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "locatedOnUnseparatedParcel": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedConstructionActionNoPersonData": {
+        "type": "object",
+        "properties": {
+          "constructionActionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionActionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide/code/09"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpide. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide\">http://uri.suomi.fi/codelist/rytj/Rakentamistoimenpide</a>",
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "required": [
+              "buildingObjectChangeKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectChange"
+              }
+            ],
+            "description": "Rakennuskohteen muutos",
+            "nullable": true
+          },
+          "descriptionOfAction": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "areaUndergoingChanges": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "reasonForDemolition": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/01",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/02",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/03",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/04",
+              "http://uri.suomi.fi/codelist/rytj/PurkamisenSyy/code/05"
+            ],
+            "type": "string",
+            "description": "Purkamisen syy. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/PurkamisenSyy\">http://uri.suomi.fi/codelist/rytj/PurkamisenSyy</a>",
+            "nullable": true
+          },
+          "renovation": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "renovationRate": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "finishedBuilding": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StructureNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivitiesNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "completionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "statusOfConstructionAction": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/4",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila/code/5"
+            ],
+            "type": "string",
+            "description": "Rakentamistoimenpiteen tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila\">http://uri.suomi.fi/codelist/rytj/rakkohteen-toimenpiteen-tila</a>",
+            "nullable": true
+          },
+          "fullyApprovedForUse": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "businessConstruction": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "changeType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/01",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/02",
+              "http://uri.suomi.fi/codelist/rytj/muutostyo/code/03"
+            ],
+            "type": "string",
+            "description": "Muutostyön tarkenne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/muutostyo\">http://uri.suomi.fi/codelist/rytj/muutostyo</a>",
+            "nullable": true
+          },
+          "dvvPermitIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "locatedOnUnseparatedParcel": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedDemolitionPermitIssue": {
+        "required": [
+          "dateOfInitiation",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
+            },
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "decisionDocument",
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionAction"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedDemolitionPermitIssueChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "demolitionPermitApplication",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "demolitionPermitApplication",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedDemolitionPermitIssueChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssueChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedDemolitionPermitIssueChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "demolitionPermitApplication",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssueChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedPurpose": {
+        "type": "object",
+        "properties": {
+          "purposeKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedUsageData": {
+        "type": "object",
+        "properties": {
+          "commissioningDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "usageStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/01",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/02",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/03",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/04",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/05",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/06",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/07",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/08",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/09",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/10",
+              "http://uri.suomi.fi/codelist/vtj/rake_kaytossaolotilanne/code/11"
+            ],
+            "type": "string",
+            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
+            "nullable": true
+          },
+          "purpose": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedPurpose"
+            },
+            "nullable": true
+          },
+          "usefulFloorArea": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "intendedWorkingLife": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "plannedUserCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "GeoJsonGeometry": {
         "type": "object",
@@ -9223,12 +13496,14 @@
         "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
       },
       "GetChangeInfo": {
+        "required": [
+          "eventId"
+        ],
         "type": "object",
         "properties": {
           "eventId": {
             "type": "string",
-            "format": "uuid",
-            "nullable": true
+            "format": "uuid"
           },
           "objectKey": {
             "type": "string",
@@ -9614,6 +13889,105 @@
         },
         "additionalProperties": false
       },
+      "InspectionNoPersonData": {
+        "type": "object",
+        "properties": {
+          "inspectionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "inspectionType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/06",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/07",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/08",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/09",
+              "http://uri.suomi.fi/codelist/rytj/Katselmuslaji/code/10"
+            ],
+            "type": "string",
+            "description": "Katselmuksen laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/Katselmuslaji\">http://uri.suomi.fi/codelist/rytj/Katselmuslaji</a>"
+          },
+          "inspectionDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "requiredByPermitRegulations": {
+            "type": "boolean"
+          },
+          "partiality": {
+            "type": "string"
+          },
+          "inspectionStatus": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/01",
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/02",
+              "http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne/code/03"
+            ],
+            "type": "string",
+            "description": "Katselmuksen tilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne\">http://uri.suomi.fi/codelist/rytj/KatselmuksenTilanne</a>"
+          },
+          "buildingReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionBuildingReference"
+            },
+            "nullable": true
+          },
+          "structureReference": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InspectionStructureReference"
+            },
+            "nullable": true
+          },
+          "specificAreaReference": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "nullable": true
+          },
+          "buildingObjectChange": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingObjectChange"
+            },
+            "nullable": true
+          },
+          "specificationOfObjectOfInspection": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "inspectionRemarks": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "buildingsAttachmentDocument": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "InspectionStructureReference": {
         "required": [
           "permanentStructureIdentifierReference"
@@ -9655,6 +14029,680 @@
         },
         "additionalProperties": false,
         "description": "Sisätilojen tiedot"
+      },
+      "LandscapeWorkPermitApplication": {
+        "required": [
+          "applicationContent",
+          "dateOfReception",
+          "landscapeWorkPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "landscapeWorkPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModel"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesign"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Maisematyölupahakemus"
+      },
+      "LandscapeWorkPermitApplicationNoPersonData": {
+        "required": [
+          "applicationContent",
+          "dateOfReception",
+          "landscapeWorkPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "landscapeWorkPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModelNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesignNoPersonData"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandscapeWorkPermitDecision": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "engagingParty",
+          "landscapeWorkPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "landscapeWorkPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "format": "date"
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "description": ""
+          }
+        },
+        "additionalProperties": false,
+        "description": "Maisemalupapäätös"
+      },
+      "LandscapeWorkPermitDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "landscapeWorkPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "landscapeWorkPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "format": "date"
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandscapeWorkPermitIssueNoPersonData": {
+        "required": [
+          "buildingSite",
+          "dateOfInitiation",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "landscapeWorkPermitDecision": {
+            "required": [
+              "decisionDocument",
+              "landscapeWorkPermitDecisionKey",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandscapeWorkPermitDecisionNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "landscapeWorkPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandscapeWorkPermitApplicationNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionActionNoPersonData"
+            }
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecisionNoPersonData"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermitNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProjectNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandscapeWorkPermitIssueNoPersonDataChangeDiffDto": {
+        "type": "object",
+        "properties": {
+          "changeType": {
+            "type": "string"
+          },
+          "objectKey": {
+            "nullable": true
+          },
+          "objectType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "nullable": true
+          },
+          "parentType": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentChain": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParentTypeKey"
+            }
+          },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "objectStatePrev": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandscapeWorkPermitIssueNoPersonDataChangeInfoCollectionDto": {
+        "type": "object",
+        "properties": {
+          "lastSeen": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationToken"
+              }
+            ],
+            "nullable": true
+          },
+          "upToDate": {
+            "type": "boolean"
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonDataChangeInfoDto"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "LandscapeWorkPermitIssueNoPersonDataChangeInfoDto": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "eventTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "objectKey": { },
+          "objectState": {
+            "required": [
+              "permanentPermitIdentifier",
+              "buildingSite",
+              "dateOfInitiation",
+              "lifeCycleState",
+              "municipalityNumber"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "diff": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LandscapeWorkPermitIssueNoPersonDataChangeDiffDto"
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "LanguageString": {
         "type": "object",
@@ -10468,6 +15516,42 @@
         },
         "additionalProperties": false
       },
+      "RyhtiGeometry3d": {
+        "required": [
+          "geometryData3d",
+          "srid3d"
+        ],
+        "type": "object",
+        "properties": {
+          "srid3d": {
+            "enum": [
+              "3067",
+              "3873",
+              "3874",
+              "3875",
+              "3876",
+              "3877",
+              "3878",
+              "3879",
+              "3880",
+              "3881",
+              "3882",
+              "3883",
+              "3884",
+              "3885",
+              "4326"
+            ],
+            "type": "string",
+            "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
+          },
+          "geometryData3d": {
+            "minLength": 1,
+            "type": "string",
+            "description": "3d-geometria wkt-string"
+          }
+        },
+        "additionalProperties": false
+      },
       "SpecialDesign": {
         "required": [
           "document",
@@ -10532,17 +15616,13 @@
         },
         "additionalProperties": false
       },
-      "Structure": {
+      "StructureNoPersonData": {
         "required": [
           "address",
-          "administrativeLocationUnit",
-          "buildingObjectOwner",
           "buildingObjectType",
-          "location",
           "permanentStructureIdentifier",
           "structureKey",
           "structureMainPurpose",
-          "structureSection",
           "temporary"
         ],
         "type": "object",
@@ -10568,13 +15648,6 @@
             "format": "int32",
             "nullable": true
           },
-          "structureSection": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StructureSection"
-            },
-            "nullable": true
-          },
           "structureMainPurpose": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
@@ -10670,344 +15743,6 @@
               }
             ],
             "description": "Rakennuskohteen sijaintitiedot",
-            "nullable": true
-          },
-          "administrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö"
-          },
-          "decisionAdministrativeLocationUnit": {
-            "required": [
-              "administrativeLocationUnitKey",
-              "propertyIdentifier"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AdministrativeLocationUnit"
-              }
-            ],
-            "description": "Hallinnollinen sijaintiyksikkö",
-            "nullable": true
-          },
-          "buildingObjectOwner": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingObjectOwner"
-            },
-            "description": "Rakennuskohteen omistaja",
-            "nullable": true
-          },
-          "address": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Address"
-            },
-            "nullable": true
-          },
-          "name": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "description": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Rakennelma"
-      },
-      "StructureChangeDiffDto": {
-        "type": "object",
-        "properties": {
-          "changeType": {
-            "type": "string"
-          },
-          "objectKey": {
-            "nullable": true
-          },
-          "objectType": {
-            "type": "string",
-            "nullable": true
-          },
-          "parentKey": {
-            "nullable": true
-          },
-          "parentType": {
-            "type": "string",
-            "nullable": true
-          },
-          "parentChain": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ParentTypeKey"
-            }
-          },
-          "objectState": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          },
-          "objectStatePrev": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "StructureChangeInfoCollectionDto": {
-        "type": "object",
-        "properties": {
-          "lastSeen": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PaginationToken"
-              }
-            ],
-            "nullable": true
-          },
-          "upToDate": {
-            "type": "boolean"
-          },
-          "changes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StructureChangeInfoDto"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "StructureChangeInfoDto": {
-        "type": "object",
-        "properties": {
-          "eventId": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "eventTime": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "objectKey": { },
-          "objectState": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          },
-          "diff": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StructureChangeDiffDto"
-            }
-          }
-        },
-        "additionalProperties": false
-      },
-      "StructureNoPersonData": {
-        "required": [
-          "buildingObjectType",
-          "structureMainPurpose"
-        ],
-        "type": "object",
-        "properties": {
-          "structureKey": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "permanentStructureIdentifier": {
-            "type": "string"
-          },
-          "temporary": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "demolitionDeadline": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "numberOfStoreys": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "structureMainPurpose": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/001",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/002",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/003",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/004",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/005",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/006",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/007",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/008",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/009",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/010",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/011",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/012",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/013",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/014",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/015",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/016",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/017",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/018",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/019",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/020",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/021",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/022",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/023",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/024",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/025",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/026",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/027",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/028",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/029",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/030",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/031",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/032",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/033",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/034",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/035",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/036",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/037",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/038",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/039",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/040",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/041",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/042",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/043",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/044",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/045",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/046",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/047",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/048",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/049",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/050",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/051",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/052",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/053",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/054",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/055",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/056",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/057",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/058",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/059",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/060",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/061",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/062",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/063",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/064",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/065",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/066",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/067",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/068",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/069",
-              "http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus/code/070"
-            ],
-            "type": "string",
-            "description": "Rakennelman käyttötarkoitus. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus\">http://uri.suomi.fi/codelist/rytj/RakennelmanKayttotarkoitus</a>"
-          },
-          "buildingObjectType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
-              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
-            ],
-            "type": "string",
-            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
-          },
-          "location": {
-            "required": [
-              "buildingObjectLocationDataKey",
-              "pointLocation"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingObjectLocationData"
-              }
-            ],
-            "description": "Rakennuskohteen sijaintitiedot",
-            "nullable": true
-          },
-          "administrativeLocationUnit": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-              }
-            ]
-          },
-          "decisionAdministrativeLocationUnit": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-              }
-            ],
             "nullable": true
           },
           "address": {
@@ -11041,6 +15776,21 @@
               "$ref": "#/components/schemas/StructureSectionNoPersonData"
             },
             "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -11073,8 +15823,12 @@
           },
           "objectState": {
             "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
               "structureMainPurpose",
-              "buildingObjectType"
+              "buildingObjectType",
+              "address"
             ],
             "allOf": [
               {
@@ -11085,8 +15839,12 @@
           },
           "objectStatePrev": {
             "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
               "structureMainPurpose",
-              "buildingObjectType"
+              "buildingObjectType",
+              "address"
             ],
             "allOf": [
               {
@@ -11135,8 +15893,12 @@
           "objectKey": { },
           "objectState": {
             "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
               "structureMainPurpose",
-              "buildingObjectType"
+              "buildingObjectType",
+              "address"
             ],
             "allOf": [
               {

--- a/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Muutostietopalvelu OpenApi Beta.json
@@ -1434,6 +1434,454 @@
         }
       }
     },
+    "/api/ChangeInformation/BuildingPersonsLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae rakennuksen muutostiedot ilman turvakiellollisia toimijoita.",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/StructurePersonsLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae rakennelmien muutostiedot ilman turvakiellollisia toimijoita.",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/OperatorPersonLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae toimijoiden muutostiedot ilman turvakiellollisia toimijoita.",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ChangeInformation/BuildingPermitPersonsLimited": {
+      "post": {
+        "tags": [
+          "ChangeInformation"
+        ],
+        "summary": "Hae rakennuslupien muutostiedot turvakiellolliset tiedot käsiteltynä",
+        "parameters": [
+          {
+            "name": "municipality",
+            "in": "query",
+            "description": "Kuntanumerot joista muutoksia halutaan. Eroteltu pilkulla.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Viimeisin ID muutostentietojen hakemiseksi.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/GetChangeInfo"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingChangeInfoCollectionDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Content",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/InitialInformation/Building": {
       "post": {
         "tags": [
@@ -3649,6 +4097,7 @@
       "BuildingPermitApplication": {
         "required": [
           "applicationContent",
+          "buildingPermitApplicationType",
           "dateOfReception",
           "lifeCycleState",
           "permitApplicationKey",
@@ -3694,6 +4143,20 @@
             ],
             "type": "string",
             "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          },
+          "buildingPermitApplicationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/04",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/05",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/06",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/07"
+            ],
+            "type": "string",
+            "description": "Rakentamislupahakemuksen hakemustyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi\">http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi</a>",
             "nullable": true
           }
         },

--- a/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
@@ -403,6 +403,107 @@
         }
       }
     },
+    "/api/BuildingPersonsLimited/{permanentBuildingIdentifier}": {
+      "get": {
+        "tags": [
+          "Building"
+        ],
+        "summary": "Hae karkeutettu rakennustieto ilman turvakiellollisten toimijoiden tietoja.",
+        "parameters": [
+          {
+            "name": "permanentBuildingIdentifier",
+            "in": "path",
+            "description": "Rakennuskohteen pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakennuskohteen haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingNoPersonData"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakennuskohdetta ei löytynyt pysyvällä rakennustunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakennuskohteen tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/BuildingObject/Validate": {
       "post": {
         "tags": [
@@ -1069,6 +1170,105 @@
           }
         }
       },
+      "get": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Hae rakentamislupa-asia.",
+        "parameters": [
+          {
+            "name": "buildingPermitId",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakentamisluvan hakeminen onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
       "put": {
         "tags": [
           "BuildingPermit"
@@ -1210,106 +1410,6 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomValidationProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/BuildingPermit/{permitId}": {
-      "get": {
-        "tags": [
-          "BuildingPermit"
-        ],
-        "summary": "Hae rakentamislupa-asia.",
-        "parameters": [
-          {
-            "name": "permitId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Rakentamisluvan hakeminen onnistui.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ChangeInformationBuildingPermitIssue"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Käyttäjältä puuttuu tarvittava scope.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -1519,6 +1619,107 @@
         }
       }
     },
+    "/api/BuildingPermitPersonsLimited/{buildingPermitId}": {
+      "get": {
+        "tags": [
+          "BuildingPermit"
+        ],
+        "summary": "Hae karkeutettu rakentamislupa-asia ilman turvakiellollisten toimijoiden tietoja.",
+        "parameters": [
+          {
+            "name": "buildingPermitId",
+            "in": "path",
+            "description": "Rakentamislupa-asian pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Karkeutetun rakentamisluvan hakeminen onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedBuildingPermitIssue"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakentamislupaa ei löytynyt pysyvällä rakentamislupatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakentamisluvan tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/DemolitionPermit/Validate": {
       "post": {
         "tags": [
@@ -1531,8 +1732,8 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1548,8 +1749,8 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1565,8 +1766,8 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1652,8 +1853,8 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1669,8 +1870,8 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1686,8 +1887,8 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1773,7 +1974,7 @@
         "tags": [
           "DemolitionPermit"
         ],
-        "summary": "Hae purkamislupa-asia. Määrittely kesken. Rakenne tarkentuu myöhemmin.",
+        "summary": "Hae purkamislupa-asia.",
         "parameters": [
           {
             "name": "demolitionPermitId",
@@ -1853,8 +2054,8 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1870,8 +2071,8 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1887,8 +2088,8 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "demolitionPermitApplication",
                   "demolitionDecision",
+                  "demolitionPermitApplication",
                   "dateOfInitiation",
                   "lifeCycleState",
                   "municipalityNumber"
@@ -1951,6 +2152,198 @@
         }
       }
     },
+    "/api/DemolitionPermitGeneralized/{demolitionPermitId}": {
+      "get": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Hae karkeutettu purkamislupa-asia.",
+        "parameters": [
+          {
+            "name": "demolitionPermitId",
+            "in": "path",
+            "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Purkamislupa löytyi ja se palautettiin."
+          },
+          "400": {
+            "description": "Purkamisluvan hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamisluvan haku epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DemolitionPermitPersonsLimited/{demolitionPermitId}": {
+      "get": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Hae karkeutettu purkamislupa-asia ilman turvakiellollisten toimijoiden tietoja.",
+        "parameters": [
+          {
+            "name": "demolitionPermitId",
+            "in": "path",
+            "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Purkamislupa löytyi ja se palautettiin."
+          },
+          "400": {
+            "description": "Purkamisluvan hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamisluvan haku epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DemolitionPermitNoPersons/{demolitionPermitId}": {
+      "get": {
+        "tags": [
+          "DemolitionPermit"
+        ],
+        "summary": "Hae karkeutettu purkamislupa-asia, josta on poistettu henkilötiedot.",
+        "parameters": [
+          {
+            "name": "demolitionPermitId",
+            "in": "path",
+            "description": "Purkamisluvan yksilöivä pysyvä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Purkamislupa löytyi ja se palautettiin."
+          },
+          "400": {
+            "description": "Purkamisluvan hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Purkamisluvan haku epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/DeviationPermit/Validate": {
       "post": {
         "tags": [
@@ -1962,10 +2355,10 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -1982,10 +2375,10 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2002,10 +2395,10 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2091,10 +2484,10 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2111,10 +2504,10 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2131,10 +2524,10 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2337,10 +2730,10 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2357,10 +2750,10 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2377,10 +2770,10 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "deviationPermitDecision",
                   "deviationPermitApplication",
                   "deviationObject",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2457,6 +2850,208 @@
               "text/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DeviationPermitPersonsLimited/{permanentPermitId}": {
+      "get": {
+        "tags": [
+          "DeviationPermit"
+        ],
+        "summary": "Hae karkeutettu poikkeamislupa-asia ilman turvakiellollisten toimijoiden tietoja.",
+        "parameters": [
+          {
+            "name": "permanentPermitId",
+            "in": "path",
+            "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Poikkeamislupa-asia löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssue"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Poikkeamuslupa-asiaa ei löytynyt pysyvällä tunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea poikkeamuslupa-asian tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/DeviationPermitNoPersons/{permanentPermitId}": {
+      "get": {
+        "tags": [
+          "DeviationPermit"
+        ],
+        "summary": "Hae karkeutettu poikkeamislupa-asia, josta on poistettu henkilötiedot.",
+        "parameters": [
+          {
+            "name": "permanentPermitId",
+            "in": "path",
+            "description": "Poikkeamisluvan pysyvä yksilöivä lupatunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Poikkeamislupa-asia löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueNoPersonData"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueNoPersonData"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviationPermitIssueNoPersonData"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Poikkeamuslupa-asiaa ei löytynyt pysyvällä tunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea poikkeamuslupa-asian tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -2793,10 +3388,10 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2813,10 +3408,10 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2833,10 +3428,10 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2923,10 +3518,10 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2943,10 +3538,10 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -2963,10 +3558,10 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -3150,10 +3745,10 @@
             "application/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -3170,10 +3765,10 @@
             "text/json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -3190,10 +3785,10 @@
             "application/*+json": {
               "schema": {
                 "required": [
-                  "permanentPermitIdentifier",
                   "landscapeWorkPermitDecision",
                   "landscapeWorkPermitApplication",
                   "constructionAction",
+                  "permanentPermitIdentifier",
                   "buildingSite",
                   "dateOfInitiation",
                   "lifeCycleState",
@@ -3256,6 +3851,168 @@
           },
           "422": {
             "description": "Maisematyölupa-asia päivitys epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/LandscapeWorkPermitPersonsLimited/{landscapeWorkPermitIssueId}": {
+      "get": {
+        "tags": [
+          "LandscapeWorkPermit"
+        ],
+        "summary": "Hae karkeutettu maisematyölupa-asia ilman turvakiellollisten toimijoiden tietoja.",
+        "parameters": [
+          {
+            "name": "landscapeWorkPermitIssueId",
+            "in": "path",
+            "description": "Maisematyölupa-asian pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Maisematyölupa-asia löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Maisematyölupa-asia hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Maisematyölupa-asia haku epäonnistui virheellisten tietojen johdosta.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomValidationProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/LandscapeWorkPermitNoPersons/{landscapeWorkPermitIssueId}": {
+      "get": {
+        "tags": [
+          "LandscapeWorkPermit"
+        ],
+        "summary": "Hae maisematyölupa-asia, josta on poistettu henkilötiedot",
+        "parameters": [
+          {
+            "name": "landscapeWorkPermitIssueId",
+            "in": "path",
+            "description": "Maisematyölupa-asian pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Maisematyölupa-asia löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandscapeWorkPermitIssue"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Maisematyölupa-asia hakeminen epäonnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Maisematyölupa-asia haku epäonnistui virheellisten tietojen johdosta.",
             "content": {
               "text/plain": {
                 "schema": {
@@ -3809,6 +4566,208 @@
           "Structure"
         ],
         "summary": "Hae rakennelman kaikki tiedot Ryhdin REST-rajapinnasta.",
+        "parameters": [
+          {
+            "name": "permanentStructureIdentifier",
+            "in": "path",
+            "description": "Rakennelman pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakennelman haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakennelmaa ei löytynyt pysyvällä rakennelmatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakennelman tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/StructurePersonsLimited/{permanentStructureIdentifier}": {
+      "get": {
+        "tags": [
+          "Structure"
+        ],
+        "summary": "Hae karkeutettu rakennelma ilman turvakiellollisten toimijoiden tietoja.",
+        "parameters": [
+          {
+            "name": "permanentStructureIdentifier",
+            "in": "path",
+            "description": "Rakennelman pysyvä yksilöivä tunnus.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rakennelman haku onnistui.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Structure"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rakennelmaa ei löytynyt pysyvällä rakennelmatunnuksella.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Käyttäjältä puuttuu tarvittava scope.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Ei oikeutta lukea rakennelman tietoja.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/StructureNoPersons/{permanentStructureIdentifier}": {
+      "get": {
+        "tags": [
+          "Structure"
+        ],
+        "summary": "Hae karkeutettu rakennelma, josta on poistettu henkilötiedot.",
         "parameters": [
           {
             "name": "permanentStructureIdentifier",
@@ -4860,7 +5819,8 @@
             "nullable": true
           },
           "attachmentType": {
-            "type": "string"
+            "type": "string",
+            "description": "Liiteasiakirjan laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/ravaasiaki\">http://uri.suomi.fi/codelist/rytj/ravaasiaki</a>"
           }
         },
         "additionalProperties": false
@@ -4882,25 +5842,30 @@
             "type": "string",
             "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
           },
-          "document": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "nullable": true
-          },
           "referencePoint": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/RyhtiGeometry"
               }
             ]
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false,
         "description": "Rakennustietomalli"
       },
       "BuildingInformationModelNoPersonData": {
+        "required": [
+          "buildingInformationModelKey",
+          "buildingInformationModelType",
+          "referencePoint"
+        ],
         "type": "object",
         "properties": {
           "buildingInformationModelKey": {
@@ -4911,19 +5876,19 @@
             "type": "string",
             "description": "Rakennuksen tietomallin laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji\">http://uri.suomi.fi/codelist/rytj/rakennuksentietomallinlaji</a>"
           },
-          "document": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
-            },
-            "nullable": true
-          },
           "referencePoint": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/RyhtiGeometry"
               }
             ]
+          },
+          "document": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -5298,15 +6263,6 @@
             "format": "date",
             "nullable": true
           },
-          "decisionDocument": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            ],
-            "description": "Liiteasiakirja",
-            "nullable": true
-          },
           "decisionArticle": {
             "allOf": [
               {
@@ -5359,6 +6315,15 @@
               }
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
             "nullable": true
           },
           "buildingPermitDecisionKey": {
@@ -5449,11 +6414,11 @@
               "constructionToBeStartedBy",
               "constructionToBeCompletedBy",
               "engagingParty",
+              "decisionDocument",
               "lifeCycleState",
               "decisionDate",
               "dateOfDecision",
               "dateOfValidityOfDecision",
-              "decisionDocument",
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
@@ -6556,11 +7521,18 @@
       },
       "ChangeInformationBuildingPermitIssue": {
         "required": [
+          "dateOfInitiation",
           "lifeCycleState",
           "municipalityNumber"
         ],
         "type": "object",
         "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
           "lifeCycleState": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
@@ -6584,11 +7556,11 @@
               "constructionToBeStartedBy",
               "constructionToBeCompletedBy",
               "engagingParty",
+              "decisionDocument",
               "lifeCycleState",
               "decisionDate",
               "dateOfDecision",
               "dateOfValidityOfDecision",
-              "decisionDocument",
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
@@ -6685,11 +7657,6 @@
               }
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "dateOfInitiation": {
-            "type": "string",
-            "format": "date",
             "nullable": true
           }
         },
@@ -6907,6 +7874,11 @@
         "additionalProperties": false
       },
       "ChangeInformationConstructionAction": {
+        "required": [
+          "constructionActionKey",
+          "constructionActionType",
+          "statusOfConstructionAction"
+        ],
         "type": "object",
         "properties": {
           "constructionActionKey": {
@@ -6976,34 +7948,6 @@
             "format": "int32",
             "nullable": true
           },
-          "building": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationBuilding"
-              }
-            ],
-            "nullable": true
-          },
-          "structure": {
-            "required": [
-              "structureMainPurpose",
-              "buildingObjectType"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationStructure"
-              }
-            ],
-            "nullable": true
-          },
-          "areaToBeBuiltForSpecificActivities": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
-              }
-            ],
-            "nullable": true
-          },
           "startDate": {
             "type": "string",
             "format": "date",
@@ -7058,6 +8002,38 @@
             "format": "date",
             "nullable": true
           },
+          "building": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationBuilding"
+              }
+            ],
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationStructure"
+              }
+            ],
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "nullable": true
+          },
           "locatedOnUnseparatedParcel": {
             "type": "boolean",
             "nullable": true
@@ -7067,8 +8043,12 @@
       },
       "ChangeInformationStructure": {
         "required": [
+          "address",
           "buildingObjectType",
-          "structureMainPurpose"
+          "permanentStructureIdentifier",
+          "structureKey",
+          "structureMainPurpose",
+          "temporary"
         ],
         "type": "object",
         "properties": {
@@ -7190,21 +8170,6 @@
             "description": "Rakennuskohteen sijaintitiedot",
             "nullable": true
           },
-          "administrativeLocationUnit": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-              }
-            ]
-          },
-          "decisionAdministrativeLocationUnit": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
-              }
-            ],
-            "nullable": true
-          },
           "address": {
             "type": "array",
             "items": {
@@ -7230,19 +8195,34 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
+          },
           "buildingObjectOwner": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BuildingObjectOwner"
             },
             "description": "Rakennuskohteen omistaja",
-            "nullable": true
-          },
-          "structureSection": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StructureSection"
-            },
             "nullable": true
           }
         },
@@ -7305,15 +8285,6 @@
             "format": "date",
             "nullable": true
           },
-          "decisionDocument": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            ],
-            "description": "Liiteasiakirja",
-            "nullable": true
-          },
           "decisionArticle": {
             "allOf": [
               {
@@ -7366,6 +8337,15 @@
               }
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
             "nullable": true
           },
           "changePermitKey": {
@@ -7547,111 +8527,6 @@
             "format": "int32",
             "nullable": true
           },
-          "building": {
-            "required": [
-              "buildingKey",
-              "permanentBuildingIdentifier",
-              "temporary",
-              "numberOfStoreys",
-              "buildingSection",
-              "mainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Building"
-              }
-            ],
-            "description": "Rakennuksen tiedot.",
-            "nullable": true
-          },
-          "finishedBuilding": {
-            "required": [
-              "buildingKey",
-              "permanentBuildingIdentifier",
-              "temporary",
-              "numberOfStoreys",
-              "buildingSection",
-              "mainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Building"
-              }
-            ],
-            "description": "Rakennuksen tiedot.",
-            "nullable": true
-          },
-          "structure": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          },
-          "finishedStructure": {
-            "required": [
-              "structureKey",
-              "permanentStructureIdentifier",
-              "temporary",
-              "structureSection",
-              "structureMainPurpose",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Structure"
-              }
-            ],
-            "description": "Rakennelma",
-            "nullable": true
-          },
-          "areaToBeBuiltForSpecificActivities": {
-            "required": [
-              "areaToBeBuiltForSpecificActivitiesKey",
-              "specificActivitiesAreaType",
-              "temporary",
-              "buildingObjectType",
-              "location",
-              "administrativeLocationUnit",
-              "buildingObjectOwner",
-              "address"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
-              }
-            ],
-            "description": "Erityistä toimintaa varten rakennettava alue",
-            "nullable": true
-          },
           "startDate": {
             "type": "string",
             "format": "date",
@@ -7706,6 +8581,109 @@
             "format": "date",
             "nullable": true
           },
+          "building": {
+            "required": [
+              "buildingKey",
+              "permanentBuildingIdentifier",
+              "temporary",
+              "numberOfStoreys",
+              "buildingSection",
+              "mainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Building"
+              }
+            ],
+            "description": "Rakennuksen tiedot.",
+            "nullable": true
+          },
+          "finishedBuilding": {
+            "required": [
+              "buildingKey",
+              "permanentBuildingIdentifier",
+              "temporary",
+              "numberOfStoreys",
+              "buildingSection",
+              "mainPurpose",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Building"
+              }
+            ],
+            "description": "Rakennuksen tiedot.",
+            "nullable": true
+          },
+          "structure": {
+            "required": [
+              "structureSection",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "finishedStructure": {
+            "required": [
+              "structureSection",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
+              "structureMainPurpose",
+              "buildingObjectType",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Structure"
+              }
+            ],
+            "description": "Rakennelma",
+            "nullable": true
+          },
+          "areaToBeBuiltForSpecificActivities": {
+            "required": [
+              "areaToBeBuiltForSpecificActivitiesKey",
+              "specificActivitiesAreaType",
+              "temporary",
+              "buildingObjectType",
+              "location",
+              "administrativeLocationUnit",
+              "buildingObjectOwner",
+              "address"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AreaToBeBuiltForSpecificActivities"
+              }
+            ],
+            "description": "Erityistä toimintaa varten rakennettava alue",
+            "nullable": true
+          },
           "finishedAreaToBeBuiltForSpecificActivities": {
             "required": [
               "areaToBeBuiltForSpecificActivitiesKey",
@@ -7732,8 +8710,7 @@
       "ConstructionDesign": {
         "required": [
           "constructionDesignKey",
-          "constructionDesignType",
-          "document"
+          "constructionDesignType"
         ],
         "type": "object",
         "properties": {
@@ -7756,6 +8733,10 @@
         "description": "Rakennussuunnitelma"
       },
       "ConstructionDesignNoPersonData": {
+        "required": [
+          "constructionDesignKey",
+          "constructionDesignType"
+        ],
         "type": "object",
         "properties": {
           "constructionDesignKey": {
@@ -8220,15 +9201,6 @@
             "format": "date",
             "nullable": true
           },
-          "decisionDocument": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            ],
-            "description": "Liiteasiakirja",
-            "nullable": true
-          },
           "decisionArticle": {
             "allOf": [
               {
@@ -8323,6 +9295,15 @@
               "$ref": "#/components/schemas/EngagingParty"
             },
             "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -8358,6 +9339,9 @@
           "municipalityNumber": {
             "type": "string"
           },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
           "demolitionPermitApplication": {
             "type": "array",
             "items": {
@@ -8366,14 +9350,50 @@
             "description": "Purkamislupahakemus",
             "nullable": true
           },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
           "demolitionDecision": {
             "required": [
+              "decisionDocument",
               "demolitionPermitDecisionKey",
               "lifeCycleState",
               "decisionDate",
               "dateOfDecision",
               "dateOfValidityOfDecision",
-              "decisionDocument",
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
@@ -8402,21 +9422,6 @@
             },
             "nullable": true
           },
-          "buildingSite": {
-            "required": [
-              "buildingSiteKey",
-              "stormWaterTreatmentType",
-              "buildingSiteAddress",
-              "tenure"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingSite"
-              }
-            ],
-            "description": "Rakennuspaikka",
-            "nullable": true
-          },
           "constructionAction": {
             "type": "array",
             "items": {
@@ -8442,31 +9447,6 @@
             ],
             "description": "Rakentamishanke",
             "nullable": true
-          },
-          "updateType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-            ],
-            "type": "string",
-            "description": "Rakennuksen käytössäolotilanne. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne\">http://uri.suomi.fi/codelist/vtj/Rake_kaytossaolotilanne</a>",
-            "nullable": true
-          },
-          "updateDescription": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "permanentPermitIdentifier": {
-            "type": "string"
           }
         },
         "additionalProperties": false,
@@ -8529,6 +9509,30 @@
             ],
             "description": "Rakennuskohteen sijaintitiedot"
           },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
           "administrativeLocationUnit": {
             "required": [
               "administrativeLocationUnitKey",
@@ -8560,6 +9564,47 @@
               "$ref": "#/components/schemas/BuildingObjectOwner"
             },
             "description": "Rakennuskohteen omistaja"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamisen kohde"
+      },
+      "DeviationObjectNoPersonData": {
+        "required": [
+          "address",
+          "buildingObjectType",
+          "deviationObjectKey"
+        ],
+        "type": "object",
+        "properties": {
+          "deviationObjectKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingObjectType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji/code/2"
+            ],
+            "type": "string",
+            "description": "Rakennuskohteen tiedon laji. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>"
+          },
+          "totalArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "location": {
+            "required": [
+              "buildingObjectLocationDataKey",
+              "pointLocation"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingObjectLocationData"
+              }
+            ],
+            "description": "Rakennuskohteen sijaintitiedot"
           },
           "address": {
             "type": "array",
@@ -8584,10 +9629,25 @@
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
+          },
+          "administrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ]
+          },
+          "decisionAdministrativeLocationUnit": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChangeInformationAdministrativeLocationUnit"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false,
-        "description": "Poikkeamisen kohde"
+        "description": "Poikkeamisen kohde ilman henkilötietoja"
       },
       "DeviationPermitApplication": {
         "required": [
@@ -8643,6 +9703,61 @@
         },
         "additionalProperties": false,
         "description": "Poikkeamislupahakemus"
+      },
+      "DeviationPermitApplicationNoPersonData": {
+        "required": [
+          "applicationContent",
+          "constructionDesign",
+          "dateOfReception",
+          "deviationPermitApplicationKey",
+          "lifeCycleState"
+        ],
+        "type": "object",
+        "properties": {
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/lupahak-elinkaaren-tila/code/3"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji\">http://uri.suomi.fi/codelist/rytj/rakkohteen-tiedon-laji</a>",
+            "nullable": true
+          },
+          "applicationContent": {
+            "type": "string"
+          },
+          "dateOfReception": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "callForDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CallForDeviation"
+            },
+            "nullable": true
+          },
+          "deviationPermitApplicationKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "buildingInformationModel": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingInformationModelNoPersonData"
+            }
+          },
+          "constructionDesign": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConstructionDesignNoPersonData"
+            }
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupahakemus ilman henkilötietoja"
       },
       "DeviationPermitDecision": {
         "required": [
@@ -8703,13 +9818,149 @@
             "format": "date",
             "nullable": true
           },
+          "decisionArticle": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "deviationPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expiryDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "format": "date"
+          },
           "decisionDocument": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/BuildingAttachmentDocument"
               }
             ],
-            "description": "Liiteasiakirja",
+            "description": "",
+            "nullable": true
+          },
+          "engagingParty": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EngagingParty"
+            },
+            "description": ""
+          }
+        },
+        "additionalProperties": false,
+        "description": "Poikkeamislupapäätös"
+      },
+      "DeviationPermitDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionInForceUntil",
+          "decisionMakerFirstName",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "deviationPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>"
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
             "nullable": true
           },
           "decisionArticle": {
@@ -8768,30 +10019,27 @@
           },
           "deviationPermitDecisionKey": {
             "type": "string",
-            "description": "",
             "format": "uuid"
           },
           "expiryDate": {
             "type": "string",
-            "description": "",
             "format": "date",
             "nullable": true
           },
-          "engagingParty": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EngagingParty"
-            },
-            "description": ""
-          },
           "decisionInForceUntil": {
             "type": "string",
-            "description": "",
             "format": "date"
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
           }
         },
-        "additionalProperties": false,
-        "description": "Poikkeamislupapäätös"
+        "additionalProperties": false
       },
       "DeviationPermitIssue": {
         "required": [
@@ -8832,50 +10080,6 @@
           "recordNumber": {
             "type": "string"
           },
-          "deviationPermitDecision": {
-            "required": [
-              "deviationPermitDecisionKey",
-              "engagingParty",
-              "decisionInForceUntil",
-              "lifeCycleState",
-              "decisionDate",
-              "dateOfDecision",
-              "dateOfValidityOfDecision",
-              "decisionDocument",
-              "publicNoticeDate",
-              "decisionText",
-              "decisionMakerType",
-              "decisionMakerFirstName",
-              "decisionMakerName"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DeviationPermitDecision"
-              }
-            ],
-            "description": "Poikkeamislupapäätös"
-          },
-          "deviationPermitApplication": {
-            "required": [
-              "deviationPermitApplicationKey",
-              "constructionDesign",
-              "lifeCycleState",
-              "applicationContent",
-              "dateOfReception"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/DeviationPermitApplication"
-              }
-            ],
-            "description": "Poikkeamislupahakemus"
-          },
-          "deviationObject": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/DeviationObject"
-            }
-          },
           "buildingSite": {
             "required": [
               "buildingSiteKey",
@@ -8889,13 +10093,6 @@
               }
             ],
             "description": "Rakennuspaikka"
-          },
-          "attachment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingAttachmentDocument"
-            },
-            "nullable": true
           },
           "updateType": {
             "enum": [
@@ -8917,10 +10114,187 @@
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
+          },
+          "deviationPermitDecision": {
+            "required": [
+              "decisionDocument",
+              "engagingParty",
+              "deviationPermitDecisionKey",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitDecision"
+              }
+            ],
+            "description": "Poikkeamislupapäätös"
+          },
+          "deviationPermitApplication": {
+            "required": [
+              "constructionDesign",
+              "deviationPermitApplicationKey",
+              "lifeCycleState",
+              "applicationContent",
+              "dateOfReception"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitApplication"
+              }
+            ],
+            "description": "Poikkeamislupahakemus"
+          },
+          "deviationObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationObject"
+            }
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false,
         "description": "Poikkeamislupa-asia"
+      },
+      "DeviationPermitIssueNoPersonData": {
+        "required": [
+          "buildingSite",
+          "dateOfInitiation",
+          "lifeCycleState",
+          "municipalityNumber",
+          "permanentPermitIdentifier"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "recordNumber": {
+            "type": "string"
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "deviationPermitDecision": {
+            "required": [
+              "decisionDocument",
+              "deviationPermitDecisionKey",
+              "decisionInForceUntil",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerFirstName",
+              "decisionMakerName"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitDecisionNoPersonData"
+              }
+            ],
+            "nullable": true
+          },
+          "deviationPermitApplication": {
+            "required": [
+              "constructionDesign",
+              "deviationPermitApplicationKey",
+              "lifeCycleState",
+              "applicationContent",
+              "dateOfReception"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DeviationPermitApplicationNoPersonData"
+              }
+            ],
+            "description": "Poikkeamislupahakemus ilman henkilötietoja",
+            "nullable": true
+          },
+          "deviationObject": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviationObjectNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "ElectricalEnergySource": {
         "required": [
@@ -9497,15 +10871,6 @@
             "format": "date",
             "nullable": true
           },
-          "decisionDocument": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            ],
-            "description": "Liiteasiakirja",
-            "nullable": true
-          },
           "decisionArticle": {
             "allOf": [
               {
@@ -9560,6 +10925,15 @@
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "Liiteasiakirja",
+            "nullable": true
+          },
           "extensionDecisionKey": {
             "type": "string",
             "description": "",
@@ -9596,6 +10970,14 @@
               }
             ],
             "description": "",
+            "nullable": true
+          },
+          "shape3d": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RyhtiGeometry3d"
+              }
+            ],
             "nullable": true
           },
           "relationToGroundLevel": {
@@ -10056,11 +11438,18 @@
       },
       "GeneralizedBuildingPermitIssue": {
         "required": [
+          "dateOfInitiation",
           "lifeCycleState",
           "municipalityNumber"
         ],
         "type": "object",
         "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
           "lifeCycleState": {
             "enum": [
               "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
@@ -10084,11 +11473,11 @@
               "constructionToBeStartedBy",
               "constructionToBeCompletedBy",
               "engagingParty",
+              "decisionDocument",
               "lifeCycleState",
               "decisionDate",
               "dateOfDecision",
               "dateOfValidityOfDecision",
-              "decisionDocument",
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
@@ -10185,11 +11574,6 @@
               }
             ],
             "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "dateOfInitiation": {
-            "type": "string",
-            "format": "date",
             "nullable": true
           }
         },
@@ -10693,8 +12077,12 @@
           },
           "structure": {
             "required": [
+              "structureKey",
+              "permanentStructureIdentifier",
+              "temporary",
               "structureMainPurpose",
-              "buildingObjectType"
+              "buildingObjectType",
+              "address"
             ],
             "allOf": [
               {
@@ -12123,15 +13511,6 @@
             "format": "date",
             "nullable": true
           },
-          "decisionDocument": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingAttachmentDocument"
-              }
-            ],
-            "description": "Liiteasiakirja",
-            "nullable": true
-          },
           "decisionArticle": {
             "allOf": [
               {
@@ -12188,19 +13567,39 @@
           },
           "landscapeWorkPermitDecisionKey": {
             "type": "string",
-            "description": "",
             "format": "uuid"
           },
           "constructionToBeStartedBy": {
             "type": "string",
-            "description": "",
             "format": "date",
             "nullable": true
           },
           "constructionToBeCompletedBy": {
             "type": "string",
-            "description": "",
             "format": "date",
+            "nullable": true
+          },
+          "decisionInForceUntil": {
+            "type": "string",
+            "format": "date"
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocument"
+              }
+            ],
+            "description": "",
             "nullable": true
           },
           "engagingParty": {
@@ -12209,23 +13608,6 @@
               "$ref": "#/components/schemas/EngagingParty"
             },
             "description": ""
-          },
-          "decisionInForceUntil": {
-            "type": "string",
-            "description": "",
-            "format": "date"
-          },
-          "constructionToBeStartedByExtension": {
-            "type": "string",
-            "description": "",
-            "format": "date",
-            "nullable": true
-          },
-          "constructionToBeCompletedByExtension": {
-            "type": "string",
-            "description": "",
-            "format": "date",
-            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -12267,16 +13649,51 @@
           "permanentPermitIdentifier": {
             "type": "string"
           },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka"
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
           "landscapeWorkPermitDecision": {
             "required": [
-              "landscapeWorkPermitDecisionKey",
+              "decisionDocument",
               "engagingParty",
+              "landscapeWorkPermitDecisionKey",
               "decisionInForceUntil",
               "lifeCycleState",
               "decisionDate",
               "dateOfDecision",
               "dateOfValidityOfDecision",
-              "decisionDocument",
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
@@ -12317,20 +13734,6 @@
             },
             "nullable": true
           },
-          "buildingSite": {
-            "required": [
-              "buildingSiteKey",
-              "stormWaterTreatmentType",
-              "buildingSiteAddress",
-              "tenure"
-            ],
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingSite"
-              }
-            ],
-            "description": "Rakennuspaikka"
-          },
           "attachment": {
             "type": "array",
             "items": {
@@ -12348,27 +13751,6 @@
               }
             ],
             "description": "Rakentamishanke",
-            "nullable": true
-          },
-          "updateType": {
-            "enum": [
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
-              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
-            ],
-            "type": "string",
-            "nullable": true
-          },
-          "updateDescription": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           }
         },
@@ -13119,6 +14501,42 @@
         },
         "additionalProperties": false
       },
+      "RyhtiGeometry3d": {
+        "required": [
+          "geometryData3d",
+          "srid3d"
+        ],
+        "type": "object",
+        "properties": {
+          "srid3d": {
+            "enum": [
+              "3067",
+              "3873",
+              "3874",
+              "3875",
+              "3876",
+              "3877",
+              "3878",
+              "3879",
+              "3880",
+              "3881",
+              "3882",
+              "3883",
+              "3884",
+              "3885",
+              "4326"
+            ],
+            "type": "string",
+            "description": "Gauss Krüger projektio; SRID koodi; SRID nimi\r\n\r\n   19;3873;ETRS89 / GK19FIN EPSG:3873\r\n\r\n   20;3874;ETRS89 / GK20FIN EPSG:3874\r\n\r\n   21;3875;ETRS89 / GK21FIN EPSG:3875\r\n\r\n   22;3876;ETRS89 / GK22FIN EPSG:3876\r\n\r\n   23;3877;ETRS89 / GK23FIN EPSG:3877\r\n\r\n   24;3878;ETRS89 / GK24FIN EPSG:3878\r\n\r\n   25;3879;ETRS89 / GK25FIN EPSG:3879\r\n\r\n   26;3880;ETRS89 / GK26FIN EPSG:3880\r\n\r\n   27;3881;ETRS89 / GK27FIN EPSG:3881\r\n\r\n   28;3882;ETRS89 / GK28FIN EPSG:3882\r\n\r\n   29;3883;ETRS89 / GK29FIN EPSG:3883\r\n\r\n   30;3884;ETRS89 / GK30FIN EPSG:3884\r\n\r\n   31;3885;ETRS89 / GK31FIN EPSG:3885\r\n\r\n   3067 TM35FIN\r\n"
+          },
+          "geometryData3d": {
+            "minLength": 1,
+            "type": "string",
+            "description": "3d-geometria wkt-string"
+          }
+        },
+        "additionalProperties": false
+      },
       "SpecialDesign": {
         "required": [
           "document",
@@ -13189,7 +14607,6 @@
           "administrativeLocationUnit",
           "buildingObjectOwner",
           "buildingObjectType",
-          "location",
           "permanentStructureIdentifier",
           "structureKey",
           "structureMainPurpose",
@@ -13217,13 +14634,6 @@
           "numberOfStoreys": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "structureSection": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/StructureSection"
-            },
             "nullable": true
           },
           "structureMainPurpose": {
@@ -13323,6 +14733,38 @@
             "description": "Rakennuskohteen sijaintitiedot",
             "nullable": true
           },
+          "address": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            },
+            "nullable": true
+          },
+          "name": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "description": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "structureSection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/StructureSection"
+            },
+            "nullable": true
+          },
           "administrativeLocationUnit": {
             "required": [
               "administrativeLocationUnitKey",
@@ -13354,31 +14796,6 @@
               "$ref": "#/components/schemas/BuildingObjectOwner"
             },
             "description": "Rakennuskohteen omistaja",
-            "nullable": true
-          },
-          "address": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Address"
-            },
-            "nullable": true
-          },
-          "name": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
-            "nullable": true
-          },
-          "description": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
             "nullable": true
           }
         },

--- a/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/Rakentaminen OpenApi Beta.json
@@ -5172,6 +5172,7 @@
       "BuildingPermitApplication": {
         "required": [
           "applicationContent",
+          "buildingPermitApplicationType",
           "dateOfReception",
           "lifeCycleState",
           "permitApplicationKey",
@@ -5217,6 +5218,20 @@
             ],
             "type": "string",
             "description": "Rakentamislupahakemuksen lupatyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/LuvanSisalto\">http://uri.suomi.fi/codelist/rytj/LuvanSisalto</a>",
+            "nullable": true
+          },
+          "buildingPermitApplicationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/01",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/02",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/03",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/04",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/05",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/06",
+              "http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/07"
+            ],
+            "type": "string",
+            "description": "Rakentamislupahakemuksen hakemustyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi\">http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi</a>",
             "nullable": true
           }
         },


### PR DESCRIPTION
 
 # Sisältö

Rakennustiedot

* Tuki GK-kaistoille (uusi ominaisuus)
* 3D-tuki tuki rakennuksen osan ulkokuoren muodolle
* Muutostietopalvelu ilman turvakiellollisia henkilötietoja (uusi toiminnallisuus)
* Muutostietopalvelun ilman henkilötietoja täydennys
* Rakentamislupahakemuksen tyyppi (HUOM! uusi **pakollinen** tieto validointi- ja tallennusrajapinnassa)
* Validointimuutoksia ja korjauksia

# Yleistä

# Rakennustieto

## Rakennustietojen validointi- ja tallennus-API

* Lisätty tuki GK-kaistoille
    * kohteiden sijaintigeometria on mahdollista toimittaa myös kunnan käyttämässä GK-kaistassa. Aiemmin sallittuna oli vain TM35FIN
        * geometrian koordinaattijärjestelmä ilmoitetaan attribuutilla srid (epsg-koodi)
    * HUOM! kohteen geometria muutostietopalvelussa ja avoimessa karttapalvelussa annetaan edelleen TM35FIN-muodossa (Ryhti muuntaa mahdollisen GK-sijainnin)
* Lisätty 3D-tuki tuki rakennuksen osan ulkokuoren muodolle (shape3d)
    * 3D-geometria wkt-string (polyhedralsurface)
* Lisätty Rakentamislupahakemukselle uusi Rakentamislupahakemuksen tyyppi (BuildingPermitApplicationType) attribuutti ja siihen liittyvä koodisto
    * **HUOM! Kyseessä uusi pakollinen tieto**
    * BuildingPermitApplication{
        * description:	
            Rakentamislupahakemus
            lifeCycleState\*	[...]
            applicationContent\*	[...]
            dateOfReception\*	[...]
            callForDeviation	[...]
            permitApplicationKey\*	[...]
            permitApplicationType\*	[...]
            **buildingPermitApplicationType\***	string
            * nullable: true
                Rakentamislupahakemuksen hakemustyyppi. Käytetään koodiston URI arvoa http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi
                Enum:
                [ http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/01, http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/02, http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/03, http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/04, http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/05, http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/06, http://uri.suomi.fi/codelist/rytj/HakemuksenTyyppi/code/07 ]
* Korjattu tilanne, jossa osoitteen (address) validointi ei onnistunut, jos osoite alkoi skandinaavisella merkillä
* Poistettu sisäänkäynnin (entrance) geometria-attribuutin (geometry) pakollisuus
* Poistettu verkostoliittymän (networkConnetion) liitettyattribuutin (connected) pakollisuus
* Lisätty yksittäkyselyitä muille luville kuin rakentamisluville ja rakennelmille:
    * /api/DemolitionPermitGeneralized/{demolitionPermitId}= purkamisluvan karkeutetut tiedot
    * /api/DemolitionPermitNoPersons/{demolitionPermitId} = purkamisluvan karkeutetut tiedot, ilman henkilötietoja
    * /api/DeviationPermitNoPersons/{permanentPermitId} = poikkeamisluvan kaikki tiedot, ilman henkilötietoja
    * /api/LandscapeWorkPermitNoPersons/{landscapeWorkPermitIssueId} = maisematyöluvan kaikki tiedot, ilman henkilötietoja
    * /api/StructureNoPersons/{permanentStructureIdentifier} = rakennelman kaikki tiedot, ilman henkilötietoja

## Rakennustietojen muutostietopalvelu

* Lisätty muutostietopalvelu ilman turvakiellollisia henkilötietoja
    * HUOM! mikäli jo aiemmin julkaistulle ei-turvakiellolliselle osapuolelle tulee VTJ:n kautta turvakielto, niin tästä näytetään Ryhdin muutostietopalvelussa osapuolen poisto ja lisäksi kerrotaan poiston syyksi turvakielto (nonDiscloseureForSafety = true)
    * /api/InitialInformation/BuildingPersonsLimited = karkeutettujen rakennusten perustiedot, ilman turvakiellollisia henkilötietoja
    * /api/InitialInformation/BuildingPermitPersonsLimited = karkeutettujen lupien perustiedot, ilman turvakiellollisia henkilötietoja
    * /api/InitialInformation/StructurePersonsLimited = karkeutettujen rakennelmien perustiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/BuildingPersonsLimited = karkeutettujen rakennusten muutostiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/BuildingPermitPersonsLimited = karkeutettujen lupien muutostiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/StructurePersonsLimited = karkeutettujen rakennelmien muutostiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/OperatorPersonLimited = ei-turvakiellollisten toimijoiden muutostiedot
    * /api/InitialInformation/DemolitionPermitPersonsLimited = purkamislupien karkeutetut perustiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/DemolitionPermitPersonsLimited = purkamislupien karkeutetut muutostiedot, ilman turvakiellollisia henkilötietoja
    * /api/InitialInformation/DeviationPermitPersonsLimited = poikkeamislupien perustiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/DeviationPermitPersonsLimited = poikkeamislupien muutostiedot, ilman turvakiellollisia henkilötietoja
    * /api/InitialInformation/LandscapeWorkPermitPersonsLimited = maisematyölupien perustiedot, ilman turvakiellollisia henkilötietoja
    * /api/ChangeInformation/LandscapeWorkPermitPersonsLimited = maisematyölupien muutostiedot, ilman turvakiellollisia henkilötietoja
* Täydennetty muutostietopalvelua ilman henkilötietoja muille luville kuin rakentamisluville ja rakennelmille:
    * /api/InitialInformation/DemolitionPermitNoPersons = purkamislupien karkeutetut perustiedot, ilman henkilötietoja
    * /api/ChangeInformation/DemolitionPermitNoPersons = purkamislupien karkeutetut muutostiedot, ilman henkilötietoja
    * /api/InitialInformation/DeviationPermitNoPersons = poikkeamislupien perustiedot, ilman henkilötietoja
    * /api/ChangeInformation/DeviationPermitNoPersons = poikkeamislupien muutostiedot, ilman henkilötietoja
    * /api/InitialInformation/LandscapeWorkPermitNoPersons = maisematyölupien perustiedot, ilman henkilötietoja
    * /api/ChangeInformation/LandscapeWorkPermitNoPersons = maisematyölupien muutostiedot, ilman henkilötietoja - devissä
* Muutettu muutostietopalvelua (changeInformation endpointit) niin, että muutosten hakeminen ilman Ryhdistä löytyvää muutostapahtumaa (eventid) ei ole mahdollista
    * HUOM! Muutostietopalvelua ei ole suunniteltu käytettävän koko aineiston lataamiseen, vaan siihen tulee käyttää perustietopalvelua (initialInformation), jonka yhteydessä saadaan ko. aineistoon liittyvä viimeisin muutostapahtuma (eventid)

## Rakennustietojen avoin karttakäyttöliittymä

* Lisätty paikan haku haku Ryhdin rakennuksen tai hankerakennuksen sijaintikiinteistöllä
* Lisätty käännökset osoitehaun palauttamille kohdetyypeille
* Muutetty haen rakennuksen sijainnin zoomitasoa
* 

## Rakennustietojen validointi- ja tallennus-APIn tiedossa oleva virheet ja rajapintaan vaikuttavia tulevia muutoksia

* ei tiedossa olevia virheitä

# Alueidenkäyttö

## Alueidenkäytön validointi- ja tallennus-API

* 

### Kaavasuunnitelmien julkinen validointirajapinta

### Kaavatietojen validointi- ja tallennus-API

* Uusi **pakollinen** tieto partiallyCancelledPlanObjectInfoKey\` tyypille PartiallyCancelledPlanObjectInfo.
* Kaava-asian päätökselle lisätty assosiaatiot kumoamistietoon `planCancellationInfos` ja osittaiseen kumottavaan kaavakohteeseen `partiallyCancelledPlanObjectInfos`
* Geotiff kaavakartalle lisätty validointeja. esimerkiksi Geotiff-tiedoston rajaus tulee peittää kaavan aluerajaus. Geotiff kaavakartalla vain ETRS-TM35FIN koordinaatisto sallittu. Kaavakartta luokalla tulee olla  koordinaatisto uri muodossa (http://uri.suomi.fi/codelist/rakrek/ETRS89/code/EPSG3067 )
* Kaavan kumoutumiskokonaisuuteen liittyviä validointia. Esimerkiksi kumoutumistieto voi olla mukana ainoastaan elinkaarentilassa voimassa.
* Korjattu havaittuja kaavamääräyksien validointeihin liittyviä bugeja. Esimerkiksi korjattu tuulivoimalan enimmäiskorkeus arvon tietotyyppi. Korjattu katja-asetuksen mukaisesti positiiviseksi kokonaisluvuksi

## Kaavatiedon tallennuskäyttöliittymä

## Sitova tonttijako

## Alueidenkäytön rajoitus

## Tiedossa oleva virheet ja rajapintaan vaikuttavia tulevia muutoksia

# Asemakaavan seurantalomake

## Muutokset