### PR TITLE
Julkaisun 2026-release-8 alustavat rajapintamuutokset.

### DIFF
--- a/OpenApi/Alueidenkäyttö/Palveluväylä/planService-OpenApi.json
+++ b/OpenApi/Alueidenkäyttö/Palveluväylä/planService-OpenApi.json
@@ -6176,97 +6176,6 @@
         },
         "additionalProperties": false
       },
-      "AttachmentDocument": {
-        "required": [
-          "accessibility",
-          "attachmentDocumentKey",
-          "categoryOfPublicity",
-          "documentDate",
-          "documentIdentifier",
-          "fileKey",
-          "languages",
-          "name",
-          "personalDataContent",
-          "retentionTime"
-        ],
-        "type": "object",
-        "properties": {
-          "attachmentDocumentKey": {
-            "minLength": 1,
-            "type": "string",
-            "description": "Tiedon tuottajatahon tietojärjestelmän generoima kohteen versioriippumaton tunnus",
-            "format": "uuid"
-          },
-          "documentIdentifier": {
-            "minLength": 1,
-            "type": "string",
-            "description": "Asiakirjan pysyvä tunnus, esim. diaarinumero tai muu dokumentinhallinnan tunnus."
-          },
-          "name": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/LanguageString"
-              }
-            ],
-            "description": "Lokalisoitu merkkijono-luokka eri kielille. Lisää vähintään yksi kieli."
-          },
-          "personalDataContent": {
-            "minLength": 1,
-            "type": "string",
-            "description": "Kuvaa asiakirjan henkilötietosisällön. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/henkilotietosisalto\">http://uri.suomi.fi/codelist/rytj/henkilotietosisalto</a>"
-          },
-          "categoryOfPublicity": {
-            "minLength": 1,
-            "type": "string",
-            "description": "Kuvaa asiakirjan julkisuusluokan. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/julkisuus\">http://uri.suomi.fi/codelist/rytj/julkisuus</a>"
-          },
-          "accessibility": {
-            "type": "boolean"
-          },
-          "retentionTime": {
-            "minLength": 1,
-            "type": "string",
-            "description": "Asiakirjan säilytysaika vuosina ennen sen hävittämistä. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/sailytysaika\">http://uri.suomi.fi/codelist/rytj/sailytysaika</a>"
-          },
-          "confirmationDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          },
-          "languages": {
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Asiakirjan kieli tai sisältämät kielet. Käytetään koodistoa <a href=\"http://uri.suomi.fi/codelist/rytj/ryhtikielet\">http://uri.suomi.fi/codelist/rytj/ryhtikielet</a>"
-          },
-          "fileKey": {
-            "type": "string",
-            "description": "Erillisen rajapinnan kautta tallennetun tiedoston avain.",
-            "format": "uuid"
-          },
-          "descriptors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Descriptor"
-            },
-            "nullable": true
-          },
-          "documentDate": {
-            "minLength": 1,
-            "type": "string",
-            "format": "date"
-          },
-          "arrivedDate": {
-            "type": "string",
-            "format": "date",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Liiteasiakirja (base)"
-      },
       "AttributeValue": {
         "type": "object",
         "properties": {
@@ -7400,6 +7309,29 @@
         "additionalProperties": false,
         "description": "Toimija"
       },
+      "CancelledByResponse": {
+        "type": "object",
+        "properties": {
+          "planCancellationKey": {
+            "type": "string",
+            "description": "Kumoamistiedon avain",
+            "format": "uuid"
+          },
+          "permanentPlanIdentifier": {
+            "type": "string",
+            "description": "Kumoavan kaavan pysyvä kaavatunnus",
+            "nullable": true
+          },
+          "dateOfValidity": {
+            "type": "string",
+            "description": "Voimaantulopäivämäärä",
+            "format": "date",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Kuvaa kumoamistiedon, eli minkä kaavan toimesta tämä kaava-asia on kumottu."
+      },
       "CancelledGroupRelations": {
         "required": [
           "planObjectUri",
@@ -7711,37 +7643,19 @@
         "additionalProperties": false,
         "description": "Yleismääräysryhmä"
       },
-      "GeoJsonGeometry": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Tuetut geometriatyypit"
-          }
-        },
-        "additionalProperties": false,
-        "description": "GeoJson geometria (abstrakti luokka, katso toteutukset)"
-      },
       "GeoJsonLineStringGeometry": {
         "required": [
           "coordinates",
           "type"
         ],
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          }
-        ],
         "properties": {
+          "type": {
+            "enum": [
+              "LineString"
+            ],
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
@@ -7750,25 +7664,11 @@
                 "type": "number",
                 "format": "double"
               }
-            },
-            "description": "Koordinaatit",
-            "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
-          },
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+            }
           }
         },
         "additionalProperties": false,
-        "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+        "description": "GeoJSON LineString"
       },
       "GeoJsonMultiLineStringGeometry": {
         "required": [
@@ -7776,12 +7676,13 @@
           "type"
         ],
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          }
-        ],
         "properties": {
+          "type": {
+            "enum": [
+              "MultiLineString"
+            ],
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
@@ -7793,25 +7694,11 @@
                   "format": "double"
                 }
               }
-            },
-            "description": "Koordinaatit",
-            "example": "[ [[100.0, 0.0], [101.0, 1.0]], [[101.0, 1.0], [100.0, 1.0]] ]"
-          },
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Geometriatyyppi. Pakollinen arvo: \"lineString\""
+            }
           }
         },
         "additionalProperties": false,
-        "description": "LineString GeoJson\r\n\r\nEsimerkki: { \"type\": \"lineString\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+        "description": "GeoJSON MultiLineString"
       },
       "GeoJsonMultiPointGeometry": {
         "required": [
@@ -7819,12 +7706,13 @@
           "type"
         ],
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          }
-        ],
         "properties": {
+          "type": {
+            "enum": [
+              "MultiPoint"
+            ],
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
@@ -7833,25 +7721,11 @@
                 "type": "number",
                 "format": "double"
               }
-            },
-            "description": "Koordinaatit",
-            "example": "[ [100.0, 0.0], [101.0, 1.0] ]"
-          },
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Geometriatyyppi. Pakollinen arvo: \"multiPoint\""
+            }
           }
         },
         "additionalProperties": false,
-        "description": "MultiPoint GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPoint\", \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ] }"
+        "description": "GeoJSON MultiPoint"
       },
       "GeoJsonMultiPolygonGeometry": {
         "required": [
@@ -7859,12 +7733,13 @@
           "type"
         ],
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          }
-        ],
         "properties": {
+          "type": {
+            "enum": [
+              "MultiPolygon"
+            ],
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
@@ -7879,25 +7754,11 @@
                   }
                 }
               }
-            },
-            "description": "Koordinaatit",
-            "example": "[ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ]"
-          },
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Geometriatyyppi. Pakollinen arvo: \"multiPolygon\""
+            }
           }
         },
         "additionalProperties": false,
-        "description": "MultiPolygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"multiPolygon\", \"coordinates\": [ [ [ [102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0], [102.0, 2.0 ] ] ], [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] ] }"
+        "description": "GeoJSON MultiPolygon"
       },
       "GeoJsonPointGeometry": {
         "required": [
@@ -7905,36 +7766,23 @@
           "type"
         ],
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          }
-        ],
         "properties": {
+          "type": {
+            "enum": [
+              "Point"
+            ],
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
               "type": "number",
               "format": "double"
-            },
-            "description": "Koordinaatit",
-            "example": "[100.0, 0.0]"
-          },
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Geometriatyyppi. Pakollinen arvo: \"point\""
+            }
           }
         },
         "additionalProperties": false,
-        "description": "Point GeoJson\r\n\r\nEsimerkki: { \"type\": \"point\", \"coordinates\": [100.0, 0.0] }"
+        "description": "GeoJSON Point"
       },
       "GeoJsonPolygonGeometry": {
         "required": [
@@ -7942,12 +7790,13 @@
           "type"
         ],
         "type": "object",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/GeoJsonGeometry"
-          }
-        ],
         "properties": {
+          "type": {
+            "enum": [
+              "Polygon"
+            ],
+            "type": "string"
+          },
           "coordinates": {
             "type": "array",
             "items": {
@@ -7959,25 +7808,11 @@
                   "format": "double"
                 }
               }
-            },
-            "description": "Koordinaatit",
-            "example": " [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
-          },
-          "type": {
-            "enum": [
-              "Point",
-              "MultiPoint",
-              "LineString",
-              "MultiLineString",
-              "Polygon",
-              "MultiPolygon"
-            ],
-            "type": "string",
-            "description": "Geometriatyyppi. Pakollinen arvo: \"polygon\""
+            }
           }
         },
         "additionalProperties": false,
-        "description": "Polygon GeoJson\r\n\r\nEsimerkki: { \"type\": \"polygon\", \"coordinates\": [ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ] ] }"
+        "description": "GeoJSON Polygon"
       },
       "HandlingEvent": {
         "required": [
@@ -9500,6 +9335,14 @@
             "description": "Kumoamistieto",
             "nullable": true
           },
+          "bindingPlotDivisionCancellationInfos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BindingPlotDivisionCancellationInfo"
+            },
+            "description": "Sitovan tonttijaon kumoutumistieto.",
+            "nullable": true
+          },
           "planReport": {
             "allOf": [
               {
@@ -9900,6 +9743,14 @@
               "$ref": "#/components/schemas/PlanCancellationInfo"
             },
             "description": "Kumoamistieto",
+            "nullable": true
+          },
+          "bindingPlotDivisionCancellationInfos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BindingPlotDivisionCancellationInfo"
+            },
+            "description": "Sitovan tonttijaon kumoutumistieto.",
             "nullable": true
           }
         },
@@ -10558,11 +10409,32 @@
             "description": "Liittyvät kaava asiat (URI)",
             "nullable": true
           },
+          "effectiveLifeCycleStatus": {
+            "type": "string",
+            "description": "Ajantasainen elinkaaren tila. Jos kaavan kaikki kaavakohteet on kumottu, palautetaan kumottu (14).",
+            "nullable": true
+          },
+          "periodOfValidity": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TimePeriodDateOnly"
+              }
+            ],
+            "description": "Ajantasainen voimassaoloaika (alku- ja loppupäivämäärä).",
+            "nullable": true
+          },
           "planMatterPhases": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PlanMatterPhaseUriResponse"
             }
+          },
+          "cancelledBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CancelledByResponse"
+            },
+            "description": "Kumoamistieto. Kuvaa kaavan kumoamista. Kumoamistieto voi kumota kaavan kokonaan tai osittain."
           },
           "originalAdministrativeAreaIdentifiers": {
             "type": "array",
@@ -12519,7 +12391,7 @@
                 "$ref": "#/components/schemas/GeoJsonMultiPolygonGeometry"
               }
             ],
-            "description": "Geometria GeoJson rakenteella: https://geojson.org/"
+            "description": "Geometria GeoJSON rakenteella: https://geojson.org/"
           }
         },
         "additionalProperties": false

--- a/OpenApi/Rakentaminen/Palveluväylä/buildingDataSharingService-OpenApi.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/buildingDataSharingService-OpenApi.json
@@ -4818,6 +4818,10 @@
             "type": "number",
             "format": "double"
           },
+          "b3Repair": {
+            "type": "number",
+            "format": "double"
+          },
           "b4ProductReplacements": {
             "type": "number",
             "format": "double"
@@ -5688,14 +5692,21 @@
             ],
             "type": "string"
           },
-          "climateReport": {
+          "buildingCarbonFootprint": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClimateReport"
+                "$ref": "#/components/schemas/BuildingCarbonFootprint"
               }
             ],
-            "description": "Ilmastoselvitys",
-            "nullable": true
+            "description": "Rakennuksen hiilijalanjälki"
+          },
+          "buildingCarbonHandprint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingCarbonHandprint"
+              }
+            ],
+            "description": "Rakennuksen hiilikädenjälki"
           }
         },
         "additionalProperties": false,
@@ -5725,14 +5736,21 @@
             ],
             "type": "string"
           },
-          "climateReport": {
+          "buildingCarbonFootprint": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClimateReportNoPersonData"
+                "$ref": "#/components/schemas/BuildingCarbonFootprint"
               }
             ],
-            "description": "Ilmastoselvitys",
-            "nullable": true
+            "description": "Rakennuksen hiilijalanjälki"
+          },
+          "buildingCarbonHandprint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingCarbonHandprint"
+              }
+            ],
+            "description": "Rakennuksen hiilikädenjälki"
           }
         },
         "additionalProperties": false,
@@ -5949,6 +5967,10 @@
             "format": "double"
           },
           "b2Maintenance": {
+            "type": "number",
+            "format": "double"
+          },
+          "b3Repair": {
             "type": "number",
             "format": "double"
           },
@@ -6831,6 +6853,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReport"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "mainPurpose1994": {
             "type": "integer",
             "format": "int32",
@@ -6844,13 +6875,6 @@
           "numberOfDeletedApartments": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
-            },
             "nullable": true
           },
           "buildingProductList": {
@@ -9149,21 +9173,12 @@
             "format": "date-time",
             "nullable": true
           },
-          "buildingCarbonFootprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonFootprint"
-              }
-            ],
-            "description": "Rakennuksen hiilijalanjälki"
-          },
-          "buildingCarbonHandprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonHandprint"
-              }
-            ],
-            "description": "Rakennuksen hiilikädenjälki"
+          "buildingPurposeForLowCarbonAssessment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
+            },
+            "nullable": true
           },
           "buildingSiteCarbonFootprint": {
             "allOf": [
@@ -9214,21 +9229,12 @@
             "format": "date-time",
             "nullable": true
           },
-          "buildingCarbonFootprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonFootprint"
-              }
-            ],
-            "description": "Rakennuksen hiilijalanjälki"
-          },
-          "buildingCarbonHandprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonHandprint"
-              }
-            ],
-            "description": "Rakennuksen hiilikädenjälki"
+          "buildingPurposeForLowCarbonAssessment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessmentNoPersonData"
+            },
+            "nullable": true
           },
           "buildingSiteCarbonFootprint": {
             "allOf": [
@@ -12087,6 +12093,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReport"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "mainPurpose1994": {
             "type": "integer",
             "format": "int32",
@@ -12100,13 +12115,6 @@
           "numberOfDeletedApartments": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
-            },
             "nullable": true
           },
           "buildingProductList": {
@@ -12313,6 +12321,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReportNoPersonData"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "mainPurpose1994": {
             "type": "integer",
             "format": "int32",
@@ -12326,13 +12343,6 @@
           "numberOfDeletedApartments": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessmentNoPersonData"
-            },
             "nullable": true
           },
           "buildingProductList": {

--- a/OpenApi/Rakentaminen/Palveluväylä/buildingService-OpenApi.json
+++ b/OpenApi/Rakentaminen/Palveluväylä/buildingService-OpenApi.json
@@ -5845,6 +5845,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReport"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "buildingProductList": {
             "allOf": [
               {
@@ -5852,13 +5861,6 @@
               }
             ],
             "description": "Rakennustuoteluettelo",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
-            },
             "nullable": true
           },
           "chargingPoint": {
@@ -6150,6 +6152,10 @@
             "format": "double"
           },
           "b2Maintenance": {
+            "type": "number",
+            "format": "double"
+          },
+          "b3Repair": {
             "type": "number",
             "format": "double"
           },
@@ -7234,14 +7240,21 @@
             ],
             "type": "string"
           },
-          "climateReport": {
+          "buildingCarbonFootprint": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClimateReport"
+                "$ref": "#/components/schemas/BuildingCarbonFootprint"
               }
             ],
-            "description": "Ilmastoselvitys",
-            "nullable": true
+            "description": "Rakennuksen hiilijalanjälki"
+          },
+          "buildingCarbonHandprint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingCarbonHandprint"
+              }
+            ],
+            "description": "Rakennuksen hiilikädenjälki"
           }
         },
         "additionalProperties": false,
@@ -7271,14 +7284,21 @@
             ],
             "type": "string"
           },
-          "climateReport": {
+          "buildingCarbonFootprint": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/ClimateReportNoPersonData"
+                "$ref": "#/components/schemas/BuildingCarbonFootprint"
               }
             ],
-            "description": "Ilmastoselvitys",
-            "nullable": true
+            "description": "Rakennuksen hiilijalanjälki"
+          },
+          "buildingCarbonHandprint": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BuildingCarbonHandprint"
+              }
+            ],
+            "description": "Rakennuksen hiilikädenjälki"
           }
         },
         "additionalProperties": false,
@@ -7767,6 +7787,10 @@
             "format": "double"
           },
           "b2Maintenance": {
+            "type": "number",
+            "format": "double"
+          },
+          "b3Repair": {
             "type": "number",
             "format": "double"
           },
@@ -8614,6 +8638,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReport"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "mainPurpose1994": {
             "type": "integer",
             "format": "int32",
@@ -8627,13 +8660,6 @@
           "numberOfDeletedApartments": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
-            },
             "nullable": true
           },
           "buildingProductList": {
@@ -10260,21 +10286,12 @@
             "format": "date-time",
             "nullable": true
           },
-          "buildingCarbonFootprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonFootprint"
-              }
-            ],
-            "description": "Rakennuksen hiilijalanjälki"
-          },
-          "buildingCarbonHandprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonHandprint"
-              }
-            ],
-            "description": "Rakennuksen hiilikädenjälki"
+          "buildingPurposeForLowCarbonAssessment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
+            },
+            "nullable": true
           },
           "buildingSiteCarbonFootprint": {
             "allOf": [
@@ -10325,21 +10342,12 @@
             "format": "date-time",
             "nullable": true
           },
-          "buildingCarbonFootprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonFootprint"
-              }
-            ],
-            "description": "Rakennuksen hiilijalanjälki"
-          },
-          "buildingCarbonHandprint": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/BuildingCarbonHandprint"
-              }
-            ],
-            "description": "Rakennuksen hiilikädenjälki"
+          "buildingPurposeForLowCarbonAssessment": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessmentNoPersonData"
+            },
+            "nullable": true
           },
           "buildingSiteCarbonFootprint": {
             "allOf": [
@@ -14467,6 +14475,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReport"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "mainPurpose1994": {
             "type": "integer",
             "format": "int32",
@@ -14480,13 +14497,6 @@
           "numberOfDeletedApartments": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessment"
-            },
             "nullable": true
           },
           "buildingProductList": {
@@ -14641,6 +14651,15 @@
             "format": "date",
             "nullable": true
           },
+          "climateReport": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClimateReportNoPersonData"
+              }
+            ],
+            "description": "Ilmastoselvitys",
+            "nullable": true
+          },
           "mainPurpose1994": {
             "type": "integer",
             "format": "int32",
@@ -14654,13 +14673,6 @@
           "numberOfDeletedApartments": {
             "type": "integer",
             "format": "int32",
-            "nullable": true
-          },
-          "buildingPurposeForLowCarbonAssessment": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BuildingPurposeForLowCarbonAssessmentNoPersonData"
-            },
             "nullable": true
           },
           "buildingProductList": {


### PR DESCRIPTION
Julkaisun 2026-release-8 alustavat rajapintamuutokset

-----------------------
# Sisältö

# Yleistä

# Rakennustieto

## Rakennustietojen validointi- ja tallennus-API
- Korjattu constructionDesignType sallitut arvot vastaamaan koodiston arvoja
- Muutettu rakennuksen skeemaa ilmastoselvityksen osalta
- Korjattu osittainen purkaminen toimimaan purkamisluvalla

## Rakennustietojen muutostietopalvelu
- Muutettu rakennuksen skeemaa ilmastoselvityksen osalta

## Rakennustietojen avoin karttakäyttöliittymä ja paikkatietorajapinnat
- Korjattu tilanne jossa koko rakennus näyttää puretulta vaikka vain yksi osa puretaan
- Lisätty sisäänkäynnin tiedot karttakäyttöliittymään
- Lisätty ruotsinkielisiä termejä tarkempien rakennustietojen ikkunaan
- Poistettu ylimääräisiä harmaita viivoja tarkempien rakennustietojen ikkunasta
- Ulkokuoren tiedot järjestetty samaan järjestykseen tarkemmissa tiedoissa kuin sivupalkissa

# Alueidenkäyttö

### Karttapalvelu ja paikkatietorajapinnat

- Sitovalla tonttijakotontilla näytetään erikseen rakentamisen määrä, kerrosala ja rakentamisen määrä, rakennustilavuus
- Tonttijakotontilla sivupalkissa näytetään ensin tonttia koskevat tiedot kun aiemmin avautui ensin tonttijaon tiedot.
- Tonttijakotontille lisätty ajantasainen asemakaavatieto
- Vireilläolevien kaavojen kaavahakemistorajapinnalle (asemakaava, yleiskaava, maakuntakaava) on lisätty nähtävilläoloaika (public_presentation_time_begin_utc, public_presentation_time_end_utc)
- Kaavamääräysrajapinnalle on lisätty värikoodi (color_number) 
- Karttapalveluun lisätty asema,- yleis,- ja maakuntakaavoille voimassaolevien ja vireilläolevien kaavakohdetasot. 
  - Aluevaraukset (kohteet joilla lisätietona pääkäyttötarkoitus) ovat omalla tasollaan
  - Muut kaavakohteet (osa-alueet, pisteet, viivat) ovat omalla tasollaan. 
        - valituista tasoista saa otettua pois päältä eri geometriatyypit   

### Muutostietopalvelu
- Huomioidaan kaavan kiinteistökohtaisilla kyselyrajapinnoilla kaavan digitaalinen alkuperä. 

### Kaavatietojen validointi- ja tallennus-API
- Asemakaavan kyselyrajapinnalle _/api/LocalDetailedPlanMatter/{permanentPlanIdentifier}_   lisätty kumotumistieto, ajantasainen elinkaarentila sekä voimassaoloaika
- Yleiskaavan kyselyrajapinnalle _/api/LocalMasterPlanMatter/{permanentPlanIdentifier}_  lisätty kumotumistieto, ajantasainen elinkaarentila sekä voimassaoloaika
- Maakuntakaavan kyselyrajapinnalle _/api/RegionalPlanMatter/{permanentPlanIdentifier}_  lisätty kumotumistieto, ajantasainen elinkaarentila sekä voimassaoloaika
- Mahdollistettu, että uudella kaavalla voi kumota sekä alle jäävän asemakaavan että kaikki vaihekaavat jotka liittyvät alla olevaan kaavaan.

- Lisätty asemakaavan tallennusrajapinnoille mahdollisuus tuoda tonttijaon kumoutumistieto
`-` Lisätty kaavalle ja päätökselle assosiaatio sitovanTonttijaonKumoutumistieto
`-` Lisätty sitovanTonttijaonkumoutumistieto-luokka
- Lisätty validointisääntöjä kun kaavalla kumotaan tonttijako
`-` tonttijaon/kumottavan tonttijakotontin tulee olla voimassa
`-` tonttijaon/kumottavan tonttijakotontin geometrian tulee leikata kaavan kanssa 
