### PR TITLE
Julkaisun 2026 release 6 alustavat rajapintamuutokset

### DIFF
--- a/OpenApi/Alueidenkäyttö/Palveluväylä/planService-OpenApi.json
+++ b/OpenApi/Alueidenkäyttö/Palveluväylä/planService-OpenApi.json
@@ -12243,10 +12243,12 @@
         "properties": {
           "planObjectKey": {
             "type": "string",
+            "description": "Key of the plan object this presentation alignment is associated with.",
             "format": "uuid"
           },
           "planRegulationGroupKey": {
             "type": "string",
+            "description": "Key of the plan regulation group this presentation alignment is associated with.",
             "format": "uuid"
           },
           "geometry": {
@@ -12254,15 +12256,18 @@
               {
                 "$ref": "#/components/schemas/RyhtiGeometry"
               }
-            ]
+            ],
+            "description": "Geometry of the presentation alignment. Allowed types: Point, LineString."
           },
           "rotation": {
             "type": "integer",
+            "description": "Rotation of the presentation alignment in degrees. Allowed range: -360 to 360.",
             "format": "int32",
             "nullable": true
           },
           "language": {
             "type": "string",
+            "description": "Language of the presentation alignment.\r\nCode value from: http://uri.suomi.fi/codelist/rytj/ryhtikielet\r\n\r\nAllowed values:\r\n<list type=\"bullet\"><item><description>fi - suomi</description></item><item><description>sv - ruotsi</description></item><item><description>en - englanti</description></item><item><description>smn - inarinsaame</description></item><item><description>sms - koltansaame</description></item><item><description>se - pohjoissaame</description></item></list>",
             "nullable": true
           }
         },

--- a/OpenApi/Rakentaminen/Palveluväylä/buildingDataSharingService-OpenApi.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/buildingDataSharingService-OpenApi.json
@@ -5574,20 +5574,16 @@
             "type": "string"
           },
           "buildingBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingBuildingProduct"
-              }
-            ],
-            "description": "Rakennuksen rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingBuildingProduct"
+            }
           },
           "buildingSiteBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
-              }
-            ],
-            "description": "Rakennuspaikan rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
+            }
           }
         },
         "additionalProperties": false,
@@ -5605,20 +5601,16 @@
             "format": "date"
           },
           "buildingBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingBuildingProduct"
-              }
-            ],
-            "description": "Rakennuksen rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingBuildingProduct"
+            }
           },
           "buildingSiteBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
-              }
-            ],
-            "description": "Rakennuspaikan rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
+            }
           }
         },
         "additionalProperties": false
@@ -9452,10 +9444,7 @@
             "format": "date-time"
           },
           "nameOfPreparer": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
+            "type": "string",
             "nullable": true
           },
           "assessmentPeriodLength": {
@@ -11522,9 +11511,9 @@
             "nullable": true
           },
           "computationalEnergyEfficiencyComparand": {
-            "type": "number",
+            "type": "integer",
             "description": "",
-            "format": "double",
+            "format": "int32",
             "nullable": true
           },
           "heatingMethod": {
@@ -11632,8 +11621,8 @@
             "nullable": true
           },
           "computationalEnergyEfficiencyComparand": {
-            "type": "number",
-            "format": "double",
+            "type": "integer",
+            "format": "int32",
             "nullable": true
           },
           "heatingMethod": {

--- a/OpenApi/Rakentaminen/Palveluväylä/buildingDataSharingService-OpenApi.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/buildingDataSharingService-OpenApi.json
@@ -5028,8 +5028,8 @@
             "nullable": true
           },
           "floorAreaChange": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "basementAreaChange": {
@@ -5240,7 +5240,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -5408,7 +5407,6 @@
           "dateOfDecision",
           "dateOfValidityOfDecision",
           "decisionDate",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -6384,6 +6382,11 @@
             "type": "integer",
             "format": "int32",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -6516,6 +6519,11 @@
             "nullable": true
           },
           "specificActivitiesAreaArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "bikespaceCount": {
             "type": "integer",
             "format": "int32",
             "nullable": true
@@ -6857,6 +6865,11 @@
           "buildingCultureHistoricalSignificance": {
             "type": "string",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7069,7 +7082,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -7862,7 +7874,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -8198,7 +8209,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -8442,7 +8452,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -8958,6 +8967,11 @@
             "description": "Latauspiste",
             "nullable": true
           },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "structureSection": {
             "type": "array",
             "items": {
@@ -9119,7 +9133,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -9249,7 +9262,6 @@
           "dateOfDecision",
           "dateOfValidityOfDecision",
           "decisionDate",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -9394,11 +9406,6 @@
           },
           "otherCablingRoutes": {
             "type": "boolean"
-          },
-          "bikespaceCount": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
           },
           "conduit": {
             "type": "boolean"
@@ -10039,7 +10046,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -10207,7 +10213,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -10448,7 +10453,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -10833,7 +10837,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -10982,7 +10985,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -11194,7 +11196,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -11436,23 +11437,23 @@
             "nullable": true
           },
           "insideLength": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "insideWidth": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "doorOpeningWidth": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "doorOpeningHeight": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "passengerCapacity": {
@@ -11932,7 +11933,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -12063,7 +12063,6 @@
           "dateOfDecision",
           "dateOfValidityOfDecision",
           "decisionDate",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -12591,6 +12590,11 @@
           "buildingCultureHistoricalSignificance": {
             "type": "string",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -12856,6 +12860,11 @@
           "buildingCultureHistoricalSignificance": {
             "type": "string",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -13002,7 +13011,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -13260,7 +13268,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -14372,7 +14379,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -16316,7 +16322,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -16480,7 +16485,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -16707,7 +16711,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -18222,6 +18225,11 @@
               }
             ],
             "description": "Latauspiste",
+            "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
             "nullable": true
           },
           "structureSection": {

--- a/OpenApi/Rakentaminen/Palveluväylä/buildingService-OpenApi.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/buildingService-OpenApi.json
@@ -1988,7 +1988,24 @@
         ],
         "responses": {
           "200": {
-            "description": "Purkamislupa löytyi ja se palautettiin."
+            "description": "Purkamislupa löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeInformationDemolitionPermitIssue"
+                }
+              }
+            }
           },
           "400": {
             "description": "Purkamisluvan hakeminen epäonnistui.",
@@ -2171,7 +2188,24 @@
         ],
         "responses": {
           "200": {
-            "description": "Purkamislupa löytyi ja se palautettiin."
+            "description": "Purkamislupa löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+                }
+              }
+            }
           },
           "400": {
             "description": "Purkamisluvan hakeminen epäonnistui.",
@@ -2235,7 +2269,24 @@
         ],
         "responses": {
           "200": {
-            "description": "Purkamislupa löytyi ja se palautettiin."
+            "description": "Purkamislupa löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralizedDemolitionPermitIssue"
+                }
+              }
+            }
           },
           "400": {
             "description": "Purkamisluvan hakeminen epäonnistui.",
@@ -2299,7 +2350,24 @@
         ],
         "responses": {
           "200": {
-            "description": "Purkamislupa löytyi ja se palautettiin."
+            "description": "Purkamislupa löytyi ja se palautettiin.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonData"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonData"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DemolitionPermitIssueNoPersonData"
+                }
+              }
+            }
           },
           "400": {
             "description": "Purkamisluvan hakeminen epäonnistui.",
@@ -5426,6 +5494,11 @@
             ],
             "description": "Latauspiste",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -5802,6 +5875,11 @@
               }
             ],
             "description": "Latauspiste",
+            "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
             "nullable": true
           }
         },
@@ -6285,8 +6363,8 @@
             "nullable": true
           },
           "floorAreaChange": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "basementAreaChange": {
@@ -6551,7 +6629,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -6719,7 +6796,6 @@
           "dateOfDecision",
           "dateOfValidityOfDecision",
           "decisionDate",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -6922,7 +6998,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -8125,6 +8200,11 @@
             "type": "integer",
             "format": "int32",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -8257,6 +8337,11 @@
             "nullable": true
           },
           "specificActivitiesAreaArea": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "bikespaceCount": {
             "type": "integer",
             "format": "int32",
             "nullable": true
@@ -8598,6 +8683,11 @@
           "buildingCultureHistoricalSignificance": {
             "type": "string",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -8713,7 +8803,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -9307,6 +9396,147 @@
         },
         "additionalProperties": false
       },
+      "ChangeInformationDemolitionPermitIssue": {
+        "required": [
+          "dateOfInitiation",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
+            },
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "decisionDocument",
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerName",
+              "relatedApplication"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangeInformationConstructionAction"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ChangeInformationOperator": {
         "type": "object",
         "properties": {
@@ -9547,6 +9777,11 @@
             "description": "Latauspiste",
             "nullable": true
           },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "structureSection": {
             "type": "array",
             "items": {
@@ -9587,7 +9822,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -9717,7 +9951,6 @@
           "dateOfDecision",
           "dateOfValidityOfDecision",
           "decisionDate",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -9862,11 +10095,6 @@
           },
           "otherCablingRoutes": {
             "type": "boolean"
-          },
-          "bikespaceCount": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
           },
           "conduit": {
             "type": "boolean"
@@ -11366,7 +11594,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -11528,6 +11755,164 @@
         "additionalProperties": false,
         "description": "Rakentamislupapäätös"
       },
+      "DemolitionPermitDecisionNoPersonData": {
+        "required": [
+          "dateOfDecision",
+          "dateOfValidityOfDecision",
+          "decisionDate",
+          "decisionDocument",
+          "decisionMakerName",
+          "decisionMakerType",
+          "decisionText",
+          "demolitionPermitDecisionKey",
+          "lifeCycleState",
+          "publicNoticeDate",
+          "relatedApplication"
+        ],
+        "type": "object",
+        "properties": {
+          "acceptedDeviation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AcceptedDeviation"
+            },
+            "nullable": true
+          },
+          "permitRegulation": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermitRegulation"
+            },
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/11",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/12",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Päätöksen elinkaaren tila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/paatoksen-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "decisionDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "dateOfValidityOfDecision": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionArticle": {
+            "type": "string",
+            "nullable": true
+          },
+          "publicNoticeDate": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionText": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "guidingStatute": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GuidingStatute"
+            },
+            "nullable": true
+          },
+          "relatedPermit": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "decisionMakerType": {
+            "type": "string",
+            "description": "Päätöksen tekijän tyyppi. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/PaatoksenTekija\">http://uri.suomi.fi/codelist/rytj/PaatoksenTekija</a>",
+            "nullable": true
+          },
+          "decisionMakerFirstName": {
+            "type": "string",
+            "nullable": true
+          },
+          "decisionMakerName": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "relatedApplication": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "demolitionPermitDecisionKey": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permitApplicationType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/01",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/02",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/03",
+              "http://uri.suomi.fi/codelist/rytj/LuvanSisalto/code/04"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "constructionToBeStartedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedBy": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeStartedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "constructionToBeCompletedByExtension": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "decisionDocument": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "DemolitionPermitIssue": {
         "required": [
           "dateOfInitiation",
@@ -11616,7 +12001,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -11671,6 +12055,144 @@
         },
         "additionalProperties": false,
         "description": "Purkamislupa-asia"
+      },
+      "DemolitionPermitIssueNoPersonData": {
+        "required": [
+          "dateOfInitiation",
+          "demolitionDecision",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
+            },
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "decisionDocument",
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerName",
+              "relatedApplication"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecisionNoPersonData"
+              }
+            ],
+            "description": "Purkamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecisionNoPersonData"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermitNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionActionNoPersonData"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocumentNoPersonData"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProjectNoPersonData"
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       },
       "Descriptor": {
         "type": "object",
@@ -11987,7 +12509,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -12136,7 +12657,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -12352,7 +12872,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -12475,7 +12994,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -12599,23 +13117,23 @@
             "nullable": true
           },
           "insideLength": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "insideWidth": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "doorOpeningWidth": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "doorOpeningHeight": {
-            "type": "integer",
-            "format": "int32",
+            "type": "number",
+            "format": "double",
             "nullable": true
           },
           "passengerCapacity": {
@@ -13095,7 +13613,6 @@
           "dateOfValidityOfDecision",
           "decisionDate",
           "decisionDocument",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -13226,7 +13743,6 @@
           "dateOfDecision",
           "dateOfValidityOfDecision",
           "decisionDate",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -13990,6 +14506,11 @@
           "buildingCultureHistoricalSignificance": {
             "type": "string",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -14158,6 +14679,11 @@
           "buildingCultureHistoricalSignificance": {
             "type": "string",
             "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -14207,7 +14733,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -14353,7 +14878,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -15261,6 +15785,147 @@
           },
           "locatedOnUnseparatedParcel": {
             "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "GeneralizedDemolitionPermitIssue": {
+        "required": [
+          "dateOfInitiation",
+          "demolitionPermitApplication",
+          "lifeCycleState",
+          "municipalityNumber"
+        ],
+        "type": "object",
+        "properties": {
+          "dateOfInitiation": {
+            "type": "string",
+            "description": "Vireilletulopäivä",
+            "format": "date",
+            "nullable": true
+          },
+          "lifeCycleState": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/1",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/2",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/3",
+              "http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila/code/4"
+            ],
+            "type": "string",
+            "description": "Elinkaaritila. Käytetään koodiston URI arvoa <a href=\"http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila\">http://uri.suomi.fi/codelist/rytj/rakvalv-asian-elinkaaren-tila</a>",
+            "nullable": true
+          },
+          "municipalityNumber": {
+            "type": "string"
+          },
+          "permanentPermitIdentifier": {
+            "type": "string"
+          },
+          "demolitionPermitApplication": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DemolitionPermitApplication"
+            },
+            "description": "Purkamislupahakemus",
+            "nullable": true
+          },
+          "buildingSite": {
+            "required": [
+              "buildingSiteKey",
+              "stormWaterTreatmentType",
+              "buildingSiteAddress",
+              "tenure"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingSite"
+              }
+            ],
+            "description": "Rakennuspaikka",
+            "nullable": true
+          },
+          "updateType": {
+            "enum": [
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/01",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/02",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/03",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/04",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/05",
+              "http://uri.suomi.fi/codelist/rytj/paivityksenlaji/code/99"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "updateDescription": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LanguageString"
+              }
+            ],
+            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli.",
+            "nullable": true
+          },
+          "demolitionDecision": {
+            "required": [
+              "decisionDocument",
+              "demolitionPermitDecisionKey",
+              "lifeCycleState",
+              "decisionDate",
+              "dateOfDecision",
+              "dateOfValidityOfDecision",
+              "publicNoticeDate",
+              "decisionText",
+              "decisionMakerType",
+              "decisionMakerName",
+              "relatedApplication"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DemolitionPermitDecision"
+              }
+            ],
+            "description": "Rakentamislupapäätös",
+            "nullable": true
+          },
+          "extensionDecision": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExtensionDecision"
+            },
+            "nullable": true
+          },
+          "changePermit": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChangePermit"
+            },
+            "nullable": true
+          },
+          "constructionAction": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeneralizedConstructionAction"
+            },
+            "nullable": true
+          },
+          "attachment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingAttachmentDocument"
+            },
+            "nullable": true
+          },
+          "constructionProject": {
+            "required": [
+              "constructionProjectKey"
+            ],
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConstructionProject"
+              }
+            ],
+            "description": "Rakentamishanke",
             "nullable": true
           }
         },
@@ -17032,7 +17697,6 @@
           "decisionDate",
           "decisionDocument",
           "decisionInForceUntil",
-          "decisionMakerFirstName",
           "decisionMakerName",
           "decisionMakerType",
           "decisionText",
@@ -17273,7 +17937,6 @@
               "publicNoticeDate",
               "decisionText",
               "decisionMakerType",
-              "decisionMakerFirstName",
               "decisionMakerName",
               "relatedApplication"
             ],
@@ -18739,6 +19402,11 @@
             "description": "Latauspiste",
             "nullable": true
           },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
           "structureSection": {
             "type": "array",
             "items": {
@@ -18951,6 +19619,11 @@
               }
             ],
             "description": "Latauspiste",
+            "nullable": true
+          },
+          "bikespaceCount": {
+            "type": "integer",
+            "format": "int32",
             "nullable": true
           },
           "structureSection": {

--- a/OpenApi/Rakentaminen/Palveluväylä/buildingService-OpenApi.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/buildingService-OpenApi.json
@@ -7120,20 +7120,16 @@
             "type": "string"
           },
           "buildingBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingBuildingProduct"
-              }
-            ],
-            "description": "Rakennuksen rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingBuildingProduct"
+            }
           },
           "buildingSiteBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
-              }
-            ],
-            "description": "Rakennuspaikan rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
+            }
           }
         },
         "additionalProperties": false,
@@ -7151,20 +7147,16 @@
             "format": "date"
           },
           "buildingBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingBuildingProduct"
-              }
-            ],
-            "description": "Rakennuksen rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingBuildingProduct"
+            }
           },
           "buildingSiteBuildingProduct": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
-              }
-            ],
-            "description": "Rakennuspaikan rakennustuotteet ja niiden hyödyntäminen"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingSiteBuildingProduct"
+            }
           }
         },
         "additionalProperties": false
@@ -10217,10 +10209,7 @@
             "format": "date-time"
           },
           "nameOfPreparer": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
+            "type": "string",
             "nullable": true
           },
           "assessmentPeriodLength": {
@@ -13202,9 +13191,9 @@
             "nullable": true
           },
           "computationalEnergyEfficiencyComparand": {
-            "type": "number",
+            "type": "integer",
             "description": "",
-            "format": "double",
+            "format": "int32",
             "nullable": true
           },
           "heatingMethod": {
@@ -13312,8 +13301,8 @@
             "nullable": true
           },
           "computationalEnergyEfficiencyComparand": {
-            "type": "number",
-            "format": "double",
+            "type": "integer",
+            "format": "int32",
             "nullable": true
           },
           "heatingMethod": {


### PR DESCRIPTION
_Kuvaukset ovat alustavia ja voivat muuttua vielä osana testausta ja käyttäjäpalautetta. Palvelut julkaistu Ryhdin testi-ympäristöön._

-----------------------------

# Yleistä

# Rakennustieto

## Rakennustietojen validointi- ja tallennus-API
- Muutettiin floorAreaChange atribuutti decimaliksi
- Muutettu hissin mitat decimaleiksi
- Siirretty bikeSpaceCount atribuutti latauspisteestä rakennuskohteelle 
- Poistettu pakollisuusmerkintä decisionMakerFirstName kentältä openApi kuvauksista koska tämä ei aina ole pakollinen
- False arvo sallittu fullyApprovedForUse atribuutille kun rakennus ei ole valmis tai käyttöönotettu
- False arvo sallittu sisäänkäynnin isPrimary atribuutille
- False arvo sallittu sisäverkon tiedoille
- False arvo sallittu katselmuksen requiredByPermitRegulations atribuutille
- Demolitionpermit GET rajapinnan content-osioon lisätty viittaus vastaavaan skeemaan
- Korjattiin, että ilmastoselvitykselle voi olla vain yksi laatija
- Rakennuksen ja rakennuspaikan rakennustuoteluottelo muutettiin listaksi tuotteita, aiemmin saattoi olla vain yksi
- Laskennallinen energiatehokkuus muutettiin kokonaisluvuksi

## Rakennustietojen muutostietopalvelu
 
## Rakennustietojen avoin karttakäyttöliittymä ja paikkatietorajapinnat
- As Oy tiedot uuteen kenttään housingCompanyOwners julkisessa datassa
- Käytössäolotiedot poistettu karttakäyttöliittymästä